### PR TITLE
[fix] Change publication ftp bundle symlink to reference relative paths.

### DIFF
--- a/core/components/com_publications/migrations/Migration20180820101435ComPublications.php
+++ b/core/components/com_publications/migrations/Migration20180820101435ComPublications.php
@@ -1,0 +1,112 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+require_once Component::path('com_publications') . '/models/publication.php';
+require_once Component::path('com_publications') . '/models/orm/version.php';
+use Components\Publications\Models\Orm\Version;
+use Components\Publications\Models\Publication;
+
+/**
+ * Migration script for creating sym links in the SFTP directory
+ **/
+class Migration20180820101435ComPublications extends Base
+{
+	/**
+	 * Number of database rows to process at a time
+	 *
+	 * @var  integer
+	 */
+	public $limit = 1000;
+
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$versionCount = Version::all()->whereEquals('state', 1)->total();
+		$offset = 0;
+		while ($offset < $versionCount)
+		{
+			$publications = Version::all()
+				->whereEquals('state', 1)
+				->limit($this->limit)
+				->start($offset)
+				->rows();
+
+			foreach ($publications as $publication)
+			{
+				$pubId = $publication->get('publication_id');
+				$versionId = $publication->get('id');
+
+				$pubModel = new Publication($pubId, null, $versionId);
+				$pubModel->setCuration();
+				$pubModel->_curationModel->removeSymLink();
+			}
+
+			$offset += $this->limit;
+		}
+
+		if (is_dir(PATH_APP . '/site/publications/ftp'))
+		{
+			$versionCount = Version::all()->whereEquals('state', 1)->total();
+			$offset = 0;
+			while ($offset < $versionCount)
+			{
+				$publications = Version::all()
+					->whereEquals('state', 1)
+					->limit($this->limit)
+					->start($offset)
+					->rows();
+
+				foreach ($publications as $publication)
+				{
+					$pubId = $publication->get('publication_id');
+					$versionId = $publication->get('id');
+
+					$pubModel = new Publication($pubId, null, $versionId);
+					$pubModel->setCuration();
+					$pubModel->_curationModel->createSymLink();
+				}
+
+				$offset += $this->limit;
+			}
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		if (is_dir(PATH_APP . '/site/publications/ftp'))
+		{
+			$versionCount = Version::all()->whereEquals('state', 1)->total();
+			$offset = 0;
+			while ($offset < $versionCount)
+			{
+				$publications = Version::all()
+					->whereEquals('state', 1)
+					->limit($this->limit)
+					->start($offset)
+					->rows();
+
+				foreach ($publications as $publication)
+				{
+					$pubId = $publication->get('publication_id');
+					$versionId = $publication->get('id');
+
+					$pubModel = new Publication($pubId, null, $versionId);
+					$pubModel->setCuration();
+					$pubModel->_curationModel->removeSymLink();
+				}
+
+				$offset += $this->limit;
+			}
+		}
+
+	}
+}

--- a/core/components/com_publications/migrations/Migration20180820101435ComPublications.php
+++ b/core/components/com_publications/migrations/Migration20180820101435ComPublications.php
@@ -5,11 +5,6 @@ use Hubzero\Content\Migration\Base;
 // No direct access
 defined('_HZEXEC_') or die();
 
-require_once Component::path('com_publications') . '/models/publication.php';
-require_once Component::path('com_publications') . '/models/orm/version.php';
-use Components\Publications\Models\Orm\Version;
-use Components\Publications\Models\Publication;
-
 /**
  * Migration script for creating sym links in the SFTP directory
  **/
