### PR TITLE
Cli

### DIFF
--- a/core/bootstrap/Cli/Providers/TranslationServiceProvider.php
+++ b/core/bootstrap/Cli/Providers/TranslationServiceProvider.php
@@ -93,10 +93,12 @@ class TranslationServiceProvider extends ServiceProvider
 		// Detect default language
 		if (!$language && $this->app->has('component'))
 		{
-			try {
+			try 
+			{
 				$params = $this->app['component']->params('com_languages');
 			}
-			catch (Exception $e) {
+			catch (\Hubzero\Database\Exception\QueryFailedException $e)
+			{
 				$params = new \Hubzero\Config\Registry;
 			}
 

--- a/core/bootstrap/Cli/Providers/TranslationServiceProvider.php
+++ b/core/bootstrap/Cli/Providers/TranslationServiceProvider.php
@@ -93,7 +93,12 @@ class TranslationServiceProvider extends ServiceProvider
 		// Detect default language
 		if (!$language && $this->app->has('component'))
 		{
-			$params = $this->app['component']->params('com_languages');
+			try {
+				$params = $this->app['component']->params('com_languages');
+			}
+			catch (Exception $e) {
+				$params = new \Hubzero\Config\Registry;
+			}
 
 			$language = $params->get(
 				$this->app['client']->name,

--- a/core/bootstrap/Cli/Providers/UserServiceProvider.php
+++ b/core/bootstrap/Cli/Providers/UserServiceProvider.php
@@ -68,10 +68,12 @@ class UserServiceProvider extends ServiceProvider
 		// Set the picture resolver
 		if ($this->app->has('component'))
 		{
-			try {
+			try 
+			{
 				$params = $this->app['component']->params('com_members');
 			}
-			catch (Exception $e) {
+			catch (\Hubzero\Database\Exception\QueryFailedException $e)
+			{
 				$params = new \Hubzero\Config\Registry;
 			}
 

--- a/core/bootstrap/Cli/Providers/UserServiceProvider.php
+++ b/core/bootstrap/Cli/Providers/UserServiceProvider.php
@@ -68,7 +68,12 @@ class UserServiceProvider extends ServiceProvider
 		// Set the picture resolver
 		if ($this->app->has('component'))
 		{
-			$params = $this->app['component']->params('com_members');
+			try {
+				$params = $this->app['component']->params('com_members');
+			}
+			catch (Exception $e) {
+				$params = new \Hubzero\Config\Registry;
+			}
 
 			$config = [
 				'path'          => PATH_APP . DS . 'site' . DS . 'members',


### PR DESCRIPTION
Old commits for updates to TranslationServiceProvider() and UserServiceProvider() to provide sensible defaults so that they can run when the database is in a pre-2.0 state. This happens while upgrading very old hubs.