### PR TITLE
[feat] Moving bundle contents to modal & styling it

### DIFF
--- a/core/components/com_publications/helpers/html.php
+++ b/core/components/com_publications/helpers/html.php
@@ -872,9 +872,10 @@ class Html
 	 * @param   string   $action    Link action
 	 * @param   boolean  $disabled  Is the button disable?
 	 * @param   string   $pop       Pop-up content
+	 * @param   array    $options
 	 * @return  string
 	 */
-	public static function primaryButton($class, $href, $msg, $xtra = '', $title = '', $action = '', $disabled = false, $pop = '')
+	public static function primaryButton($class, $href, $msg, $xtra = '', $title = '', $action = '', $disabled = false, $pop = '', $options = array())
 	{
 		$view = new \Hubzero\Component\View(array(
 			'base_path' => dirname(__DIR__) . DS . 'site',
@@ -890,6 +891,7 @@ class Html
 		$view->xtra     = $xtra;
 		$view->pop      = $pop;
 		$view->msg      = $msg;
+		$view->options  = $options;
 
 		return $view->loadTemplate();
 	}

--- a/core/components/com_publications/models/attachments/data.php
+++ b/core/components/com_publications/models/attachments/data.php
@@ -224,7 +224,20 @@ class Data extends Base
 			$class = 'btn btn-primary active icon-next';
 			$class .= $disabled ? ' link_disabled' : '';
 			$title = $configs->title ? $configs->title : Lang::txt('Go to data');
-			$html  = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, 'rel="external"', $disabled, $pop);
+
+			$options = array();
+
+			if (file_exists($pub->bundlePath()) && $pub->base == 'databases')
+			{
+				$show = new \stdClass;
+				$show->href = Route::url('index.php?option=com_publications&id=' . $pub->id . '&task=serve&v=' . $pub->version_number . '&render=archive');
+				$show->class = 'archival-package';
+				$show->title = Lang::txt('COM_PUBLICATIONS_ARCHIVE_PACKAGE');
+
+				$options[] = $show;
+			}
+
+			$html  = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, 'rel="external"', $disabled, $pop, $options);
 		}
 		elseif ($role == 2 && $attachments)
 		{
@@ -894,7 +907,10 @@ class Data extends Base
 			return false;
 		}
 
-		$list .= '<li>' . \Components\Projects\Models\File::drawIcon('csv') . ' data.csv</li>';
+		$list .= '<li>';
+		$list .= '<span class="item-icon">' . \Components\Projects\Models\File::drawIcon('csv') . '</span>';
+		$list .= '<span class="item-title">data.csv</span>';
+		$list .= '</li>';
 
 		// Add data files
 		$dataFiles = array();
@@ -904,7 +920,10 @@ class Data extends Base
 		}
 		if (!empty($dataFiles))
 		{
-			$list .= '<li>' . \Components\Projects\Models\File::drawIcon('folder') . ' data</li>';
+			$list .= '<li>';
+			$list .= '<span class="item-icon">' . \Components\Projects\Models\File::drawIcon('folder') . '</span>';
+			$list .= '<span class="item-title">data</span>';
+			$list .= '</li>';
 			foreach ($dataFiles as $e)
 			{
 				// Skip thumbnails and CSV
@@ -922,7 +941,10 @@ class Data extends Base
 				$fPath = $a_dir && $a_dir != '.' ? $a_dir . DS : '';
 				$where = 'data' . DS . $fPath . basename($e);
 
-				$list .= '<li class="level2"><span class="item-title">' . $file::drawIcon($file->get('ext')) . ' ' . trim($where, DS) . '</span></li>';
+				$list .= '<li class="level2">';
+				$list .= '<span class="item-icon">' . $file::drawIcon($file->get('ext')) . '</span>';
+				$list .= '<span class="item-title">' . trim($where, DS) . '</span>';
+				$list .= '</li>';
 			}
 		}
 

