### PR TITLE
[amoebahub] JPath::check() also check in PATH_CORE which may not be under JPATH_ROOT

### DIFF
--- a/core/libraries/joomla/filesystem/path.php
+++ b/core/libraries/joomla/filesystem/path.php
@@ -176,7 +176,7 @@ class JPath
 		}
 
 		$path = JPath::clean($path);
-		if ((JPATH_ROOT != '') && strpos($path, JPath::clean(JPATH_ROOT)) !== 0)
+		if ((JPATH_ROOT != '') && strpos($path, JPath::clean(JPATH_ROOT)) !== 0 && strpos($path, JPath::clean(PATH_CORE)) !== 0 )
 		{
 			// Don't translate
 			JError::raiseError(20, 'JPath::check Snooping out of bounds @ ' . $path);


### PR DESCRIPTION

PATH_CORE is outside the document root in Amoebahub. This fixes one instance where the assumption is otherwise.