### PR TITLE
[feat] Event call and plugins for OG & Twitter

### DIFF
--- a/core/components/com_blog/site/controllers/entries.php
+++ b/core/components/com_blog/site/controllers/entries.php
@@ -189,6 +189,8 @@ class Entries extends SiteController
 			Event::trigger('content.onAfterContentSubmission', array('Blog'));
 		}
 
+		Event::trigger('blog.onBlogView', array($row));
+
 		// Output HTML
 		$this->view
 			->set('archive', $this->model)

--- a/core/plugins/blog/opengraph/language/en-GB/en-GB.plg_blog_opengraph.ini
+++ b/core/plugins/blog/opengraph/language/en-GB/en-GB.plg_blog_opengraph.ini
@@ -1,0 +1,9 @@
+; @package      hubzero-cms
+; @file         language/en-GB/en-GB.plg_blog_opengraph.ini
+; @copyright    Copyright 2005-2015 HUBzero Foundation, LLC.
+; @license      http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_BLOG_OPENGRAPH="Blog - (metadata) Open Graph"
+PLG_BLOG_OPENGRAPH_XML_DESCRIPTION="Add metadata for Open Graph to the document"

--- a/core/plugins/blog/opengraph/language/en-GB/en-GB.plg_blog_opengraph.sys.ini
+++ b/core/plugins/blog/opengraph/language/en-GB/en-GB.plg_blog_opengraph.sys.ini
@@ -1,0 +1,9 @@
+; @package      hubzero-cms
+; @file         language/en-GB/en-GB.plg_blog_opengraph.sys.ini
+; @copyright    Copyright 2005-2015 HUBzero Foundation, LLC.
+; @license      http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_BLOG_OPENGRAPH="Blog - (metadata) Open Graph"
+PLG_BLOG_OPENGRAPH_XML_DESCRIPTION="Add metadata for Open Graph to the document"

--- a/core/plugins/blog/opengraph/migrations/Migration20180721000000PlgBlogOpengraph.php
+++ b/core/plugins/blog/opengraph/migrations/Migration20180721000000PlgBlogOpengraph.php
@@ -1,0 +1,28 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding Blog - Opengraph plugin
+ **/
+class Migration20180721000000PlgBlogOpengraph extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$this->addPluginEntry('blog', 'opengraph');
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$this->deletePluginEntry('blog', 'opengraph');
+	}
+}

--- a/core/plugins/blog/opengraph/opengraph.php
+++ b/core/plugins/blog/opengraph/opengraph.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * HUBzero CMS
+ *
+ * Copyright 2005-2015 HUBzero Foundation, LLC.
+ *
+ * This file is part of: The HUBzero(R) Platform for Scientific Collaboration
+ *
+ * The HUBzero(R) Platform for Scientific Collaboration (HUBzero) is free
+ * software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * HUBzero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * HUBzero is a registered trademark of Purdue University.
+ *
+ * @package   hubzero-cms
+ * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
+ * @license   http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Blog Plugin class for adding Open Graph metadata to the document
+ */
+class plgBlogOpengraph extends \Hubzero\Plugin\Plugin
+{
+	/**
+	 * Return data on a resource view (this will be some form of HTML)
+	 *
+	 * @param   object  $model   Current model
+	 * @return  void
+	 */
+	public function onBlogView($model)
+	{
+		if (!App::isSite())
+		{
+			return;
+		}
+
+		if (Request::getWord('tmpl') || Request::getWord('format') || Request::getInt('no_html'))
+		{
+			return;
+		}
+
+		$view = $this->view();
+
+		Document::addCustomTag('<meta property="og:title" content="' . $view->escape(Hubzero\Utility\Str::truncate(strip_tags($model->title), 40)) . '" />');
+
+		$content = Hubzero\Utility\Str::truncate(strip_tags($model->content), 300);
+		$content = str_replace(array("\n", "\t", "\r"), ' ', $content);
+		$content = trim($content);
+
+		Document::addCustomTag('<meta property="og:description" content="' . $view->escape($content) . '" />');
+
+		Document::addCustomTag('<meta property="og:type" content="article" />');
+
+		$url = Route::url($model->link());
+		$url = rtrim(Request::root(), '/') . '/' . trim($url, '/');
+
+		Document::addCustomTag('<meta property="og:url" content="' . $url . '" />');
+	}
+}

