### PR TITLE
[fix] Only pull the latest version instead of all

### DIFF
--- a/core/components/com_groups/models/page.php
+++ b/core/components/com_groups/models/page.php
@@ -114,17 +114,20 @@ class Page extends Model
 	/**
 	 * Get Page Versions
 	 *
+	 * @param   array   $opt
 	 * @return  object  \Hubzero\Base\ItemList
 	 */
-	public function versions()
+	public function versions($opt = array())
 	{
 		if (!isset($this->_versions))
 		{
-			$pageVersionArchive = new Page\Version\Archive();
-			$this->_versions = $pageVersionArchive->versions('list', array(
+			$options = array_merge(array(
 				'pageid'  => $this->get('id', -1),
 				'orderby' => 'version DESC',
-			));
+			), $opt);
+
+			$pageVersionArchive = new Page\Version\Archive();
+			$this->_versions = $pageVersionArchive->versions('list', $options);
 		}
 		return $this->_versions;
 	}

--- a/core/components/com_groups/site/views/pages/tmpl/list.php
+++ b/core/components/com_groups/site/views/pages/tmpl/list.php
@@ -49,7 +49,7 @@ if ($this->level == 0)
 			<?php
 				// get page details
 				$category = $this->categories->fetch('id', $page->get('category'));
-				$version  = $page->versions()->first();
+				$version  = $page->versions(array('limit' => 1))->first();
 
 				// page class
 				$cls = '';


### PR DESCRIPTION
The code would pull all versions for a page when only the latest was
needed. This could cause serious memory issues for a gorup that has
many pages, many versions of a page, or both.

Fixes: https://nanohub.org/support/ticket/329866