### PR TITLE
Catch failure when running timezone data update hook

### DIFF
--- a/core/migrations/hooks/UpdateTimezoneDatabase.php
+++ b/core/migrations/hooks/UpdateTimezoneDatabase.php
@@ -101,7 +101,20 @@ class UpdateTimezoneDatabase extends Base
 				}
 
 				$this->db->setQuery($s);
-				$this->db->query();
+				
+				try
+				{
+					$this->db->query();
+				}
+				catch (Exception $e)
+				{
+					$return = array(
+						'success' => false,
+						'message' => $e->getMessage()
+					);
+
+					return $return;
+				}
 			}
 		}
 

--- a/core/migrations/hooks/UpdateTimezoneDatabase.php
+++ b/core/migrations/hooks/UpdateTimezoneDatabase.php
@@ -101,7 +101,7 @@ class UpdateTimezoneDatabase extends Base
 				}
 
 				$this->db->setQuery($s);
-				
+
 				try
 				{
 					$this->db->query();


### PR DESCRIPTION
In some cases (Amazon RDS) it will not be possible to run the timezone data update hook. So catch the error and display a warning rather than abort with a messy exception error.