### PR TITLE
 fix validemail registration check to allow longer label parts

### DIFF
--- a/core/components/com_members/helpers/utility.php
+++ b/core/components/com_members/helpers/utility.php
@@ -122,7 +122,7 @@ class Utility
 	 */
 	public static function validemail($email)
 	{
-		if (preg_match("/^[_\+\.\%0-9a-zA-Z-]+@([0-9a-zA-Z-]+\.)+[a-zA-Z]{2,6}$/", $email))
+		if (preg_match("/^[_\+\.\%0-9a-zA-Z-]+@([0-9a-zA-Z-]+\.)+[a-zA-Z]{2,63}$/", $email))
 		{
 			return true;
 		}


### PR DESCRIPTION
same fix for 2.2.5 branch so package can be made for new test installs