### PR TITLE
[amoebahub] use __construct instead of class name for constructor [PHP7]

### DIFF
--- a/core/libraries/phpass/PasswordHash.php
+++ b/core/libraries/phpass/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
PHP 7 throws a deprecation error when using classname for the constructor. Simple rename to __construct.