### PR TITLE
[fix] Don't pass values as querystring

### DIFF
--- a/core/components/com_members/site/assets/js/register.js
+++ b/core/components/com_members/site/assets/js/register.js
@@ -108,7 +108,7 @@ jQuery(document).ready(function($){
 			$.ajax({
 				url: "/api/members/checkpass",
 				type: "POST",
-				data: "password1="+passwd.val(),
+				data: {"password1": passwd.val()},
 				dataType: "json",
 				cache: false,
 				success: function(json) {


### PR DESCRIPTION
Passing values as a querystring can cause characters in the password,
such as an ampersand (&), to be misinterprutted and truncate the pass.

Fixes: https://hubicl.org/support/ticket/14