### PR TITLE
[HUBZERO][#10328][COM_PUBLICATIONS] Fixed getting the block ID in the curation model.

### DIFF
--- a/core/components/com_publications/models/curation.php
+++ b/core/components/com_publications/models/curation.php
@@ -280,15 +280,13 @@ class Curation extends Object
 	public function getBlockId($name = NULL)
 	{
 		$blockId = NULL;
-		$i = 1;
-		foreach ($this->_blocks as $block)
+		foreach ($this->_blocks as $index => $block)
 		{
 			if ($block->name == $name)
 			{
-				$blockId = $i;
+				$blockId = $index;
 				break;
 			}
-			$i++;
 		}
 
 		return $blockId;

--- a/core/plugins/user/ldap/ldap.php
+++ b/core/plugins/user/ldap/ldap.php
@@ -91,7 +91,7 @@ class plgUserLdap extends \Hubzero\Plugin\Plugin
 	{
 		\Hubzero\Utility\Ldap::syncUser($user['id']);
 
-		return true
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the bug where clicking `review & submit to be published` will take the user to a block other than the review block.