### PR TITLE
[PURR][#1461]Fix the ORCID search issue

### DIFF
--- a/core/components/com_members/site/controllers/orcid.php
+++ b/core/components/com_members/site/controllers/orcid.php
@@ -148,7 +148,8 @@ class Orcid extends SiteController
 			$root = '';
 		}
 		
-        $name = array();		
+		$name = array();
+		
 		if (!empty($root))
 		{			
 			foreach ($root->children() as $child)
@@ -185,12 +186,10 @@ class Orcid extends SiteController
 						if (($profile->getName() == 'path'))
 						{
 							$fields[$profile->getName()] = $profile->__toString();
-							
-							// Get the user's name which is associated with the ORCID id 
 							$names = $this->_getUserName($profile->__toString(), $this->_accessToken);
 							$fields = array_merge($fields, $names);
 						}
-						else if ( $profile->getName() == 'uri')
+						else if ($profile->getName() == 'uri')
 						{
 							$fields[$profile->getName()] = $profile->__toString();
 						}
@@ -236,10 +235,10 @@ class Orcid extends SiteController
 		
 		// Search by first name, last name, email address
 		$url = Request::scheme() . '://' . $this->_services[$srv] . '/v2.0/search/?q=';
-		$tkn = $this->_accessToken;		
-
+		$tkn = $this->_accessToken;
+		
 		$bits = array();
-
+		
 		if ($fname)
 		{
 			$bits[] = 'given-names:' . $fname;
@@ -254,7 +253,7 @@ class Orcid extends SiteController
 		{
 			$bits[] = 'email:' . $email;
 		}
-
+		
 		$url .= implode('+AND+', $bits);
 		
 		$header = array('Accept: application/vnd.orcid+xml');
@@ -269,15 +268,12 @@ class Orcid extends SiteController
 		curl_setopt($initedCurl, CURLOPT_FOLLOWLOCATION, true);
 		curl_setopt($initedCurl, CURLOPT_MAXREDIRS, 3);
 		curl_setopt($initedCurl, CURLOPT_RETURNTRANSFER, 1);
-
+		
 		$curlData = curl_exec($initedCurl);
-		
 		$xmlStr = htmlentities($curlData);
-		
 		$xmlStr = preg_replace('/[a-zA-Z]+:([a-zA-Z])/', '$1', $xmlStr);
-		
 		$xmlStr = html_entity_decode($xmlStr);
-
+		
 		if (!curl_errno($initedCurl))
 		{
 			$info = curl_getinfo($initedCurl);
@@ -286,9 +282,9 @@ class Orcid extends SiteController
 		{
 			echo 'Curl error: ' . curl_error($initedCurl);
 		}
-
+		
 		curl_close($initedCurl);
-
+		
 		try
 		{
 			$root = simplexml_load_string($xmlStr);
@@ -377,7 +373,6 @@ class Orcid extends SiteController
 	 */
 	public function fetchTask($is_return = false)
 	{
-		
 		$first_name  = Request::getVar('fname', '');
 		$last_name   = Request::getVar('lname', '');
 		$email       = Request::getVar('email', '');
@@ -389,7 +384,7 @@ class Orcid extends SiteController
 		{
 			$callbackPrefix = 'HUB.Register.';
 		}
-
+		
 		// Separated into three requests for better results
 		$filled = 0;
 		$fnames = array();

--- a/core/components/com_members/site/views/orcid/tmpl/display.php
+++ b/core/components/com_members/site/views/orcid/tmpl/display.php
@@ -80,32 +80,35 @@ $this->css('orcid.css');
 
 $srv = $this->config->get('orcid_service', 'members');
 $tkn = $this->config->get('orcid_' . $srv . '_token');
+$clientID = $this->config->get('orcid_' . $srv . '_client_id', '');
+$redirectURI = $this->config->get('orcid_' . $srv . '_redirect_uri', '');
+
 ?>
 <section class="main section">
 	<form name="orcid-search-form">
 		<?php if ($srv != 'public' && !$tkn) { ?>
-			<p class="warning"><?php echo Lang::txt('This service is currently unavailable and/or not configured correctly. Please contact <a href="%s">support</a> for further assistance.', Route::url('index.php?option=com_support')); ?></p>
+			<p class="warning"><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_UNAVAILABLE', Route::url('index.php?option=com_support')); ?></p>
 		<?php } else { ?>
-			<h3><?php echo Lang::txt('Associate your <b>ORCID</b> (Open Researcher and Contributor ID)'); ?></h3>
+			<h3><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_ASSOCIATE_ORCID'); ?></h3>
 			<fieldset>
-				<legend><?php echo Lang::txt('Profile Info'); ?></legend>
+				<legend><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_PROFILE_INFO'); ?></legend>
 
 				<div class="grid nobreak">
 					<div class="col span4">
 						<label for="first-name">
-							<?php echo Lang::txt('First name:'); ?>
+							<?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_FIRST_NAME'); ?>
 							<input type="text" id="first-name" name="first-name" value="<?php echo $this->escape($fname); ?>" />
 						</label>
 					</div>
 					<div class="col span4">
 						<label for="last-name">
-							<?php echo Lang::txt('Last name:'); ?>
+							<?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_LAST_NAME'); ?>
 							<input type="text" id="last-name" name="last-name" value="<?php echo $this->escape($lname); ?>" />
 						</label>
 					</div>
 					<div class="col span4 omega">
 						<label for="email">
-							<?php echo Lang::txt('Email:'); ?>
+							<?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_EMAIL'); ?>
 							<input type="text" id="email" name="email" value="<?php echo $this->escape($email); ?>" />
 						</label>
 					</div>
@@ -115,15 +118,15 @@ $tkn = $this->config->get('orcid_' . $srv . '_token');
 			</fieldset>
 
 			<div class="orcid-section orcid-search">
-				<h4><?php echo Lang::txt('Search for an existing ORCID'); ?></h4>
+				<h4><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_SEARCH_FOR_EXISTING'); ?></h4>
 				<div class="grid nobreak">
 					<div class="col span8">
-						<p><?php echo Lang::txt('If you have created an ORCID, fill in the fields above and search for your ID from the list.'); ?></p>
-						<p><?php echo Lang::txt('Note that most ORCID records have the email address marked as private and private information will not be returned in the search results.'); ?></p>
+						<p><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_FILL_AND_SEARCH'); ?></p>
+						<p><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_NOTE_ABOUT_PRIVATE_ORCID'); ?></p>
 					</div>
 					<div class="col span4 omega">
 						<p>
-							<a id="get-orcid-results" class="btn" href="javascript:;"><?php echo Lang::txt('Search ORCID'); ?></a>
+							<a id="get-orcid-results" class="btn" onclick="<?php echo 'HUB.Orcid.fetchOrcidRecords(\'' . $this->escape($fname) . '\', \'' . $this->escape($lname) . '\', \'' . $this->escape($email) . '\');'; ?>"><?php echo Lang::txt('Search ORCID'); ?></a>
 						</p>
 					</div>
 				</div>
@@ -140,13 +143,16 @@ $tkn = $this->config->get('orcid_' . $srv . '_token');
 
 			<?php if ($this->config->get('orcid_service', 'members') != 'public') { ?>
 				<div class="orcid-section orcid-create">
-					<h4><?php echo Lang::txt('Create a new ORCID'); ?></h4>
+					<h4><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_CREATE_ORCID'); ?></h4>
 					<div class="grid nobreak">
 						<div class="col span8">
-							<p><?php echo Lang::txt('If you can\'t find your ID or would like to create one, click the "Create new ORCID" button.'); ?></p>
+							<p><?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_CLICK_CREATE_BUTTON'); ?></p>
 						</div>
 						<div class="col span4 omega">
-							<p><a id="create-orcid" class="btn" href="https://orcid.org/register" target="_blank"><?php echo Lang::txt('Create new ORCID'); ?></a></p>
+							<p><a id="create-orcid" class="btn" href="https://<?php if ($this->config->get('orcid_service', 'members') == 'sandbox') { echo 'sandbox.'; }?>orcid.org/oauth/authorize?client_id=<?php echo $clientID ?>
+							<?php echo htmlspecialchars('&'); ?>response_type=code<?php echo htmlspecialchars('&'); ?>scope=/authenticate<?php echo htmlspecialchars('&'); ?>redirect_uri=<?php echo urlencode($redirectURI) ?><?php echo htmlspecialchars('&'); ?>family_names=<?php echo $this->escape($lname);?>
+							<?php echo htmlspecialchars('&'); ?>given_names=<?php echo $this->escape($fname);?><?php echo htmlspecialchars('&'); ?>email=<?php echo $this->escape($email);?> " target="_blank">
+							<?php echo Lang::txt('COM_MEMBERS_PROFILE_ORCID_CREATE_OR_CONNECT'); ?></a></p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
The pop-up form doesn't show any ORCID searching result after clicking on the "Find your ORCID" on user's profile page. The reason is that the ORCID search response has changed. At the moment there's no name associated with the ORCID ID return which cause the search fail and no results return.

The ORCID API 2.0 search functionality introduction can be accessed through link below: 
https://members.orcid.org/api/tutorial/search-orcid-registry

According to the introduction, client has to get the record access token, and then perform the search. So the fix to the issue contains the items below.
1. Add process to get the ORCID record access token, then perform the search by name and email address.
2. Get the name associated with each ORCID ID in the search results in step 1. It has to search by the access token and ORCID ID in order to get the name.

You may find there are couple of new process in _fetchXml(). The reason is that there is parsing issue with the namespace of xml for simplexml_load_string(), so that's why the prefix has to be removed before the curl output can be successfully converted to SimpleXMLElement. 

