### PR TITLE
[fix] Allow group pages to share the same alias

### DIFF
--- a/core/components/com_groups/helpers/pages.php
+++ b/core/components/com_groups/helpers/pages.php
@@ -226,27 +226,22 @@ class Pages
 		}
 
 		// loop through each segment to to get right page
-		foreach ($segments as $k => $segment)
+		// make sure a page was found
+		$urlString = ltrim(implode('/', $segments), '/');
+		foreach ($pages as $p)
 		{
-			// make sure a page was found
-			foreach ($pages as $p)
+			if (ltrim($p->url(false), '/') == $urlString)
 			{
-				if ($p->get('alias') == $segment
-					&& $p->get('depth') == ($k + 1))
-				{
-					$page = $p;
-				}
+				$page = $p;
+				break;
 			}
+		}
 
-			// make sure we have page
-			// make sure page is child of parent
-			if (!$page || $page->get('parent') != $prevPage->get('id'))
-			{
-				return null;
-			}
-
-			// hold on to the page
-			$prevPage = $page;
+		// make sure we have page
+		// make sure page is child of parent
+		if (!$page)
+		{
+			return null;
 		}
 
 		// return page object

--- a/core/components/com_groups/models/page.php
+++ b/core/components/com_groups/models/page.php
@@ -232,27 +232,35 @@ class Page extends Model
 		{
 			$alias .= '_page';
 		}
-
 		// get current page as it exists in db
 		$page = new Page( $this->get('id') );
-		$currentAlias = $page->get('alias');
+		$page->set('gidNumber', $group->get('gidNumber'));
+		$currentUrl = $page->url();
 
 		// only against our pages if alias has changed
-		if ($currentAlias != $alias)
+		if ($currentUrl != $this->url())
 		{
 			// make sure we dont already have a page with the same alias
 			// get group pages
 			$pageArchive = Page\Archive::getInstance();
-			$aliases = $pageArchive->pages('alias', array(
+			$aliases = $pageArchive->pages('list', array(
 				'gidNumber' => $group->get('gidNumber'),
 				'state'     => array(0,1),
 				'depth'     => $this->get('depth')
 			));
 
+			$aliasUrls = array();
+			foreach ($aliases as $aliasObj)
+			{
+				$aliasUrls[] = $aliasObj->url();
+			}
+
 			// Append random number if page already exists
-			while (in_array($alias, $aliases))
+			while (in_array($this->url(), $aliasUrls))
 			{
 				$alias .= mt_rand(1, 9);
+				$this->set('alias', $alias);
+				$pageUrl = $page->url();
 			}
 		}
 


### PR DESCRIPTION
Group pages can now have the same alias, as long as they have a different
parent element.

refs: https://qubeshub.org/support/ticket/1224