--- a/core/components/com_publications/models/attachments/file.php
+++ b/core/components/com_publications/models/attachments/file.php
@@ -307,14 +307,20 @@ class File extends Base
 		if ($configs->multiZip == 1 && $attachments && count($attachments) > 1)
 		{
 			$title = $configs->bundleTitle ? $configs->bundleTitle : 'Bundle';
-			$list .= '<li>' . \Components\Projects\Models\File::drawIcon('zip') . ' ' . $title . '</li>';
+			$list .= '<li>';
+			$list .= '<span class="item-icon">' . \Components\Projects\Models\File::drawIcon('zip') . '</span>';
+			$list .= '<span class="item-title">' . $title . '</span>';
+			$list .= '</li>';
 		}
 		// Draw directories
 		if (($configs->multiZip == 2 && $configs->subdir) || $configs->bundleDirectory)
 		{
 			// Bundle name
 			$name  = $configs->bundleDirectory ? $configs->bundleDirectory : $configs->subdir;
-			$list .= '<li>' . \Components\Projects\Models\File::drawIcon('folder') . ' ' . $name . '</li>';
+			$list .= '<li>';
+			$list .= '<span class="item-icon">' . \Components\Projects\Models\File::drawIcon('folder') . '</span>';
+			$list .= '<span class="item-title">' . $name . '</span>';
+			$list .= '</li>';
 			$class = 'level2';
 		}
 		// List individual
@@ -349,8 +355,10 @@ class File extends Base
 				$file = new \Components\Projects\Models\File($filePath);
 
 				$list .= '<li class="' . $class . '">';
-				$list .= '<span class="item-title" id="file-' . $attach->id . '">' . $file::drawIcon($file->get('ext')) . ' ' . trim($where, DS) . '</span>';
-				$list .= '<span class="item-details">' . $attach->path . '</span>';
+				$list .= '<span class="item-icon">' . $file::drawIcon($file->get('ext')). '</span>';
+				$list .= '<span class="item-title" id="file-' . $attach->id . '">' . trim($where, DS) . '</span>';
+				//$list .= '<span class="item-details">' . $attach->path . '</span>';
+				$list .= '<span class="item-details">' . trim(\Hubzero\Utility\Number::formatBytes(filesize($filePath))) . '</span>';
 				$list .= '</li>';
 			}
 		}
@@ -541,6 +549,8 @@ class File extends Base
 		// Primary button
 		if ($role == 1)
 		{
+			$options = array();
+
 			if (count($attachments) > 1)
 			{
 				$fpath = $this->bundle($attachments, $configs, false);
@@ -571,19 +581,26 @@ class File extends Base
 					$url = Route::url('index.php?option=com_publications&id=' . $pub->id . '&task=serve&v=' . $pub->version_number . '&render=archive');
 					$label .= ' ' . Lang::txt('Bundle');
 					$title = $pub->title . ' ' . Lang::txt('Bundle');
+
+					$show = new \stdClass;
+					$show->href = Route::url('index.php?option=com_publications&id=' . $pub->id . '&task=serve&v=' . $pub->version_number . '&render=showcontents');
+					$show->class = 'showBundle';
+					$show->title = Lang::txt('Show bundle contents');
+
+					$options[] = $show;
 				}
 				else
 				{
 					// Get ext
 					$parts  = explode('.', $fpath);
-					$ext 	= count($parts) > 1 ? array_pop($parts) : null;
-					$ext	= strtolower($ext);
-					$label.= $ext ?  ' <span class="caption">(' . strtoupper($ext) . ')</span>' : '';
+					$ext    = count($parts) > 1 ? array_pop($parts) : null;
+					$ext    = strtolower($ext);
+					$label .= $ext ? ' <span class="caption">(' . strtoupper($ext) . ')</span>' : '';
 				}
-				$class = 'btn btn-primary active icon-next';
+				$class = 'btn btn-primary active'; //icon-next
 				$class .= $disabled ? ' link_disabled' : '';
 
-				$html  = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, '', $disabled, $pop);
+				$html  = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, '', $disabled, $pop, $options);
 			}
 		}
 		elseif ($role == 2 && $attachments)

--- a/core/components/com_publications/models/bundle.php
+++ b/core/components/com_publications/models/bundle.php
@@ -32,7 +32,7 @@
 
 namespace Components\Publications\Models;
 
-require_once Component::path('com_publications') . '/helpers/zipHelper.php';
+require_once \Component::path('com_publications') . '/helpers/zipHelper.php';
 
 use Components\Publications\Models\Publication;
 use Components\Publications\Helpers\ZipHelper;
