### PR TITLE
[QUBES][#874][COM_PUBLICATIONS] Add publication note and tag show/ hi…

### DIFF
--- a/core/components/com_publications/config/config.xml
+++ b/core/components/com_publications/config/config.xml
@@ -94,6 +94,14 @@
 			<option value="0">JHIDE</option>
 			<option value="3">COM_PUBLICATIONS_CONFIG_PUBLISHED</option>
 		</field>
+		<field name="show_notes" type="list" default="1" label="COM_PUBLICATIONS_CONFIG_NOTES" description="COM_PUBLICATIONS_CONFIG_NOTES_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field name="show_tags" type="list" default="1" label="COM_PUBLICATIONS_CONFIG_TAGS" description="COM_PUBLICATIONS_CONFIG_TAGS_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
 		<field name="show_linked_data" type="list" default="1" label="COM_PUBLICATIONS_CONFIG_LINKED_DATA" description="COM_PUBLICATIONS_CONFIG_LINKED_DATA_DESC">
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>


### PR DESCRIPTION
…de configuration

Administrators can now change the default params pertaining to showing
or hiding publication notes and tags

/administrator

Components > Publications > Options > Sections