### PR TITLE
Update index.php

### DIFF
--- a/core/templates/kimera/index.php
+++ b/core/templates/kimera/index.php
@@ -132,7 +132,7 @@ $this->setTitle(Config::get('sitename') . ' - ' . $this->getTitle());
 									<li>
 										<a class="icon-login" href="<?php echo Route::url('index.php?option=com_users&view=login'); ?>" title="<?php echo Lang::txt('TPL_KIMERA_LOGIN'); ?>"><?php echo Lang::txt('TPL_KIMERA_LOGIN'); ?></a>
 									</li>
-									<?php if ($this->params->get('registerLink') && Component::params('com_users')->get('allowUserRegistration')) : ?>
+									<?php if ($this->params->get('registerLink') && Component::params('com_members')->get('allowUserRegistration')) : ?>
 										<li>
 											<a class="icon-register" href="<?php echo Route::url('index.php?option=com_register'); ?>" title="<?php echo Lang::txt('TPL_KIMERA_SIGN_UP'); ?>"><?php echo Lang::txt('TPL_KIMERA_REGISTER'); ?></a>
 										</li>


### PR DESCRIPTION
When you disable registration in Control Panel, registration icon is not hidden, but refers to 404 Page Not Found. Reason: if you change "Users -> Members -> Options -> Allow User Registration" it affects setting in com_members, not com_users.