@@ -43,17 +43,18 @@ use Hubzero\Utility\Arr;
  */
 class Bundle
 {
-	/*
+	/**
 	 * Contents of archive
 	 *
-	 * @var array
+	 * @var  array
 	 */
 	protected $contents = null;
 
-	/*
+	/**
 	 * Instance constructor
 	 *
-	 * @param		array		$args		Instantiation data
+	 * @param   array  $args  Instantiation data
+	 * @return  void
 	 */
 	public function __construct($args)
 	{
@@ -61,10 +62,10 @@ class Bundle
 		$this->publication_version_id  = $args['publication_version_id'];
 	}
 
-	/*
+	/**
 	 * Gets size of corresponding bundle in bytes
 	 *
-	 * @return   integer
+	 * @return  integer
 	 */
 	public function getSize()
 	{
@@ -79,10 +80,10 @@ class Bundle
 		return $size;
 	}
 
-	/*
+	/**
 	 * Gets checksum of corresponding bundle
 	 *
-	 * @return   string
+	 * @return  string
 	 */
 	public function getMd5()
 	{
@@ -97,10 +98,10 @@ class Bundle
 		return $checksum;
 	}
 
-	/*
+	/**
 	 * Builds a hierarchical array of bundle's contents
 	 *
-	 * @return   array
+	 * @return  array
 	 */
 	public function getContents()
 	{
@@ -114,10 +115,10 @@ class Bundle
 		return $this->contents;
 	}
 
-	/*
+	/**
 	 * Getter for path to bundle
 	 *
-	 * @return   string
+	 * @return  string
 	 */
 	protected function getWrapperPath()
 	{
@@ -126,11 +127,11 @@ class Bundle
 		return $path;
 	}
 
-	/*
+	/**
 	 * Replace bundle element w/ hierarchical array of contents
 	 *
-	 * @param    array   $contents
-	 * @return   void
+	 * @param   array   $contents
+	 * @return  void
 	 */
 	protected function expandBundleFile(&$contents)
 	{
@@ -143,14 +144,17 @@ class Bundle
 		$bundleContents['contents'] = ZipHelper::getArchiveContents($bundlePath);
 
 		unset($contents[$bundleIndex]);
-		$contents['bundle'] = $bundleContents;
+		if ($bundleContents['contents'])
+		{
+			$contents['bundle'] = $bundleContents;
+		}
 	}
 
-	/*
+	/**
 	 * Gets index of bundle element
 	 *
-	 * @param    array     $contents
-	 * @return   integer
+	 * @param   array     $contents
+	 * @return  integer
 	 */
 	protected static function getBundleIndex($contents)
 	{
@@ -168,10 +172,10 @@ class Bundle
 		return $bundleIndex;
 	}
 
-	/*
+	/**
 	 * Builds path to bundle.zip archive
 	 *
-	 * @return   string
+	 * @return  string
 	 */
 	protected function getBundlePath()
 	{
@@ -184,10 +188,10 @@ class Bundle
 		return $bundlePath;
 	}
 
-	/*
+	/**
 	 * Getter for associated publication
 	 *
-	 * @return \Publication
+	 * @return  object  \Publication
 	 */
 	public function publication()
 	{
@@ -198,5 +202,4 @@ class Bundle
 
 		return $this->publication;
 	}
-
 }

--- a/core/components/com_publications/models/curation.php
+++ b/core/components/com_publications/models/curation.php
@@ -2033,7 +2033,29 @@ class Curation extends Obj
 
 		// Get attachment type model
 		$attModel = new Attachments($this->_db);
