### PR TITLE
Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
- - Joomla! Framework replacements
-
 ## [2.1.3] - 2016-02-01
 ### Added
  - Add Travis CI badge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+ - Joomla! Framework replacements
+
+## [2.1.3] - 2016-02-01
+### Added
+ - Add ability to archive a group or project moving to a readonly state.
+
+### Changed
+
+### Fixed
+- [QUBES][#711] Fix group pages 'trusted content'
+- [HUBZERO][#10272] Fix missing language strings 'Publish'/'Unpublish' in member citations.
+- [HUBZERO][#10265] Fix 
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,74 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.1.3] - 2016-02-01
 ### Added
  - Add ability to archive a group or project moving to a readonly state.
-
+ - Adds Travis CI badge
+ [COM_UPDATE] Fixes minor docblock issue.
+[COM_UPDATE] Allows webhooks to update the git repo. Meant for QA machines.
+[COM_UPDATE] Adds config values for QA git updater.
+ 
 ### Changed
+ - [CORE] Bump version number.
+ - [TRAVIS] Only notify on the change event for success or if build fails.
+
 
 ### Fixed
-- [QUBES][#711] Fix group pages 'trusted content'
-- [HUBZERO][#10272] Fix missing language strings 'Publish'/'Unpublish' in member citations.
-- [HUBZERO][#10265] Fix 
-
+[PLG_PROJECTS_PUBLICATIONS] Fixing codesniff errors.
+[PURR][#1243][PLG_PROJECTS_PUBLICATIONS] Don't try to process primary contact info if performing a revert
+[*_SEARCH] Fixes PHPCS errors.
+[PURR][#1290][PLG_SEARCH_MEMBERS] Only return non-blocked users. One class per file. Docblock clean-up.
+[COM_SEARCH] Fixing docblock, minor formatting clean-up, some very minor simplification of code.
+[PURR][#1294][PLG_CRON_SEARCH] For now, only process the search index queue if the component's configured engine is Solr. Minor docblock and spacing fixes.
+[COM_CART] Shawn's fix of the permissions helper to check the core.action
+[QUBES][#790][PLG_GROUPS_ANNOUNCEMENTS] Don't run announcement content through content plugins when generating email bodies
+[QUBES][#791][PLG_GROUPS_ANNOUNCEMENTS] Resolve user object correctly
+[NCIP][#1331][COM_WIKI] Fixing a number of issues with saving authors on wiki pages
+[PLG_AUTHENTICATION_SCISTARTER] Changing response object returned in accordance with changes to SciStarter's API
+[COM_MEMBERS] Reworking import model to make it more extensible. Adding handler for Projects. TODO: Plugin based?
+[COM_MEMBERS] Aadding all access values to the list to choose from
+[COM_*] Converting Joomla refs to Hubzero equivs. Minor reformatting.
+[CDMHUB][#1221][PLG_GROUPS_PROJECTS] Don't link to projects group member doesn't have access to
+[NCIP][#1200][*_PUBLICATIONS] Honor the master type's configured option for license.
+[HUBZERO][#10298][PLG_*_COLLECTIONS] Fail a little mroe gracefully when image file can't be found
+[COM_DATAVIEWER][DATACENTERHUB][283] fix dataset download issue
+[NANOHUB][#317179][COM_RESOURCES] Adding missing permissions values
+[LIB-JOOMLA][COM_*] Make sure nothing uses old Joomla mailer
+[PLG_SYSTEM_*] Updating docblock, XML manifest, converting remaining bits of Joomla
+[COM_STOREFRONT] As per community hub ticket #194 fixed the serial number length limitation
+[PURR][#1283][COM_PROJECTS] Updates to reflect changes in Google API libraries
+[COM_PROJECTS] Another check to makes sure the project repo is in good standing.
+[*] Removing or converting some remaining Joomla code
+[QUBES][#784][COM_PROJECTS][PLG_PROJECTS_TEAM] Force group syncing off if a project doesn't have a group owner
+[PLG_CONTENT_ANTISPAM] Don't bother processing submissions by admins.
+[CDMHUB][#1211][PLG_PROJECTS_TEAM] Slight reworking to avoid potential conflicts with adding individuals while 'sync group' is checked
+[COM_FORUM] Fixes according to review.
+[COM_FORUM][HUBZERO][#10256] Fixes a variable name typo.
+[PURR][#1198][COM_PROJECTS] Adds a check to see if the initial commit has not been made.
+[PLG_SYSTEM_SUPERGROUPS] Reworkng to get super group component route building working in 2.x
+[CORE] Updating file with 2.0 paths
+[PLG_GROUPS_FORUM] Corrects language file typo.
+[PLG_AUTHENTICATION_SCISTARTER] Fixing API endpoint path and adding more info to description
+[COM_COLLECTIONS] Changing how namespace is used as it can potentially conflict with existing Following Group class
+[PLG_MEMBERS_ACCOUNT] Make sure var is an object before using it as such
+[HUBZERO][#10237][COM_MEMBERS] Adding autocomplete attribute to password fields to try and prevent browsers from auto-filling the fields
+[QUBES][#772][COM_PROJECTS] Make sure HTML formatted content doesn't have line-breaks converted into break tags (to much breaking)
+[PLG_CONTENT_EMAILCLOAK] Fixes misnamed method.
+[CATALYZECARE][#565][COM_MEMBERS] Make sure 'save to new' button works
+[HABRI][#738][COM_TAGS] Purge query cache before deleting record or it may accidentally remove records that should no longer be associated with it
+[PLG_AUTHENTICATION_SCISTARTER] Minor tweaks to URL building and error handling
+[COM_MEMBERS] Try to sanitize bad MS edncoded characters
+[PLG_CONTENT_EMAILCLOAK] Fixing syntac error
+[PLG_CONTENT_*] Removing remaining bits of Joomla
+[PURR][#1279][PLG_SYSTEM_UNCONFIRMED] Prevents the use of stale User activation state.
+[COM_MEMBERS] Allow password to be set when creating a new account via the admin interface.
+[VHUB][#1330][COM_MEMBERS] Removing invalid initiate declaration and automatic method
+[PLG_CONTENT_PAGEBREAK] Removing Joomla-specific code
+[PURR][#1272][PLG_CRON_PUBLICATIONS] Reworking a few spots to be more efficient. Make sure only non-blocked, confirmed, activated accounts get emailed once.
+[PURR][#1273][PLG_PROJECTS_FILES] Make sure text wrap has the correct class name or else javascript can't find a proper hook to latch onto
+[MOD_MYSESSIONS] Fixes the screenshot display.
+[QUBES][#777][PLG_COURSES_DISCUSSIONS] Make sure sections are created with a published state
+[COM_GROUPS][PLG_GROUPS_FILES][TPL_HUBBASIC2013] Adjustments to styles so group files displays a little nicer across templates
+[QUBES][#775][PLG_*_ACTIVITY] Make sure data selector is more specific or else child responses can end up in the top-level list
+[QUBES][#779][MOD_LOGIN] Add required script
+[HUBZERO][#10265][COM_MEMBERS] Make sure header properly matches action of editing ot creating an account
+[HUBZERO][#10272][PLG_MEMBERS_CITATIONS] Adding missing language strings
+[QUBES][#711][COM_GROUPS] Catching more places where 'trusted content' config needs to be inherited before saving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.1.3] - 2016-02-01
 ### Added
+ - Add Travis CI badge
+ - Add ability to update the git respository from github webhook.
+ - Add all access values to the list to choose from when creating an account.
+ - Add whitelist for anti-spam plugins.
+ - [HUBZERO][#10237] Add autocomplete attribute to password fields to try and prevent browsers from auto-filling the fields.
+ - Allow password to be set when creating a new account via the admin interface.
  - Add ability to archive a group or project moving to a readonly state.
- - Adds Travis CI badge
- [COM_UPDATE] Fixes minor docblock issue.
-[COM_UPDATE] Allows webhooks to update the git repo. Meant for QA machines.
-[COM_UPDATE] Adds config values for QA git updater.
- - Adding all access values to the list to choose from
-- Whitelist for anti-spam plugins.
  
 ### Changed
  - [CORE] Bump version number.
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Convert Joomla refs to Hubzero equivelants in all components. (bulk find and replace)
  - Make sure nothing uses old Joomla mailer
  - Updating docblock, XML manifest, converting remaining bits of Joomla
-- [PURR][#1283] Updates the projects component to reflect changes in Google API libraries
+ - [PURR][#1283] Updates the projects component to reflect changes in Google API libraries
+ - [PLG_CONTENT_*] Removing remaining bits of Joomla
 
 
 ### Fixed
@@ -43,36 +44,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [NANOHUB][#317179][COM_RESOURCES] Adding missing permissions values ???
 - [PCH][#194] Allows for a fixed length serial number to be designated in the storefront component.
 - [COM_PROJECTS] Fixes invisible files upon upload and alleviates 'ghost' files within the Projects component.
-- [QUBES][#784] Force group syncing off if a project doesn't have a group owner
-- [CDMHUB][#1211][PLG_PROJECTS_TEAM] Slight reworking to avoid potential conflicts with adding individuals while 'sync group' is checked
-- [HUBZERO][#10256] Fixes a variable name typo.
-- [PURR][#1198][COM_PROJECTS] Adds a check to see if the initial commit has not been made.
-- [PLG_SYSTEM_SUPERGROUPS] Reworkng to get super group component route building working in 2.x
-- [CORE] Updating file with 2.0 paths
-- [PLG_GROUPS_FORUM] Corrects language file typo.
-- [PLG_AUTHENTICATION_SCISTARTER] Fixing API endpoint path and adding more info to description
-- [COM_COLLECTIONS] Changing how namespace is used as it can potentially conflict with existing Following Group class
-- [PLG_MEMBERS_ACCOUNT] Make sure var is an object before using it as such
-- [HUBZERO][#10237][COM_MEMBERS] Adding autocomplete attribute to password fields to try and prevent browsers from auto-filling the fields
-- [QUBES][#772][COM_PROJECTS] Make sure HTML formatted content doesn't have line-breaks converted into break tags (to much breaking)
-- [PLG_CONTENT_EMAILCLOAK] Fixes misnamed method.
-- [CATALYZECARE][#565][COM_MEMBERS] Make sure 'save to new' button works
-- [HABRI][#738][COM_TAGS] Purge query cache before deleting record or it may accidentally remove records that should no longer be associated with it
-- [PLG_AUTHENTICATION_SCISTARTER] Minor tweaks to URL building and error handling
-- [COM_MEMBERS] Try to sanitize bad MS edncoded characters
-- [PLG_CONTENT_EMAILCLOAK] Fixing syntac error
-- [PLG_CONTENT_*] Removing remaining bits of Joomla
-- [PURR][#1279][PLG_SYSTEM_UNCONFIRMED] Prevents the use of stale User activation state.
-- [COM_MEMBERS] Allow password to be set when creating a new account via the admin interface.
-- [VHUB][#1330][COM_MEMBERS] Removing invalid initiate declaration and automatic method
-- [PLG_CONTENT_PAGEBREAK] Removing Joomla-specific code
-- [PURR][#1272][PLG_CRON_PUBLICATIONS] Reworking a few spots to be more efficient. Make sure only non-blocked, confirmed, activated accounts get emailed once.
-- [PURR][#1273][PLG_PROJECTS_FILES] Make sure text wrap has the correct class name or else javascript can't find a proper hook to latch onto
-- [MOD_MYSESSIONS] Fixes the screenshot display.
-- [QUBES][#777][PLG_COURSES_DISCUSSIONS] Make sure sections are created with a published state
-- [COM_GROUPS][PLG_GROUPS_FILES][TPL_HUBBASIC2013] Adjustments to styles so group files displays a little nicer across templates
-- [QUBES][#775][PLG_*_ACTIVITY] Make sure data selector is more specific or else child responses can end up in the top-level list
-- [QUBES][#779][MOD_LOGIN] Add required script
-- [HUBZERO][#10265][COM_MEMBERS] Make sure header properly matches action of editing ot creating an account
-- [HUBZERO][#10272][PLG_MEMBERS_CITATIONS] Adding missing language strings
-- [QUBES][#711][COM_GROUPS] Catching more places where 'trusted content' config needs to be inherited before saving
+- [QUBES][#784] Fixes project membership management issue, allows for the removal of a member.
+- [CDMHUB][#1211] Slight reworking to avoid potential conflicts with adding individuals while 'sync group' is checked 
+- [HUBZERO][#10256] Fixes name link in forum post.
+- [PURR][#1198][COM_PROJECTS] Enforces project initial repository setup.
+- Fixes super group component route building since 2.x upgrade
+- Fixes 'red' to 'read' in group forum area description.
+- Fixes SciStarter API endpoint path and adding more info to description
+- Fixes how namespace conflict in Collections
+- Fixes object access error in Member Accounts.
+- [QUBES][#772][COM_PROJECTS] Fixes HTML formatting issues concerning extraneous break tags being inserted.
+- Fixes misnamed method in the Content - EmailCloak plugin.
+- [CATALYZECARE][#565] Fixes sure 'save to new' button.
+- [HABRI][#738] Fixes caching issue with tag record upon deletion to prevent dangling objects.
+- Fixes poorly MS-encoded characters in the Members component.
+- [PURR][#1279] Fixes account confirmation loop due to cached User session data.
+- [VHUB][#1330] Fixes 'unknown column' error when adding a new Quota class.
+- [PURR][#1272] Make sure only non-blocked, confirmed, activated accounts get emailed once about publication statistics.
+- [PURR][#1273][PLG_PROJECTS_FILES] Fixes folder expansion in Project Files area.
+- Fixes the screenshot display on the member dashboard.
+- [QUBES][#777] Make sure course discussion sections are created with a published state
+- Fixes styles so group files displays a little nicer across templates
+- [QUBES][#775] Fixes nesting of actvity feed posts.
+- [QUBES][#779] Fixes missing javascript file for login within super groups.
+- [HUBZERO][#10265] Fixes administrative header properly to match action of editing of creating an account
+- [HUBZERO][#10272] Fixes missing language strings 'publish / unpublish' on member citations.
+- [QUBES][#711] Fixes inheritence 'trusted content' configuration on group pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - [HUBZERO][#10237] Add autocomplete attribute to password fields to try and prevent browsers from auto-filling the fields.
  - Allow password to be set when creating a new account via the admin interface.
  - Add ability to archive a group or project moving to a readonly state.
+ - Add migration to create some indexes on database tables for performance effect on larger hubs.
+ - Add helper to get stats from redis when needed for the usage component.
+ - Add capability for 'watching' to be opt-out instead of opt-in.
+ - [PLG_GEOCODE_LOCAL] Adding method for getting continent of country
+ - [NCIP][#1324] Add configuration options to whitelist admins and individual usernames
  
 ### Changed
  - [CORE] Bump version number.
@@ -21,13 +26,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Changing response object returned in accordance with changes to SciStarter API
  - Change import model to be extensible, allowing for greater flexibility (aka adding members to projects on import).
  - Convert Joomla refs to Hubzero equivelants in all components. (bulk find and replace)
- - Make sure nothing uses old Joomla mailer
+ - Make sure nothing uses old Joomla mailer.
  - Updating docblock, XML manifest, converting remaining bits of Joomla
- - [PURR][#1283] Updates the projects component to reflect changes in Google API libraries
- - [PLG_CONTENT_*] Removing remaining bits of Joomla
+ - [PURR][#1283] Updates the Projects component to reflect changes in Google API libraries.
+ - Removing remaining bits of Joomla in Content Plugins.
+ - Change to Groups to disable any action other than read if group is not published.
+ - Changing references to xprofiles table to users table in Cart component.
+ - Use users table instead of xprofiles table in Wishlist component.
+ - Use users table instead of xprofiles table in Newsletter component.
+ - Minor change in how permissions are calculated for archived projects. More efficient permissions calculation for wiki adapters.
 
 
 ### Fixed
+- Fix issue preventing group logo display.
+- [HUBZERO][#10343] Fix issue with creation of project.
+- [COM_MEMBERS] Adding missing required fields checks
+- [QUBES][#795] Fix issues with group edit form losing currently selected logo
+- Fix authorization check before group is instantiated.
+- Fix minor access level issue with group wikis
+- [QUBES][#797] Fix reordering Publication master types.
+- [QUBES][#798] Fix missing language files to Content Plugin.
+- [NANOHUB][#317521] Fix loading of tri-fold on Resource browser.
+- [HUBZERO][#10273] Fix various issues with styling and functionality in the Content Pagebreak plugin.
+- [HUBZERO][#10313] Fix SQL injection issue in Resources component.
+- [HUBZERO][#10313] Fix to guard against SQL injection in Members and Projects.
+- [HUBZERO][#10321] Fix sub-query to prevent SQL error on Newsletter creation.
+- [PURR][#1264] Fix issue with deleting non-existent table in Project Databases.
 - [PURR][#1243] Fix prevents primary contact check before reverting the publication.
 - [PURR][#1290] Fix Solr search Only return non-blocked users.
 - Fix the permissions helper to check the permissions set on the administrator side for the cart component.
@@ -40,30 +64,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [COM_DATAVIEWER][DATACENTERHUB][283] fix dataset download issue ???
 - [NANOHUB][#317179][COM_RESOURCES] Adding missing permissions values ???
 - [PCH][#194] Allows for a fixed length serial number to be designated in the storefront component.
-- [COM_PROJECTS] Fixes invisible files upon upload and alleviates 'ghost' files within the Projects component.
-- [QUBES][#784] Fixes project membership management issue, allows for the removal of a member.
+- [COM_PROJECTS] Fix invisible files upon upload and alleviates 'ghost' files within the Projects component.
+- [QUBES][#784] Fix project membership management issue, allows for the removal of a member.
 - [CDMHUB][#1211] Slight reworking to avoid potential conflicts with adding individuals while 'sync group' is checked 
-- [HUBZERO][#10256] Fixes name link in forum post.
+- [HUBZERO][#10256] Fix name link in forum post.
 - [PURR][#1198][COM_PROJECTS] Enforces project initial repository setup.
-- Fixes super group component route building since 2.x upgrade
-- Fixes 'red' to 'read' in group forum area description.
-- Fixes SciStarter API endpoint path and adding more info to description
-- Fixes how namespace conflict in Collections
-- Fixes object access error in Member Accounts.
-- [QUBES][#772][COM_PROJECTS] Fixes HTML formatting issues concerning extraneous break tags being inserted.
-- Fixes misnamed method in the Content - EmailCloak plugin.
-- [CATALYZECARE][#565] Fixes sure 'save to new' button.
-- [HABRI][#738] Fixes caching issue with tag record upon deletion to prevent dangling objects.
-- Fixes poorly MS-encoded characters in the Members component.
-- [PURR][#1279] Fixes account confirmation loop due to cached User session data.
-- [VHUB][#1330] Fixes 'unknown column' error when adding a new Quota class.
+- Fix super group component route building since 2.x upgrade
+- Fix 'red' to 'read' in group forum area description.
+- Fix SciStarter API endpoint path and adding more info to description
+- Fix how namespace conflict in Collections
+- Fix object access error in Member Accounts.
+- [QUBES][#772] Fix HTML formatting issues concerning extraneous break tags being inserted within Projects.
+- Fix misnamed method in the Content - EmailCloak plugin.
+- [CATALYZECARE][#565] Fix sure 'save to new' button.
+- [HABRI][#738] Fix caching issue with tag record upon deletion to prevent dangling objects.
+- Fix poorly MS-encoded characters in the Members component.
+- [PURR][#1279] Fix account confirmation loop due to cached User session data.
+- [VHUB][#1330] Fix 'unknown column' error when adding a new Quota class.
 - [PURR][#1272] Make sure only non-blocked, confirmed, activated accounts get emailed once about publication statistics.
-- [PURR][#1273][PLG_PROJECTS_FILES] Fixes folder expansion in Project Files area.
-- Fixes the screenshot display on the member dashboard.
+- [PURR][#1273][PLG_PROJECTS_FILES] Fix folder expansion in Project Files area.
+- Fix the screenshot display on the member dashboard.
 - [QUBES][#777] Make sure course discussion sections are created with a published state
-- Fixes styles so group files displays a little nicer across templates
-- [QUBES][#775] Fixes nesting of actvity feed posts.
-- [QUBES][#779] Fixes missing javascript file for login within super groups.
-- [HUBZERO][#10265] Fixes administrative header properly to match action of editing of creating an account
-- [HUBZERO][#10272] Fixes missing language strings 'publish / unpublish' on member citations.
-- [QUBES][#711] Fixes inheritence 'trusted content' configuration on group pages.
+- Fix styles so group files displays a little nicer across templates
+- [QUBES][#775] Fix nesting of actvity feed posts.
+- [QUBES][#779] Fix missing javascript file for login within super groups.
+- [HUBZERO][#10265] Fix administrative header properly to match action of editing of creating an account
+- [HUBZERO][#10272] Fix missing language strings 'publish / unpublish' on member citations.
+- [QUBES][#711] Fix inheritence 'trusted content' configuration on group pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,70 +14,65 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  [COM_UPDATE] Fixes minor docblock issue.
 [COM_UPDATE] Allows webhooks to update the git repo. Meant for QA machines.
 [COM_UPDATE] Adds config values for QA git updater.
+ - Adding all access values to the list to choose from
+- Whitelist for anti-spam plugins.
  
 ### Changed
  - [CORE] Bump version number.
  - [TRAVIS] Only notify on the change event for success or if build fails.
+ - [PURR][#1294] For now, only process the search index queue (cron task) if Solr is configured as search provider.
+ - Changing response object returned in accordance with changes to SciStarter API
+ - Change import model to be extensible, allowing for greater flexibility (aka adding members to projects on import).
+ - Convert Joomla refs to Hubzero equivelants in all components. (bulk find and replace)
+ - Make sure nothing uses old Joomla mailer
+ - Updating docblock, XML manifest, converting remaining bits of Joomla
+- [PURR][#1283] Updates the projects component to reflect changes in Google API libraries
 
 
 ### Fixed
-[PLG_PROJECTS_PUBLICATIONS] Fixing codesniff errors.
-[PURR][#1243][PLG_PROJECTS_PUBLICATIONS] Don't try to process primary contact info if performing a revert
-[*_SEARCH] Fixes PHPCS errors.
-[PURR][#1290][PLG_SEARCH_MEMBERS] Only return non-blocked users. One class per file. Docblock clean-up.
-[COM_SEARCH] Fixing docblock, minor formatting clean-up, some very minor simplification of code.
-[PURR][#1294][PLG_CRON_SEARCH] For now, only process the search index queue if the component's configured engine is Solr. Minor docblock and spacing fixes.
-[COM_CART] Shawn's fix of the permissions helper to check the core.action
-[QUBES][#790][PLG_GROUPS_ANNOUNCEMENTS] Don't run announcement content through content plugins when generating email bodies
-[QUBES][#791][PLG_GROUPS_ANNOUNCEMENTS] Resolve user object correctly
-[NCIP][#1331][COM_WIKI] Fixing a number of issues with saving authors on wiki pages
-[PLG_AUTHENTICATION_SCISTARTER] Changing response object returned in accordance with changes to SciStarter's API
-[COM_MEMBERS] Reworking import model to make it more extensible. Adding handler for Projects. TODO: Plugin based?
-[COM_MEMBERS] Aadding all access values to the list to choose from
-[COM_*] Converting Joomla refs to Hubzero equivs. Minor reformatting.
-[CDMHUB][#1221][PLG_GROUPS_PROJECTS] Don't link to projects group member doesn't have access to
-[NCIP][#1200][*_PUBLICATIONS] Honor the master type's configured option for license.
-[HUBZERO][#10298][PLG_*_COLLECTIONS] Fail a little mroe gracefully when image file can't be found
-[COM_DATAVIEWER][DATACENTERHUB][283] fix dataset download issue
-[NANOHUB][#317179][COM_RESOURCES] Adding missing permissions values
-[LIB-JOOMLA][COM_*] Make sure nothing uses old Joomla mailer
-[PLG_SYSTEM_*] Updating docblock, XML manifest, converting remaining bits of Joomla
-[COM_STOREFRONT] As per community hub ticket #194 fixed the serial number length limitation
-[PURR][#1283][COM_PROJECTS] Updates to reflect changes in Google API libraries
-[COM_PROJECTS] Another check to makes sure the project repo is in good standing.
-[*] Removing or converting some remaining Joomla code
-[QUBES][#784][COM_PROJECTS][PLG_PROJECTS_TEAM] Force group syncing off if a project doesn't have a group owner
-[PLG_CONTENT_ANTISPAM] Don't bother processing submissions by admins.
-[CDMHUB][#1211][PLG_PROJECTS_TEAM] Slight reworking to avoid potential conflicts with adding individuals while 'sync group' is checked
-[COM_FORUM] Fixes according to review.
-[COM_FORUM][HUBZERO][#10256] Fixes a variable name typo.
-[PURR][#1198][COM_PROJECTS] Adds a check to see if the initial commit has not been made.
-[PLG_SYSTEM_SUPERGROUPS] Reworkng to get super group component route building working in 2.x
-[CORE] Updating file with 2.0 paths
-[PLG_GROUPS_FORUM] Corrects language file typo.
-[PLG_AUTHENTICATION_SCISTARTER] Fixing API endpoint path and adding more info to description
-[COM_COLLECTIONS] Changing how namespace is used as it can potentially conflict with existing Following Group class
-[PLG_MEMBERS_ACCOUNT] Make sure var is an object before using it as such
-[HUBZERO][#10237][COM_MEMBERS] Adding autocomplete attribute to password fields to try and prevent browsers from auto-filling the fields
-[QUBES][#772][COM_PROJECTS] Make sure HTML formatted content doesn't have line-breaks converted into break tags (to much breaking)
-[PLG_CONTENT_EMAILCLOAK] Fixes misnamed method.
-[CATALYZECARE][#565][COM_MEMBERS] Make sure 'save to new' button works
-[HABRI][#738][COM_TAGS] Purge query cache before deleting record or it may accidentally remove records that should no longer be associated with it
-[PLG_AUTHENTICATION_SCISTARTER] Minor tweaks to URL building and error handling
-[COM_MEMBERS] Try to sanitize bad MS edncoded characters
-[PLG_CONTENT_EMAILCLOAK] Fixing syntac error
-[PLG_CONTENT_*] Removing remaining bits of Joomla
-[PURR][#1279][PLG_SYSTEM_UNCONFIRMED] Prevents the use of stale User activation state.
-[COM_MEMBERS] Allow password to be set when creating a new account via the admin interface.
-[VHUB][#1330][COM_MEMBERS] Removing invalid initiate declaration and automatic method
-[PLG_CONTENT_PAGEBREAK] Removing Joomla-specific code
-[PURR][#1272][PLG_CRON_PUBLICATIONS] Reworking a few spots to be more efficient. Make sure only non-blocked, confirmed, activated accounts get emailed once.
-[PURR][#1273][PLG_PROJECTS_FILES] Make sure text wrap has the correct class name or else javascript can't find a proper hook to latch onto
-[MOD_MYSESSIONS] Fixes the screenshot display.
-[QUBES][#777][PLG_COURSES_DISCUSSIONS] Make sure sections are created with a published state
-[COM_GROUPS][PLG_GROUPS_FILES][TPL_HUBBASIC2013] Adjustments to styles so group files displays a little nicer across templates
-[QUBES][#775][PLG_*_ACTIVITY] Make sure data selector is more specific or else child responses can end up in the top-level list
-[QUBES][#779][MOD_LOGIN] Add required script
-[HUBZERO][#10265][COM_MEMBERS] Make sure header properly matches action of editing ot creating an account
-[HUBZERO][#10272][PLG_MEMBERS_CITATIONS] Adding missing language strings
-[QUBES][#711][COM_GROUPS] Catching more places where 'trusted content' config needs to be inherited before saving
+- [PURR][#1243] Fix prevents primary contact check before reverting the publication.
+- [PURR][#1290] Fix Solr search Only return non-blocked users.
+- Fix the permissions helper to check the permissions set on the administrator side for the cart component.
+- [QUBES][#790] Fix do not cloak email addresses in emails sent out through the group announcements plugin.
+- [QUBES][#791] Fix correctly displays the senders name in the generated email.
+- [NCIP][#1331] Fix a number of issues with saving authors on wiki pages
+- [CDMHUB][#1221] Fix do not link to projects group member does not have access to. (since addtion of sub-group projects)
+- [NCIP][#1200] Fix publications to allow for optional license for a given master type.
+- [HUBZERO][#10298] Fix display 'image not found' within a collection, instead of 500 error.
+- [COM_DATAVIEWER][DATACENTERHUB][283] fix dataset download issue ???
+- [NANOHUB][#317179][COM_RESOURCES] Adding missing permissions values ???
+- [PCH][#194] Allows for a fixed length serial number to be designated in the storefront component.
+- [COM_PROJECTS] Fixes invisible files upon upload and alleviates 'ghost' files within the Projects component.
+- [QUBES][#784] Force group syncing off if a project doesn't have a group owner
+- [CDMHUB][#1211][PLG_PROJECTS_TEAM] Slight reworking to avoid potential conflicts with adding individuals while 'sync group' is checked
+- [HUBZERO][#10256] Fixes a variable name typo.
+- [PURR][#1198][COM_PROJECTS] Adds a check to see if the initial commit has not been made.
+- [PLG_SYSTEM_SUPERGROUPS] Reworkng to get super group component route building working in 2.x
+- [CORE] Updating file with 2.0 paths
+- [PLG_GROUPS_FORUM] Corrects language file typo.
+- [PLG_AUTHENTICATION_SCISTARTER] Fixing API endpoint path and adding more info to description
+- [COM_COLLECTIONS] Changing how namespace is used as it can potentially conflict with existing Following Group class
+- [PLG_MEMBERS_ACCOUNT] Make sure var is an object before using it as such
+- [HUBZERO][#10237][COM_MEMBERS] Adding autocomplete attribute to password fields to try and prevent browsers from auto-filling the fields
+- [QUBES][#772][COM_PROJECTS] Make sure HTML formatted content doesn't have line-breaks converted into break tags (to much breaking)
+- [PLG_CONTENT_EMAILCLOAK] Fixes misnamed method.
+- [CATALYZECARE][#565][COM_MEMBERS] Make sure 'save to new' button works
+- [HABRI][#738][COM_TAGS] Purge query cache before deleting record or it may accidentally remove records that should no longer be associated with it
+- [PLG_AUTHENTICATION_SCISTARTER] Minor tweaks to URL building and error handling
+- [COM_MEMBERS] Try to sanitize bad MS edncoded characters
+- [PLG_CONTENT_EMAILCLOAK] Fixing syntac error
+- [PLG_CONTENT_*] Removing remaining bits of Joomla
+- [PURR][#1279][PLG_SYSTEM_UNCONFIRMED] Prevents the use of stale User activation state.
+- [COM_MEMBERS] Allow password to be set when creating a new account via the admin interface.
+- [VHUB][#1330][COM_MEMBERS] Removing invalid initiate declaration and automatic method
+- [PLG_CONTENT_PAGEBREAK] Removing Joomla-specific code
+- [PURR][#1272][PLG_CRON_PUBLICATIONS] Reworking a few spots to be more efficient. Make sure only non-blocked, confirmed, activated accounts get emailed once.
+- [PURR][#1273][PLG_PROJECTS_FILES] Make sure text wrap has the correct class name or else javascript can't find a proper hook to latch onto
+- [MOD_MYSESSIONS] Fixes the screenshot display.
+- [QUBES][#777][PLG_COURSES_DISCUSSIONS] Make sure sections are created with a published state
+- [COM_GROUPS][PLG_GROUPS_FILES][TPL_HUBBASIC2013] Adjustments to styles so group files displays a little nicer across templates
+- [QUBES][#775][PLG_*_ACTIVITY] Make sure data selector is more specific or else child responses can end up in the top-level list
+- [QUBES][#779][MOD_LOGIN] Add required script
+- [HUBZERO][#10265][COM_MEMBERS] Make sure header properly matches action of editing ot creating an account
+- [HUBZERO][#10272][PLG_MEMBERS_CITATIONS] Adding missing language strings
+- [QUBES][#711][COM_GROUPS] Catching more places where 'trusted content' config needs to be inherited before saving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
-and this project adheres to [Semantic Versioning](http://semver.org/).
-
 ## [2.1.3] - 2016-02-01
 ### Added
  - Add Travis CI badge


### PR DESCRIPTION
A changelog helps communicate to our customers what is being delivered with the release. Inspired by the thoughts conveyed http://keepachangelog.com/en/0.3.0/.

This helps us with packaging our product in a way that promotes openness. As the web development effort grows, it helps us communicate what's going on internally. 

Documentation become easier to generate by tracking additions, removals, and changes. This also helps us identify which areas need to be tested.

This new version would go on top of the [2.1.3] section. 

Those with repository acccess (HUBzero team) can use Github's built-in editor to modify this file over time. 
