### PR TITLE
[fix] Make default value of var to be correct type

### DIFF
--- a/core/components/com_tools/admin/controllers/hosts.php
+++ b/core/components/com_tools/admin/controllers/hosts.php
@@ -239,8 +239,8 @@ class Hosts extends AdminController
 		$zones = $v->find('list');
 
 		// make sure we have a hostname
-		$toolCounts = 0;
-		$statusCounts = 0;
+		$toolCounts = array();
+		$statusCounts = array();
 		if ($row->hostname != '')
 		{
 			//get tool instance counts


### PR DESCRIPTION
Previous var default value was an integer but the rest of the code was
expecting an array.

Fixes: https://help.hubzero.org/support/ticket/11493