-		$contents = '<ul class="filelist">';
+
+		$bundle = $this->_pub->bundlePath();
+
+		$contents = '<div class="bundle-data">';
+		if (file_exists($bundle))
+		{
+			$contents .= '<div class="grid bundle-meta">
+				<div class="col span4">
+					<ul class="bundle-info">
+						<li>' . Lang::txt('COM_PUBLICATIONS_BUNDLE_CONTENT') . '</li>
+						<li><span class="bundle-size">' . \Hubzero\Utility\Number::formatBytes(filesize($bundle)) . '</span></li>
+					</ul>
+				</div>
+				<div class="col span8 omega">
+					<div class="bundle-checksum">
+						<span class="bundle-checksum-value">md5:' . md5_file($bundle) . '</span>
+						<span class="bundle-checksum-help icon-help tooltips" title="' . Lang::txt('COM_PUBLICATIONS_BUNDLE_CHECKSUM') . '">' . Lang::txt('COM_PUBLICATIONS_BUNDLE_CHECKSUM') . '</span>
+					</div>
+				</div>
+			</div>';
+		}
+		$contents .= '<div class="bundle-files">';
+		$contents .= '<ul class="filelist">';
 
 		$contents .= $attModel->showPackagedItems(
 			$elements,
@@ -2043,10 +2065,18 @@ class Curation extends Obj
 		// Custom license to be included in LICENSE.txt
 		if ($this->_pub->license_text)
 		{
-			$contents .= '<li>' . \Components\Projects\Models\File::drawIcon('txt') . ' LICENSE.txt</li>';
+			$contents .= '<li>';
+			$contents .= '<span class="item-icon">' . \Components\Projects\Models\File::drawIcon('txt') . '</span>';
+			$contents .= '<span class="item-title">LICENSE.txt</span>';
+			$contents .= '</li>';
 		}
-		$contents .= '<li>' . \Components\Projects\Models\File::drawIcon('txt') . ' README.txt</li>';
+		$contents .= '<li>';
+		$contents .= '<span class="item-icon">' . \Components\Projects\Models\File::drawIcon('txt') . '</span>';
+		$contents .= '<span class="item-title">README.txt</span>';
+		$contents .= '</li>';
 		$contents .= '</ul>';
+
+		$contents .= '</div></div>';
 
 		return $contents;
 	}

--- a/core/components/com_publications/site/assets/css/filelist.css
+++ b/core/components/com_publications/site/assets/css/filelist.css
@@ -5,31 +5,180 @@
  * @license     http://opensource.org/licenses/MIT MIT
  */
 
