### PR TITLE
[PURR][#1619]Support parsing the response to the DataCite DOI minting request

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -418,7 +418,6 @@ class Doi extends Obj
 			$doiStr = reset($resArray);
 			$out = explode('/', $doiStr);
 			$handle = trim(end($out));
-			
 			if ($handle)
 			{
 				// Return DOI

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -409,12 +409,16 @@ class Doi extends Obj
 		curl_setopt_array($ch, $options);
 
 		$response = curl_exec($ch);
+		var_dump($response);
+		echo "\n";
 		$success = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		curl_close($ch);
 
 		if ($success === 201 || $success === 200)
 		{
-			$out = explode('/', $response);
+			$resArray = explode('_', $response);
+			$doiStr = reset($resArray);
+			$out = explode('/', $doiStr);
 			$handle = trim(end($out));
 			if ($handle)
 			{

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -409,8 +409,6 @@ class Doi extends Obj
 		curl_setopt_array($ch, $options);
 
 		$response = curl_exec($ch);
-		var_dump($response);
-		echo "\n";
 		$success = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		curl_close($ch);
 
@@ -420,6 +418,7 @@ class Doi extends Obj
 			$doiStr = reset($resArray);
 			$out = explode('/', $doiStr);
 			$handle = trim(end($out));
+			
 			if ($handle)
 			{
 				// Return DOI


### PR DESCRIPTION
The change is to make the code be able to parse the response from the DataCite DOI minting request. The request is built with DataCite API, which is going to replace the EZID API, which is used on Hubzero platform now, by the end of year. The test result shows that the change doesn't have any side effect to the EZID API which is being used on Hubzero platform now.