### PR TITLE
[feat] Allow passing array of values to form

### DIFF
--- a/core/components/com_groups/site/controllers/membership.php
+++ b/core/components/com_groups/site/controllers/membership.php
@@ -144,7 +144,7 @@ class Membership extends Base
 		{
 			if (strpos($invite, '@'))
 			{
-				if (!\Components\Members\Helpers\Utility::validemail($invite))
+				if (!\Hubzero\Utility\Validate::email($invite))
 				{
 					unset($invites[$i]);
 				}

--- a/core/components/com_groups/site/controllers/membership.php
+++ b/core/components/com_groups/site/controllers/membership.php
@@ -138,6 +138,29 @@ class Membership extends Base
 			return;
 		}
 
+		$invites = Request::getArray('to', array());
+
+		foreach ($invites as $i => $invite)
+		{
+			if (strpos($invite, '@'))
+			{
+				if (!\Components\Members\Helpers\Utility::validemail($invite))
+				{
+					unset($invites[$i]);
+				}
+			}
+			else
+			{
+				$profile = User::getInstance($invite);
+				if (!$profile->get('id'))
+				{
+					unset($invites[$i]);
+				}
+			}
+		}
+
+		$this->view->invites = $invites;
+
 		// get view notifications
 		$this->view->notifications = ($this->getNotifications()) ? $this->getNotifications() : array();
 

--- a/core/components/com_groups/site/views/membership/tmpl/invite.php
+++ b/core/components/com_groups/site/views/membership/tmpl/invite.php
@@ -72,11 +72,11 @@ $this->css();
 				<label>
 					<?php echo Lang::txt('COM_GROUPS_INVITE_LOGINS'); ?> <span class="required"><?php echo Lang::txt('COM_GROUPS_REQUIRED'); ?></span>
 					<?php
-						$mc = Event::trigger('hubzero.onGetMultiEntry', array(array('members', 'logins', 'acmembers')));
+						$mc = Event::trigger('hubzero.onGetMultiEntry', array(array('members', 'logins', 'acmembers', '', implode(', ', $this->invites))));
 						if (count($mc) > 0) {
 							echo $mc[0];
 						} else { ?>
-							<input type="text" name="logins" id="acmembers" value="" size="35" />
+							<input type="text" name="logins" id="acmembers" value="<?php echo $this->escape(implode(', ', $this->invites)); ?>" size="35" />
 						<?php } ?>
 					<span class="hint"><?php echo Lang::txt('COM_GROUPS_INVITE_LOGINS_HINT'); ?></span>
 				</label>


### PR DESCRIPTION
This allows for passing a list of usernames or email addresses to
pre-populate the "to" field for the group invitation form. Each "to"
passed is validated before being passed to the form.