### PR TITLE
[fix] Don't list blocked users as assignees

### DIFF
--- a/core/components/com_support/site/controllers/tickets.php
+++ b/core/components/com_support/site/controllers/tickets.php
@@ -2741,7 +2741,7 @@ class Tickets extends SiteController
 						foreach ($members as $member)
 						{
 							$u = User::getInstance($member);
-							if (!is_object($u))
+							if (!(is_object($u) && $u->get('block') == 0))
 							{
 								continue;
 							}
@@ -2769,7 +2769,7 @@ class Tickets extends SiteController
 				foreach ($members as $member)
 				{
 					$u = User::getInstance($member);
-					if (!is_object($u))
+					if (!(is_object($u) && $u->get('block') == 0))
 					{
 						continue;
 					}


### PR DESCRIPTION
Previous code would list blocked users as a potential assignee of a
ticket