### PR TITLE
Add condition to Ticket::allWithQuery

### DIFF
--- a/core/components/com_support/models/ticket.php
+++ b/core/components/com_support/models/ticket.php
@@ -768,7 +768,7 @@ class Ticket extends Relational
 	 */
 	public static function allWithQuery($query, $filters=array())
 	{
-		if (!$query)
+		if (!$query || $query->isNew())
 		{
 			return array();
 		}


### PR DESCRIPTION
Without the additional check, the new Query instance continues through
the function, which attempts to access a property on a null return value
provided by the Query

fixes: https://help.hubzero.org/support/tickets/11502