### PR TITLE
Fix shibboleth plugin issues brought up during QubesHub deployment

### DIFF
--- a/core/plugins/authentication/shibboleth/fields/get-rs-entities.php
+++ b/core/plugins/authentication/shibboleth/fields/get-rs-entities.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * HUBzero CMS
+ *
+ * Copyright 2005-2015 HUBzero Foundation, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * HUBzero is a registered trademark of Purdue University.
+ *
+ * @package   hubzero-cms
+ * @author    Steven Snyder <snyder13@purdue.edu>
+ * @author    Sam Wilson <samwilson@purdue.edu>
+ * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+if (PHP_SAPI !== 'cli') {
+	exit();
+}
+
+$mdSource = 'https://wayf.incommonfederation.org/InCommon/InCommon-metadata.xml';
+$cache = '/www/tmp/incommon-rs-entities.json';
+
+/**
+ * Get a list of research and scholarship IDs
+ */
+$ch = curl_init();
+// fetch the latest InCommon metadata, if needed
+curl_setopt($ch, \CURLOPT_URL, $mdSource);
+curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, \CURLOPT_FOLLOWLOCATION, true);
+curl_setopt($ch, \CURLOPT_MAXREDIRS, 5);
+curl_setopt($ch, \CURLOPT_TIMEOUT, 2);
+curl_setopt($ch, \CURLOPT_HTTPHEADER, []);
+curl_setopt($ch, \CURLOPT_TIMEOUT, 60);
+if (file_exists($cache))
+{
+	curl_setopt($ch, \CURLOPT_HTTPHEADER, ['If-Modified-Since: '.gmdate('D, d M Y H:i:s \G\M\T', filemtime($cache))]);
+	$xml = curl_exec($ch);
+	if (curl_getinfo($ch, \CURLINFO_HTTP_CODE) == 304)
+	{
+		echo file_get_contents($cache);
+		exit();
+	}
+}
+else
+{
+	$xml = curl_exec($ch);
+}
+
+if (!$xml) {
+	echo '[]';
+	exit();
+}
+
+$xp = new \SimpleXMLElement($xml);
+foreach ($xp->getNamespaces(true) as $name => $url)
+{
+	$xp->registerXPathNamespace($name ? $name : 'base', $url);
+}
+$rv = [];
+// select entities having the saml attribute indicating that they are research & scholarship category members
+// being members ourselves, we can get attributes about users released fromt these entities
+foreach ($xp->xpath('//base:EntityDescriptor[
+	base:Extensions/
+		mdattr:EntityAttributes/
+			saml:Attribute[attribute::Name="http://macedir.org/entity-category-support"]/
+				saml:AttributeValue[text()="http://id.incommon.org/category/research-and-scholarship" or text()="http://refeds.org/category/research-and-scholarship"]
+	]') as $entity)
+{
+	// easier to work with as an array, the SimpleXMLElement class is bizarre
+	$entity = (array)$entity;
+	$id = $entity['@attributes']['entityID'];
+	$title = $xp->xpath('//base:EntityDescriptor[attribute::entityID="'.$id.'"]//mdui:DisplayName');
+	if (isset($title[0])) {
+		$title = (string)$title[0];
+	}
+	else {
+		continue;
+	}
+	preg_match('/([^.:]+[.][^.]+?)(?:[\/]|$)/', $id, $ma);
+	$host = $ma[1];
+	// logos no longer fetched b/c the result was ugly. if you want to experiment, go for it
+//			$logo = $xp->xpath('//base:EntityDescriptor[attribute::entityID="'.$id.'"]//mdui:Logo');
+//			$logo = isset($logo[0]) ? (string)$logo[0] : 'https://'.$host.'/favicon.ico';
+	$rv[] = [
+		'entity_id' => $id,
+		'label'     => $title,
+		'host'      => $host
+//				'logo'      => $logo
+	];
+}
+$rv = json_encode($rv);
+file_put_contents($cache, $rv);
+echo $rv;

--- a/core/plugins/authentication/shibboleth/shibboleth.php
+++ b/core/plugins/authentication/shibboleth/shibboleth.php
@@ -157,11 +157,11 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 	 */
 	private static function getInstitutions()
 	{
-		static $inst = NULL;
-		if ($inst === NULL)
+		static $inst = null;
+		if ($inst === null)
 		{
 			$plugin = Plugin::byType('authentication', 'shibboleth');
-			$inst = json_decode(json_decode($plugin->params)->institutions, TRUE);
+			$inst = json_decode(json_decode($plugin->params)->institutions, true);
 			$inst = isset($inst['activeIdps']) ? $inst['activeIdps'] : [];
 		}
 		return $inst;
@@ -174,7 +174,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 	 * @param   unknown  $key
 	 * @return  unknown
 	 */
-	public static function getInstitutionByEntityId($eid, $key = NULL)
+	public static function getInstitutionByEntityId($eid, $key = null)
 	{
 		foreach (self::getInstitutions() as $inst)
 		{
@@ -184,8 +184,8 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 				return $key ? $inst[$key] : $inst;
 			}
 		}
-		self::log('getInstitutionByEntityId', array('eid' => $eid, 'key' => $key, 'rv' => NULL));
-		return NULL;
+		self::log('getInstitutionByEntityId', array('eid' => $eid, 'key' => $key, 'rv' => null));
+		return null;
 	}
 
 	/**
@@ -201,7 +201,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 	 */
 	public static function onGetLinkDescription()
 	{
-		$sess = App::get('session')->get('shibboleth.session', NULL);
+		$sess = App::get('session')->get('shibboleth.session', null);
 		if ($sess && $sess['idp'] && ($rv = self::getInstitutionByEntityId($sess['idp'], 'label')))
 		{
 			return $rv;
@@ -217,7 +217,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 	 */
 	private static function getLoginParams()
 	{
-		$service = rtrim(Request::base(),'/');
+		$service = rtrim(Request::base(), '/');
 
 		if (empty($service))
 		{
@@ -263,16 +263,16 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 		);
 	}
 
-	public static function onRenderOption($return = NULL, $title = 'With an affiliated institution:')
+	public static function onRenderOption($return = null, $title = 'With an affiliated institution:')
 	{
 		// Hide the login box if the plugin is in "debug mode" and the special key is not set in the request
 		$params = Plugin::params('authentication', 'shibboleth');
-		if (($testKey = $params->get('testkey', NULL)) && !array_key_exists($testKey, $_GET))
+		if (($testKey = $params->get('testkey', null)) && !array_key_exists($testKey, $_GET))
 		{
 			return '<span />';
 		}
 		// Saved id provider? Use it as the default
-		$prefill = isset($_COOKIE['shib-entity-id']) ? $_COOKIE['shib-entity-id'] : NULL;
+		$prefill = isset($_COOKIE['shib-entity-id']) ? $_COOKIE['shib-entity-id'] : null;
 		if (!$prefill && // no cookie
 				($host = self::getHostByAddress(isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'], $params->get('dns', '8.8.8.8'))) && // can get a host
 				preg_match('/[.]([^.]*?[.][a-z0-9]+?)$/', $host, $ma))
@@ -331,7 +331,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 	{
 		self::log('status');
 		$sess = null;
-		if (($key = trim(isset($_COOKIE['shib-session']) ? $_COOKIE['shib-session'] : (isset($_GET['shib-session']) ? $_GET['shib-session'] : NULL))))
+		if (($key = trim(isset($_COOKIE['shib-session']) ? $_COOKIE['shib-session'] : (isset($_GET['shib-session']) ? $_GET['shib-session'] : null))))
 		{
 			self::log('status', $key);
 			$dbh = App::get('db');
@@ -342,7 +342,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 
 		if ($sess)
 		{
-			$sess = json_decode($sess, TRUE);
+			$sess = json_decode($sess, true);
 			self::log('found resumable session:', $sess);
 			return $sess;
 		}
@@ -380,7 +380,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 
 		// Extract variables set by mod_shib, if any
 		// https://www.incommon.org/federation/attributesummary.html
-		if (($sid = isset($_SERVER['REDIRECT_Shib-Session-ID']) ? $_SERVER['REDIRECT_Shib-Session-ID'] : (isset($_SERVER['Shib-Session-ID']) ? $_SERVER['Shib-Session-ID'] : NULL)))
+		if (($sid = isset($_SERVER['REDIRECT_Shib-Session-ID']) ? $_SERVER['REDIRECT_Shib-Session-ID'] : (isset($_SERVER['Shib-Session-ID']) ? $_SERVER['Shib-Session-ID'] : null)))
 		{
 			$attrs = array(
 				'id' => $sid,
@@ -457,7 +457,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 		}
 
 		// Invalid idp in request, send back to login landing
-		$eid = isset($_GET['idp']) ? $_GET['idp'] : (isset($_COOKIE['shib-entity-id']) ? $_COOKIE['shib-entity-id'] : NULL);
+		$eid = isset($_GET['idp']) ? $_GET['idp'] : (isset($_COOKIE['shib-entity-id']) ? $_COOKIE['shib-entity-id'] : null);
 		if (!isset($eid) || !self::getInstitutionByEntityId($eid))
 		{
 			self::log('failed to look up entity id, redirect', array('eid' => $eid, 'url' => $service.'/index.php?option='.$com_user.'&task=login'.$return));
@@ -548,17 +548,17 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 		if (isset($options['shibboleth']['eppn']))
 		{
 			self::log('auth with', $options['shibboleth']);
-			$method = (\Component::params('com_users')->get('allowUserRegistration', FALSE)) ? 'find_or_create' : 'find';
+			$method = (\Component::params('com_users')->get('allowUserRegistration', false)) ? 'find_or_create' : 'find';
 			$hzal = \Hubzero\Auth\Link::$method('authentication', 'shibboleth', $options['shibboleth']['idp'], $options['shibboleth']['eppn']);
 
-			if ($hzal === FALSE)
+			if ($hzal === false)
 			{
 				$response->status = \Hubzero\Auth\Status::FAILURE;
 				$response->error_message = 'Unknown user and new user registration is not permitted.';
 				return;
 			}
 
-			$hzal->email = isset($options['shibboleth']['email']) ? $options['shibboleth']['email'] : NULL;
+			$hzal->email = isset($options['shibboleth']['email']) ? $options['shibboleth']['email'] : null;
 
 			self::log('hzal', $hzal);
 			$response->auth_link = $hzal;

--- a/core/plugins/authentication/shibboleth/shibboleth.php
+++ b/core/plugins/authentication/shibboleth/shibboleth.php
@@ -162,7 +162,7 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 		{
 			$plugin = Plugin::byType('authentication', 'shibboleth');
 			$inst = json_decode(json_decode($plugin->params)->institutions, TRUE);
-			$inst = $inst['activeIdps'];
+			$inst = isset($inst['activeIdps']) ? $inst['activeIdps'] : [];
 		}
 		return $inst;
 	}


### PR DESCRIPTION
1. Filtering the InCommon metadata to look for research & scholarship entities took too much memory and the PHP limits had to be raised. I split the method off into a different file that gets 'exec'-ed instead, and meanwhile changed the caching strategy so the page loads quickly more often.

2. Enabling the plugin without adding any institutions on the back-end caused an error. Changed this to just show an empty list of providers instead.