### PR TITLE
[fix] Only attempt to remove a symlink file if it already exists

### DIFF
--- a/core/components/com_publications/models/curation.php
+++ b/core/components/com_publications/models/curation.php
@@ -2186,7 +2186,10 @@ class Curation extends Obj
 		{
 			return false;
 		}
-		unlink($symLink);
+		if (is_file($symLink))
+		{
+			unlink($symLink);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
New publication submissions were displaying an error since it was attempting to
remove symlink that wasn't created yet.

refs: https://purr.purdue.edu/support/ticket/1879