@@ -27,54 +22,34 @@ class Migration20180820101435ComPublications extends Base
 	 **/
 	public function up()
 	{
-		$versionCount = Version::all()->whereEquals('state', 1)->total();
 		$offset = 0;
+		$versionQuery = "SELECT count(*) FROM `#__publication_versions` WHERE `state` = 1";
+		$this->db->setQuery($versionQuery);
+		$this->db->query();
+		$versionCount = $this->db->loadResult();
 		while ($offset < $versionCount)
 		{
-			$publications = Version::all()
-				->whereEquals('state', 1)
-				->limit($this->limit)
-				->start($offset)
-				->rows();
+			$query = "SELECT `doi`, `publication_id`, `id`, `version_number`, `state` FROM `#__publication_versions` WHERE `state` = 1 LIMIT {$offset}, {$this->limit};";
+
+			$this->db->setQuery($query);
+			$this->db->query();
+			$publications = $this->db->loadAssocList();
 
 			foreach ($publications as $publication)
 			{
-				$pubId = $publication->get('publication_id');
-				$versionId = $publication->get('id');
-
-				$pubModel = new Publication($pubId, null, $versionId);
-				$pubModel->setCuration();
-				$pubModel->_curationModel->removeSymLink();
+				$pubId = $publication['publication_id'];
+				$versionId = $publication['id'];
+				$doi = $publication['doi'];
+				$versionNum = $publication['version_number'];
+				$this->removeSymLink($pubId, $versionId, $versionNum, $doi);
+				if (is_dir($this->_symLinkPath()))
+				{
+					$this->createSymLink($pubId, $versionId, $versionNum, $doi);
+				}
 			}
-
 			$offset += $this->limit;
 		}
 
-		if (is_dir(PATH_APP . '/site/publications/ftp'))
-		{
-			$versionCount = Version::all()->whereEquals('state', 1)->total();
-			$offset = 0;
-			while ($offset < $versionCount)
-			{
-				$publications = Version::all()
-					->whereEquals('state', 1)
-					->limit($this->limit)
-					->start($offset)
-					->rows();
-
-				foreach ($publications as $publication)
-				{
-					$pubId = $publication->get('publication_id');
-					$versionId = $publication->get('id');
-
-					$pubModel = new Publication($pubId, null, $versionId);
-					$pubModel->setCuration();
-					$pubModel->_curationModel->createSymLink();
-				}
-
-				$offset += $this->limit;
-			}
-		}
 	}
 
 	/**
@@ -82,31 +57,122 @@ class Migration20180820101435ComPublications extends Base
 	 **/
 	public function down()
 	{
-		if (is_dir(PATH_APP . '/site/publications/ftp'))
+		if (is_dir($this->_symlinkPath()))
 		{
-			$versionCount = Version::all()->whereEquals('state', 1)->total();
+			$versionQuery = "SELECT count(*) FROM `#__publication_versions` WHERE `state` = 1";
+			$this->db->setQuery($versionQuery);
+			$this->db->query();
+			$versionCount = $this->db->loadResult();
 			$offset = 0;
 			while ($offset < $versionCount)
 			{
-				$publications = Version::all()
-					->whereEquals('state', 1)
-					->limit($this->limit)
-					->start($offset)
-					->rows();
+				$query = "SELECT `doi`, `publication_id`, `id`, `version_number`, `state` FROM `#__publication_versions` WHERE `state` = 1 LIMIT {$offset}, {$this->limit};";
+
+				$this->db->setQuery($query);
+				$this->db->query();
+				$publications = $this->db->loadAssocList();
 
 				foreach ($publications as $publication)
 				{
-					$pubId = $publication->get('publication_id');
-					$versionId = $publication->get('id');
-
-					$pubModel = new Publication($pubId, null, $versionId);
-					$pubModel->setCuration();
-					$pubModel->_curationModel->removeSymLink();
+					$pubId = $publication['publication_id'];
+					$versionId = $publication['id'];
+					$doi = $publication['doi'];
+					$versionNum = $publication['version_number'];
+					$this->removeSymLink($pubId, $versionId, $versionNum, $doi);
 				}
-
 				$offset += $this->limit;
 			}
 		}
 
+	}
+
+	/**
+	 * Generate symbolic link for publication package
+	 *
+	 * @return boolean
+	 */
+	protected function createSymLink($pubId, $versionId, $versionNum, $doi = '')
+	{
+		if ($doi != '')
+		{
+			$doi = str_replace('.', '_', $doi);
+			$doi = str_replace('/', '_', $doi);
+			$bundleName = $doi;
+		}
+		else
+		{
+			$bundleName = 'Publication' . '_' . $pubId;
+			$bundleWithVersion = $bundleName . '_' . $versionNum;
+		}
+
+		$tarname = $bundleName . '.zip';
+		$symFileName = $bundleWithVersion . '.zip';
+		$tarPath = '..' . '/' . str_pad($pubId, 5, "0", STR_PAD_LEFT) . '/' . str_pad($versionId, 5, "0", STR_PAD_LEFT) . '/' . $tarname;
+		$symLinkPath = $this->_symLinkPath();
+		if ($symLinkPath !== false)
+		{
+			chdir($symLinkPath);
+		}
+		if (empty($pubId) || $symLinkPath == false || !is_file($tarPath))
+		{
+			return false;
+		}
+		$symLink = $symLinkPath . '/' . $symFileName;
+		if (!is_file($symLink))
+		{
+			if (!symlink($tarPath, $symLink))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Remove symbolic link for publication package
+	 *
+	 * @return boolean
+	 */
+	protected function removeSymLink($pubId, $versionId, $versionNum, $doi='')
+	{
+		if ($doi != '')
+		{
+			$doi = str_replace('.', '_', $doi);
+			$doi = str_replace('/', '_', $doi);
+			$bundleName = $doi;
+		}
+		else
+		{
+			$bundleName = 'Publication' . '_' . $pubId;
+			$bundleName .= '_' . $versionNum;
+		}
+
+		$tarname = $bundleName . '.zip';
+		$symLinkPath = $this->_symLinkPath();
+		$symLink = $symLinkPath . '/' . $tarname;
+		if ($symLink == false)
+		{
+			return false;
+		}
+		if (file_exists($symLink))
+		{
+			unlink($symLink);
+		}
+		return true;
+	}
+
+	/**
+	 * Get path to symbolic link used for downloading package via SFTP
+	 *
+	 * @return 	mixed 	string if sftp path provided, false if not
+	 */
+	private function _symLinkPath()
+	{
+		$sftpPath = PATH_APP . Component::params('com_publications')->get('sftppath');
+		if (!is_dir($sftpPath))
+		{
+			return false;
+		}
+		return $sftpPath;
 	}
 }

--- a/core/components/com_publications/models/curation.php
+++ b/core/components/com_publications/models/curation.php
@@ -2158,8 +2158,13 @@ class Curation extends Obj
 	public function createSymLink()
 	{
 		$tarname = $this->getBundleName();
-		$tarpath = $this->_pub->path('base', true) . DS . $tarname;
+		$tarpath = $this->_pub->path('relative') . DS . $tarname;
 		$symLink = $this->_symLinkPath();
+		if ($symLink !== false)
+		{
+			chdir(dirname($symLink));
+		}
+
 		if (empty($this->_pub) || $symLink == false || !is_file($tarpath))
 		{
 			return false;
@@ -2186,6 +2191,7 @@ class Curation extends Obj
 		{
 			return false;
 		}
+
 		if (is_file($symLink))
 		{
 			unlink($symLink);

--- a/core/components/com_publications/models/publication.php
+++ b/core/components/com_publications/models/publication.php
@@ -1917,6 +1917,10 @@ class Publication extends Obj
 		}
 		switch (strtolower($type))
 		{
+			case 'relative':
+				$path = '..' . DS . \Hubzero\Utility\Str::pad($this->get('id')) . DS . \Hubzero\Utility\Str::pad($this->get('version_id'));
+			break;
+
 			case 'base':
 				$path = $this->_basePath;
 			break;


### PR DESCRIPTION
Absolute paths to the original publication file were not accessible via FTP.
I changed the symlinks to reference the relative path instead.

refs: https://purr.purdue.edu/support/ticket/1852