### PR TITLE
[PURR][#1314] Using new ORCID creation workflow and upgrade API to version 2.0

### DIFF
--- a/core/components/com_members/site/controllers/orcid.php
+++ b/core/components/com_members/site/controllers/orcid.php
@@ -147,7 +147,7 @@ class Orcid extends SiteController
 		}
 
 		$url .= implode('+AND+', $bits);
-
+		
 		$header = array('Accept: application/vnd.orcid+xml');		
 		if ($srv != 'public')
 		{

--- a/core/components/com_members/site/controllers/orcid.php
+++ b/core/components/com_members/site/controllers/orcid.php
@@ -126,7 +126,7 @@ class Orcid extends SiteController
 	{
 		$srv = $this->config->get('orcid_service', 'members');
 
-		$url = Request::scheme() . '://' . $this->_services[$srv] . '/v1.2/search/orcid-bio?q=';
+		$url = Request::scheme() . '://' . $this->_services[$srv] . '/v2.0/search/?q=';
 		$tkn = $this->config->get('orcid_' . $srv . '_token');
 
 		$bits = array();
@@ -148,7 +148,7 @@ class Orcid extends SiteController
 
 		$url .= implode('+AND+', $bits);
 
-		$header = array('Accept: application/orcid+xml');
+		$header = array('Accept: application/vnd.orcid+xml');		
 		if ($srv != 'public')
 		{
 			$header[] = 'Authorization: Bearer ' . $tkn;
@@ -285,7 +285,7 @@ class Orcid extends SiteController
 		{
 			$filled++;
 
-			$root = $this->_fetchXml($first_name, NULL, NULL);
+			$root = $this->_fetchXml($first_name, null, null);
 
 			if (!empty($root))
 			{
@@ -298,7 +298,7 @@ class Orcid extends SiteController
 		{
 			$filled++;
 
-			$root = $this->_fetchXml(NULL, $last_name, NULL);
+			$root = $this->_fetchXml(null, $last_name, null);
 
 			if (!empty($root))
 			{
@@ -311,7 +311,7 @@ class Orcid extends SiteController
 		{
 			$filled++;
 
-			$root = $this->_fetchXml(NULL, NULL, $email);
+			$root = $this->_fetchXml(null, null, $email);
 
 			if (!empty($root))
 			{
@@ -325,7 +325,6 @@ class Orcid extends SiteController
 		if ($filled > 1)
 		{
 			$root = $this->_fetchXml($first_name, $last_name, $email);
-
 			if (!empty($root))
 			{
 				$multi = $this->_parseTree($root);

--- a/core/components/com_members/site/views/orcid/tmpl/display.php
+++ b/core/components/com_members/site/views/orcid/tmpl/display.php
@@ -118,7 +118,7 @@ $tkn = $this->config->get('orcid_' . $srv . '_token');
 				<h4><?php echo Lang::txt('Search for an existing ORCID'); ?></h4>
 				<div class="grid nobreak">
 					<div class="col span8">
-						<p><?php echo Lang::txt('If you have created an ORCID or your institution has generated one for you, fill in the fields above and search for your ID from the list.'); ?></p>
+						<p><?php echo Lang::txt('If you have created an ORCID, fill in the fields above and search for your ID from the list.'); ?></p>
 						<p><?php echo Lang::txt('Note that most ORCID records have the email address marked as private and private information will not be returned in the search results.'); ?></p>
 					</div>
 					<div class="col span4 omega">
@@ -143,10 +143,10 @@ $tkn = $this->config->get('orcid_' . $srv . '_token');
 					<h4><?php echo Lang::txt('Create a new ORCID'); ?></h4>
 					<div class="grid nobreak">
 						<div class="col span8">
-							<p><?php echo Lang::txt('If you can\'t find your ID or would like to create one, click the "Create new ORCID" button to generate a new ID based on the info above. You will receive an email from ORCID to claim the new ID.'); ?></p>
+							<p><?php echo Lang::txt('If you can\'t find your ID or would like to create one, click the "Create new ORCID" button.'); ?></p>
 						</div>
 						<div class="col span4 omega">
-							<p><a id="create-orcid" class="btn" onclick="<?php echo "HUB.Orcid.createOrcid(document.getElementById('first-name').value, document.getElementById('last-name').value, document.getElementById('email').value)"; ?>"><?php echo Lang::txt('Create new ORCID'); ?></a></p>
+							<p><a id="create-orcid" class="btn" href="https://orcid.org/register" target="_blank"><?php echo Lang::txt('Create new ORCID'); ?></a></p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
There are two changes in this request. One is the new ORCID creation process. Another is the ORCID API upgrade.

 The existing “Create-and-claim” workflow causes millions of ORCID ID created but never claimed and used . So ORCID carries out the create-on-demand workflow to ask people register ORCID by themselves and get the ORCID Id instantly.

 The change about ORCID API is that ORCID has upgraded the API from version 1.2 to version
2.0. The API version 2.0 has been live on production since February 14 2017. 

For details please refer to ticket #1314 through link below.
https://purr.purdue.edu/support/ticket/1314?show=107&search=&limit=20&start=0