### PR TITLE
[fix] Use group title instead of alias in emails

### DIFF
--- a/core/components/com_groups/site/controllers/membership.php
+++ b/core/components/com_groups/site/controllers/membership.php
@@ -378,7 +378,7 @@ class Membership extends Base
 		);
 
 		// Message subject
-		$subject = Lang::txt('COM_GROUPS_INVITE_EMAIL_SUBJECT', $this->view->group->get('cn'));
+		$subject = Lang::txt('COM_GROUPS_INVITE_EMAIL_SUBJECT', $this->view->group->get('description'));
 
 		// Message body for HUB user
 		$eview = new \Hubzero\Mail\View(array(


### PR DESCRIPTION
Fixes: https://help.hubzero.org/support/ticket/11504