--- a/core/plugins/blog/opengraph/opengraph.xml
+++ b/core/plugins/blog/opengraph/opengraph.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+@package        hubzero-cms
+@file           plugins/blog/opengraph/opengraph.xml
+@copyright      Copyright 2005-2015 HUBzero Foundation, LLC.
+@license        http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+Copyright 2005-2015 HUBzero Foundation, LLC.
+
+This file is part of: The HUBzero(R) Platform for Scientific Collaboration
+
+The HUBzero(R) Platform for Scientific Collaboration (HUBzero) is free
+software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+HUBzero is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+HUBzero is a registered trademark of Purdue University.
+-->
+
+<extension version="1.7" type="plugin" group="blog">
+	<name>plg_blog_opengraph</name>
+	<author>HUBzero</author>
+	<copyright>Copyright 2005-2015 HUBzero Foundation, LLC.</copyright>
+	<license>http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3</license>
+	<description>PLG_BLOG_OPENGRAPH_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="opengraph">opengraph.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_blog_opengraph.ini</language>
+	</languages>
+</extension>

--- a/core/plugins/blog/twitter/language/en-GB/en-GB.plg_blog_twitter.ini
+++ b/core/plugins/blog/twitter/language/en-GB/en-GB.plg_blog_twitter.ini
@@ -1,0 +1,11 @@
+; @package      hubzero-cms
+; @file         language/en-GB/en-GB.plg_blog_twitter.ini
+; @copyright    Copyright 2005-2015 HUBzero Foundation, LLC.
+; @license      http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_BLOG_TWITTER="Blog - (metadata) Twitter"
+PLG_BLOG_TWITTER_XML_DESCRIPTION="Add metadata for Twitter to the document"
+PLG_BLOG_TWITTER_PARAM_USERNAME_LABEL="Twitter Username"
+PLG_BLOG_TWITTER_PARAM_USERNAME_DESC="Provide the Twitter username that content should be associated with."

--- a/core/plugins/blog/twitter/language/en-GB/en-GB.plg_blog_twitter.sys.ini
+++ b/core/plugins/blog/twitter/language/en-GB/en-GB.plg_blog_twitter.sys.ini
@@ -1,0 +1,9 @@
+; @package      hubzero-cms
+; @file         language/en-GB/en-GB.plg_blog_twitter.sys.ini
+; @copyright    Copyright 2005-2015 HUBzero Foundation, LLC.
+; @license      http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_BLOG_TWITTER="Blog - (metadata) Twitter"
+PLG_BLOG_TWITTER_XML_DESCRIPTION="Add metadata for Twitter to the document"

--- a/core/plugins/blog/twitter/migrations/Migration20180722000000PlgBlogTwitter.php
+++ b/core/plugins/blog/twitter/migrations/Migration20180722000000PlgBlogTwitter.php
@@ -1,0 +1,28 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding Blog - Twitter plugin
+ **/
+class Migration20180722000000PlgBlogTwitter extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$this->addPluginEntry('blog', 'twitter');
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$this->deletePluginEntry('blog', 'twitter');
+	}
+}

