### PR TITLE
[feat] Allow set PATH_CORE by env var and run from core

### DIFF
--- a/core/index.php
+++ b/core/index.php
@@ -29,7 +29,7 @@ define('DS', DIRECTORY_SEPARATOR);
 */
 
 // Define the root. Typically, this is the current directory.
-$root = __DIR__;
+$root = dirname(__DIR__);
 if (isset($_SERVER['DOCUMENT_ROOT']) && $_SERVER['DOCUMENT_ROOT'])
 {
 	$root = $_SERVER['DOCUMENT_ROOT'];


### PR DESCRIPTION
This allows setting `PATH_CORE` via an environment variable. If no env
var is found, it will fallback to previous functionality (assumes it's a
directory under `PATH_ROOT`).

This also allows for running the CMS from `/core`.