### PR TITLE
 fix validemail registration check to allow longer label parts

### DIFF
--- a/core/components/com_members/helpers/utility.php
+++ b/core/components/com_members/helpers/utility.php
@@ -122,7 +122,7 @@ class Utility
 	 */
 	public static function validemail($email)
 	{
-		if (preg_match("/^[_\+\.\%0-9a-zA-Z-]+@([0-9a-zA-Z-]+\.)+[a-zA-Z]{2,6}$/", $email))
+		if (preg_match("/^[_\+\.\%0-9a-zA-Z-]+@([0-9a-zA-Z-]+\.)+[a-zA-Z]{2,63}$/", $email))
 		{
 			return true;
 		}


### PR DESCRIPTION
Email validator on registration check is balking at long top level domains which can now be up to 63 characters long (webmaster@myhub.localdomain comes up on some test builds)