--- a/core/plugins/blog/twitter/twitter.php
+++ b/core/plugins/blog/twitter/twitter.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * HUBzero CMS
+ *
+ * Copyright 2005-2015 HUBzero Foundation, LLC.
+ *
+ * This file is part of: The HUBzero(R) Platform for Scientific Collaboration
+ *
+ * The HUBzero(R) Platform for Scientific Collaboration (HUBzero) is free
+ * software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * HUBzero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * HUBzero is a registered trademark of Purdue University.
+ *
+ * @package   hubzero-cms
+ * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
+ * @license   http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Resources Plugin class for adding Twitter metadata to the document
+ */
+class plgBlogTwitter extends \Hubzero\Plugin\Plugin
+{
+	/**
+	 * Return data on a resource view (this will be some form of HTML)
+	 *
+	 * @param   object  $model   Current model
+	 * @return  void
+	 */
+	public function onBlogView($model)
+	{
+		if (!App::isSite())
+		{
+			return;
+		}
+
+		if (Request::getWord('tmpl') || Request::getWord('format') || Request::getInt('no_html'))
+		{
+			return;
+		}
+
+		$user = $this->params->get('twitter_username');
+
+		if (!$user)
+		{
+			return;
+		}
+
+		$view = $this->view();
+
+		Document::addCustomTag('<meta property="twitter:card" content="summary" />');
+
+		Document::addCustomTag('<meta property="twitter:site" content="@' . $view->escape($user) . '" />');
+
+		Document::addCustomTag('<meta property="twitter:title" content="' . $view->escape(Hubzero\Utility\Str::truncate(strip_tags($model->title), 40)) . '" />');
+
+		$content = Hubzero\Utility\Str::truncate(strip_tags($model->content), 140);
+		$content = str_replace(array("\n", "\t", "\r"), ' ', $content);
+		$content = trim($content);
+
+		Document::addCustomTag('<meta property="twitter:description" content="' . $view->escape($content) . '" />');
+
+		$url = Route::url($model->link());
+		$url = rtrim(Request::root(), '/') . '/' . trim($url, '/');
+
+		Document::addCustomTag('<meta property="twitter:url" content="' . $url . '" />');
+	}
+}

--- a/core/plugins/blog/twitter/twitter.xml
+++ b/core/plugins/blog/twitter/twitter.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+@package        hubzero-cms
+@file           plugins/blog/twitter/twitter.xml
+@copyright      Copyright 2005-2015 HUBzero Foundation, LLC.
+@license        http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+Copyright 2005-2015 HUBzero Foundation, LLC.
+
+This file is part of: The HUBzero(R) Platform for Scientific Collaboration
+
+The HUBzero(R) Platform for Scientific Collaboration (HUBzero) is free
+software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+HUBzero is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+HUBzero is a registered trademark of Purdue University.
+-->
+
+<extension version="1.7" type="plugin" group="blog">
+	<name>plg_blog_twitter</name>
+	<author>HUBzero</author>
+	<copyright>Copyright 2005-2015 HUBzero Foundation, LLC.</copyright>
+	<license>http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3</license>
+	<description>PLG_BLOG_TWITTER_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="twitter">twitter.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_blog_twitter.ini</language>
+	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field name="twitter_username" type="text" menu="hide" default="" label="PLG_BLOG_TWITTER_PARAM_USERNAME_LABEL" description="PLG_BLOG_TWITTER_PARAM_USERNAME_DESC" />
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/core/plugins/groups/blog/blog.php
+++ b/core/plugins/groups/blog/blog.php
@@ -639,6 +639,8 @@ class plgGroupsBlog extends \Hubzero\Plugin\Plugin
 			$filters['authorized'] = false;
 		}
 
+		Event::trigger('blog.onBlogView', array($row));
+
 		$view = $this->view('default', 'entry')
 			->set('option', $this->option)
 			->set('group', $this->group)

--- a/core/plugins/members/blog/blog.php
+++ b/core/plugins/members/blog/blog.php
@@ -489,6 +489,8 @@ class plgMembersBlog extends \Hubzero\Plugin\Plugin
 			$filters['access'] = User::getAuthorisedViewLevels();
 		}
 
+		Event::trigger('blog.onBlogView', array($row));
+
 		$view = $this->view('default', 'entry')
 			->set('option', $this->option)
 			->set('member', $this->member)


### PR DESCRIPTION
This adds an `onBlogView` event for when viewing an article and two
plugins that respond to said event. Each plugin pushes meta tags to the
document to aid in search (open graph) and Twitter.

Refs: https://cdmhub.org/support/ticket/1578