### PR TITLE
[fix] Fixing issue with how permissions are calc.

### DIFF
--- a/core/components/com_answers/helpers/permissions.php
+++ b/core/components/com_answers/helpers/permissions.php
@@ -56,9 +56,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_blog/admin/helpers/permissions.php
+++ b/core/components/com_blog/admin/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_citations/helpers/permissions.php
+++ b/core/components/com_citations/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_collections/helpers/permissions.php
+++ b/core/components/com_collections/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_courses/helpers/permissions.php
+++ b/core/components/com_courses/helpers/permissions.php
@@ -60,6 +60,7 @@ class Permissions
 
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_cron/helpers/permissions.php
+++ b/core/components/com_cron/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_developer/helpers/permissions.php
+++ b/core/components/com_developer/helpers/permissions.php
@@ -61,9 +61,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_feedback/helpers/permissions.php
+++ b/core/components/com_feedback/helpers/permissions.php
@@ -55,9 +55,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_forum/helpers/permissions.php
+++ b/core/components/com_forum/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_jobs/helpers/permissions.php
+++ b/core/components/com_jobs/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_kb/admin/helpers/permissions.php
+++ b/core/components/com_kb/admin/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_members/helpers/permissions.php
+++ b/core/components/com_members/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_newsletter/helpers/permissions.php
+++ b/core/components/com_newsletter/helpers/permissions.php
@@ -56,9 +56,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_oaipmh/helpers/permissions.php
+++ b/core/components/com_oaipmh/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_poll/helpers/permissions.php
+++ b/core/components/com_poll/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_projects/admin/views/projects/tmpl/description.php
+++ b/core/components/com_projects/admin/views/projects/tmpl/description.php
@@ -33,7 +33,7 @@
 defined('_HZEXEC_') or die();
 
 Toolbar::title(Lang::txt('COM_PROJECTS') . ': ' . Lang::txt('COM_PROJECTS_CUSTOM_DESCRIPTION'));
-if (User::authorise('core.edit') || User::authorise('core.create'))
+if (User::authorise('core.edit', $this->option) || User::authorise('core.create', $this->option))
 {
 	Toolbar::apply('applyDescription');
 	Toolbar::save('saveDescription');

--- a/core/components/com_projects/admin/views/projects/tmpl/display.php
+++ b/core/components/com_projects/admin/views/projects/tmpl/display.php
@@ -37,20 +37,20 @@ $this->css();
 Toolbar::title(Lang::txt('Projects'), 'projects');
 
 // Only display if enabled
-if (User::authorise('core.manage', $this->option . '.component') && $this->config->get('custom_profile') == 'custom')
+if (User::authorise('core.manage', $this->option) && $this->config->get('custom_profile') == 'custom')
 {
 	Toolbar::custom('customizeDescription', 'menus', 'menus', 'COM_PROJECTS_CUSTOM_DESCRIPTION', false);
 	Toolbar::spacer();
 }
-if (User::authorise('core.edit.state', $this->option . '.component'))
+if (User::authorise('core.edit.state', $this->option))
 {
 	Toolbar::archiveList();
 }
-if (User::authorise('core.edit', $this->option . '.component'))
+if (User::authorise('core.edit', $this->option))
 {
 	Toolbar::editList();
 }
-if (User::authorise('core.admin', $this->option . '.component'))
+if (User::authorise('core.admin', $this->option))
 {
 	Toolbar::spacer();
 	Toolbar::preferences('com_projects', '550');

--- a/core/components/com_publications/helpers/permissions.php
+++ b/core/components/com_publications/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_resources/helpers/permissions.php
+++ b/core/components/com_resources/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_services/helpers/permissions.php
+++ b/core/components/com_services/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_storefront/admin/helpers/permissions.php
+++ b/core/components/com_storefront/admin/helpers/permissions.php
@@ -50,9 +50,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_support/helpers/permissions.php
+++ b/core/components/com_support/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_tags/helpers/permissions.php
+++ b/core/components/com_tags/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_wiki/helpers/permissions.php
+++ b/core/components/com_wiki/helpers/permissions.php
@@ -57,9 +57,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 

--- a/core/components/com_wishlist/helpers/permissions.php
+++ b/core/components/com_wishlist/helpers/permissions.php
@@ -56,9 +56,9 @@ class Permissions
 	public static function getActions($assetType='component', $assetId = 0)
 	{
 		$assetName  = self::$extension;
-		$assetName .= '.' . $assetType;
 		if ($assetId)
 		{
+			$assetName .= '.' . $assetType;
 			$assetName .= '.' . (int) $assetId;
 		}
 


### PR DESCRIPTION
Asset type should only be appended to the permission string when a
specific asset ID is provided. Otherwise, it can lead to incorrect
calculations and give permission where it was meant to be denied.