+.bundle-meta {
+	margin: 0;
+	padding: 0.5em 1em;
+	background: #f5f5f5;
+	border: 1px solid #CCC;
+	border-bottom: none;
+	list-style: none;
+	line-height: 1;
+}
+.bundle-meta ul {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+.bundle-meta li {
+	border-left: 1px solid #ccc;
+	padding: 0 0.5em 0 0.7em;
+	display: inline-block;
+}
+.bundle-meta li:first-child {
+	border-left: none;
+	padding-left: 0;
+}
+.bundle-checksum {
+	text-align: right;
+	padding: 0.5em 0;
+}
+.bundle-files {
+	background-color: #fff;
+	border: 1px solid #e7e7e7;
+}
+
 .filelist {
-	margin: 2em;
+	margin: 0;
+	padding: 0;
 	list-style: none;
 }
 .filelist img {
 	margin-right: 0.5em;
 	display: inline-block;
-	position: relative;
-	vertical-align: top;
-	margin-top: 0.2em;
 }
-.filelist span.item-details {
-	display: block;
-	margin-left: 0;
+.filelist .item-details {
 	color: #999;
-	font-size: 0.8em;
-	padding-right: 3em;
-	padding-left: 2.5em;
+	float: right;
 }
 .filelist li {
-	vertical-align: top;
-	line-height: 1.2em;
-	border-bottom: 1px solid #EfEfEf;
-	min-height: 32px;
+	padding: 1em 1em;
+	margin: 0;
+	border-bottom: 1px solid #f1f1f1;
+	line-height: 1;
+	clear: right;
+}
+.filelist li:hover {
+	background: #fffaec;
 }
 .filelist li.level2 {
 	padding-left: 2.5em;
 }
+
+.bundle-checksum-help {
+	width: 1em;
+	height: 1em;
+	display: inline-block;
+	cursor: pointer;
+	white-space: nowrap;
+	overflow: hidden;
+	line-height: 1;
+	cursor: default;
+	font-size: 1.2em;
+}
+.bundle-checksum-help:before {
+	margin-right: 2em;
+	margin-left: 0.2em;
+}
+
+/*
+.item-icon {
+	width: 1em;
+	height: 1em;
+	display: inline-block;
+	cursor: pointer;
+	color: #333;
+	white-space: nowrap;
+	overflow: hidden;
+	line-height: 1;
+	cursor: default;
+	margin-right: 0.4em;
+}
+.item-extension {
+	width: 1em;
+	height: 1em;
+	font-size: 1.2em;
+	display: inline-block;
+}
+.item-extension:before {
+	line-height: 1;
+	content: '\f0f5';
+	font-family: 'Fontcons';
+	color: rgba(0, 0, 0, 0.4);
+}
+._drive:before {
+	content: '\f0a0';
+	color: #333;
+}
+._dir:before {
+	content: '\f114';
+	color: orange;
+}
+._pdf:before,
+._rtf:before,
+._txt:before {
+	content: '\f0f6';
+}
+._js:before,
+._css:before,
+._xml:before,
+._html:before,
+._htm:before,
+._py:before,
+._rb:before,
+._cc:before,
+._php:before {
+	content: '\f07e';
+}
+._keynote:before,
+._ppt:before,
+._pps:before,
+._pptx:before {
+	content: "\f000";
+}
+._pages:before,
+._doc:before,
+._docx:before {
+	content: '\f0f5';
+}
+._xsl:before,
+._csv:before,
+._xslx:before {
+	content: '\f0ce';
+}
+._mpg:before,
+._mpeg:before,
+._mov:before,
+._wmv:before,
+._asf:before,
+._asx:before,
+._ra:before,
+._rm:before,
+._avi:before,
+._qt:before,
+._mp4:before,
+._m4v:before {
+	content: '\f008';
+}
+._mp3:before,
+._aiff:before,
+._wav:before,
+._m4a:before {
+	content: '\266B';
+}
+._tar:before,
+._zip:before,
+._gz:before {
+	content: '\f005';
+}
+._gif:before,
+._png:before,
+._bmp:before,
+._tif:before,
+._tiff:before,
+._jpg:before,
+._jpe:before,
+._jpeg:before {
+	content: '\f03e';
+	color: #337ab7;
+}
+*/

--- a/core/components/com_publications/site/assets/css/publications.css
+++ b/core/components/com_publications/site/assets/css/publications.css
@@ -311,7 +311,7 @@
 	p.wip {
 		font-size: 85%;
 		color: #333333;
-		margin-top: -1em;
+		/*margin-top: -1em;*/
 	}
 	p.devversion span {
 		display: block;
@@ -547,9 +547,15 @@
 		width: 60%;
 		float: left;
 	}
-	#primary-document .btn {
+	#primary-document {
 		width: 100%;
 		text-align: left;
+	}
+	#primary-document .btn:first-child {
+		width: calc(100% - (1.5em + 8px));
+	}
+	#primary-document .dropdown-menu {
+		width: 100%;
 	}
 	#primary-document_pop {
 		display: none;

--- a/core/components/com_publications/site/assets/js/publications.js
+++ b/core/components/com_publications/site/assets/js/publications.js
@@ -17,7 +17,16 @@ jQuery(document).ready(function($){
 		width: 800,
 		height: 'auto',
 		autoSize: false,
-		fitToView: false
+		fitToView: false,
+		beforeLoad: function() {
+			href = $(this).attr('href');
+			if (href.indexOf('?') == -1) {
+				href += '?';
+			} else {
+				href += '&';
+			}
+			$(this).attr('href', href + 'tmpl=component');
+		}
 	});
 
 	$('a.play').fancybox({

--- a/core/components/com_publications/site/language/en-GB/en-GB.com_publications.ini
+++ b/core/components/com_publications/site/language/en-GB/en-GB.com_publications.ini
@@ -173,6 +173,8 @@ COM_PUBLICATIONS_BROWSE_PUBLICATIONS="Browse publications"
 COM_PUBLICATIONS_NO_RELEVANT_PUBS_FOUND="No publications found."
 COM_PUBLICATIONS_BROWSE_ALL="Browse all available publications"
 COM_PUBLICATIONS_DOWNLOAD_BUNDLE="Download publication bundle"
+COM_PUBLICATIONS_BUNDLE_CHECKSUM="This is the file fingerprint (MD5 checksum), which can be used to verify the file integrity."
+COM_PUBLICATIONS_BUNDLE_CONTENT="Contents"
 
 ; Contribute
 COM_PUBLICATIONS_ADD_NEW_PUB="Submit a new publication"

--- a/core/components/com_publications/site/views/about/tmpl/_bundle_directory.php
+++ b/core/components/com_publications/site/views/about/tmpl/_bundle_directory.php
@@ -33,19 +33,20 @@
 // No direct access
 defined('_HZEXEC_') or die();
 
-use Hubzero\Utility\Number;
-
 $directory = $this->directory;
-
 ?>
-
 <li>
-	<span class="directory">&#xf07b;</span> <?php echo $directory['name']; ?>
-	<ul style="list-style:none">
-		<?php
-			$this->view('_bundle_contents')
-				->set('contents', $directory['contents'])
-				->display();
-		?>
-	</ul>
+	<span class="item-icon">
+		<span class="item-extension _<?php echo (Filesystem::extension($directory['name']) == 'zip' ? 'zip' : 'dir'); ?>"></span>
+	</span>
+	<span class="item-title"><?php echo $this->escape($directory['name']); ?></span>
+	<?php if (isset($directory['contents']) && $directory['contents']): ?>
+		<ul>
+			<?php
+				$this->view('_bundle_contents')
+					->set('contents', $directory['contents'])
+					->display();
+			?>
+		</ul>
+	<?php endif; ?>
 </li>

--- a/core/components/com_publications/site/views/about/tmpl/_bundle_file.php
+++ b/core/components/com_publications/site/views/about/tmpl/_bundle_file.php
@@ -33,14 +33,12 @@
 // No direct access
 defined('_HZEXEC_') or die();
 
-use Hubzero\Utility\Number;
-
 $file = $this->file;
-
 ?>
-
 <li>
-	<span class="file">&#xf016;</span> <?php echo $file['name']; ?>
-	(<?php echo Number::formatBytes($file['size']); ?>)
+	<span class="item-icon">
+		<span class="item-extension _<?php echo $this->escape(strtolower(Filesystem::extension($file['name']))); ?>"></span>
+	</span>
+	<span class="item-title"><?php echo $this->escape($file['name']); ?></span>
+	<span class="item-details"><?php echo trim(Hubzero\Utility\Number::formatBytes($file['size'])); ?></span>
 </li>
-

--- a/core/components/com_publications/site/views/about/tmpl/_bundle_metadata.php
+++ b/core/components/com_publications/site/views/about/tmpl/_bundle_metadata.php
@@ -33,15 +33,24 @@
 // No direct access
 defined('_HZEXEC_') or die();
 
-use Hubzero\Utility\Number;
-
 ?>
-
-<div>
-	<p><b>Checksum</b>: <?php echo $this->bundle->getMd5(); ?></p>
-	<div>
-		<b>Contents</b> (<?php echo Number::formatBytes($this->bundle->getSize()); ?>):
-		<ul style="list-style:none;margin:0">
+<div class="grid bundle-data">
+	<div class="grid bundle-meta">
+		<div class="col span4">
+			<ul class="bundle-info">
+				<li><?php echo Lang::txt('COM_PUBLICATIONS_BUNDLE_CONTENT'); ?></li>
+				<li><span class="bundle-size"><?php echo Hubzero\Utility\Number::formatBytes($this->bundle->getSize()); ?></span></li>
+			</ul>
+		</div>
+		<div class="col span8 omega">
+			<div class="bundle-checksum">
+				<span class="bundle-checksum-value">md5:<?php echo $this->bundle->getMd5(); ?></span>
+				<span class="bundle-checksum-help icon-help tooltips" title="<?php echo Lang::txt('COM_PUBLICATIONS_BUNDLE_CHECKSUM'); ?>"><?php echo Lang::txt('COM_PUBLICATIONS_BUNDLE_CHECKSUM'); ?></span>
+			</div>
+		</div>
+	</div>
+	<div class="bundle-files">
+		<ul class="filelist">
 			<?php
 				$this->view('_bundle_contents')
 					->set('contents', $this->bundle->getContents())
@@ -50,9 +59,3 @@ use Hubzero\Utility\Number;
 		</ul>
 	</div>
 </div>
-
-<style>
-.directory, .file {
-	font-family: 'Fontcons';
-}
-</style>

--- a/core/components/com_publications/site/views/about/tmpl/default.php
+++ b/core/components/com_publications/site/views/about/tmpl/default.php
@@ -270,7 +270,9 @@ if (($this->publication->params->get('show_notes')) && $this->publication->get('
 </div><!-- / .pubabout -->
 
 <?php
+	/* Temporarily removing this from the main view in favor of an overlay
+	$this->css('filelist.css');
 	$this->view('_bundle_metadata')
 		->set('bundle', $this->bundle)
-		->display();
-?>
+		->display();*/
+

--- a/core/components/com_publications/site/views/view/tmpl/_primary.php
+++ b/core/components/com_publications/site/views/view/tmpl/_primary.php
@@ -32,22 +32,40 @@
 // No direct access
 defined('_HZEXEC_') or die();
 
-if ($this->disabled) { ?>
+if ($this->disabled): ?>
 	<p id="primary-document">
 		<span class="btn disabled <?php echo $this->class; ?>"><?php echo $this->msg; ?></span>
 	</p>
-<?php } else { ?>
-	<p id="primary-document">
-		<a class="btn btn-primary<?php echo ($this->class)  ? ' ' . $this->class : ''; ?>" <?php
-				echo ($this->href)   ? ' href="' . $this->href . '"' : '';
-				echo ($this->title)  ? ' title="' . $this->escape($this->title) . '"' : '';
-				echo ($this->action) ? ' ' . $this->action : '';
-			?>><?php echo $this->msg; ?></a>
-	</p>
-<?php } ?>
+<?php else: ?>
+	<?php if (isset($this->options) && !empty($this->options)): ?>
+		<div class="btn-group btn-primary" id="primary-document">
+			<a class="btn <?php echo ($this->class)  ? ' ' . $this->class : ''; ?>" <?php
+					echo ($this->href)   ? ' href="' . $this->href . '"' : '';
+					echo ($this->title)  ? ' title="' . $this->escape($this->title) . '"' : '';
+					echo ($this->action) ? ' ' . $this->action : '';
+				?>><?php echo $this->msg; ?></a>
+			<span class="btn dropdown-toggle"></span>
+			<ul class="dropdown-menu">
+				<?php foreach ($this->options as $option): ?>
+					<li>
+						<a <?php echo ($option->class ? 'class="' . $option->class . '"' : ''); ?> <?php echo (isset($option->attrs) ? $option->attrs : ''); ?> href="<?php echo $option->href; ?>"><?php echo $option->title; ?></a>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+	<?php else: ?>
+		<p id="primary-document">
+			<a class="btn btn-primary<?php echo ($this->class)  ? ' ' . $this->class : ''; ?>" <?php
+					echo ($this->href)   ? ' href="' . $this->href . '"' : '';
+					echo ($this->title)  ? ' title="' . $this->escape($this->title) . '"' : '';
+					echo ($this->action) ? ' ' . $this->action : '';
+				?>><?php echo $this->msg; ?></a>
+		</p>
+	<?php endif; ?>
+<?php endif; ?>
 
-<?php if ($this->pop) { ?>
+<?php if ($this->pop): ?>
 	<div id="primary-document_pop">
 		<div><?php echo $this->pop; ?></div>
 	</div>
-<?php } ?>
+<?php endif; ?>

--- a/core/templates/kimera/html/com_publications/publications.css
+++ b/core/templates/kimera/html/com_publications/publications.css
@@ -40,7 +40,7 @@
 		color: #666;
 	}
 	.com_publications #content-header .span8 a,
-	.com_publications #content-header .span4 a,
+	.com_publications #content-header .span4 p a,
 	.com_publications #content-header .aside a {
 		color: #fff;
 	}
@@ -326,7 +326,7 @@
 	p.wip {
 		font-size: 85%;
 		color: #333333;
-		margin-top: -1em;
+		/*margin-top: -1em;*/
 	}
 	p.devversion span {
 		display: block;
@@ -557,9 +557,15 @@
 		padding: 2em;
 	}
 
-	#primary-document .btn {
+	#primary-document {
 		width: 100%;
 		text-align: left;
+	}
+	#primary-document .btn:first-child {
+		width: calc(100% - (1.5em + 8px));
+	}
+	#primary-document .dropdown-menu {
+		width: 100%;
 	}
 	#primary-document_pop {
 		display: none;


### PR DESCRIPTION
This adds a dropdown menu to the main bundle download button. The menu
cotnains a link to display the contents of the bundle, which laucnhes
a modal window and lists the files and directories included in the
bundle and the checksum hash.