### PR TITLE
[fix] Clear handlers' error bags after each use

### DIFF
--- a/core/components/com_groups/models/import/record.php
+++ b/core/components/com_groups/models/import/record.php
@@ -577,6 +577,8 @@ class Record extends \Hubzero\Content\Import\Model\Record
 			{
 				array_push($this->record->notices, $error);
 			}
+
+			$handler->setErrors(array());
 		}
 	}
 
@@ -595,6 +597,8 @@ class Record extends \Hubzero\Content\Import\Model\Record
 			{
 				array_push($this->record->errors, $error);
 			}
+
+			$handler->setErrors(array());
 		}
 	}
 

--- a/core/components/com_members/models/import/record.php
+++ b/core/components/com_members/models/import/record.php
@@ -655,6 +655,8 @@ class Record extends \Hubzero\Content\Import\Model\Record
 			{
 				array_push($this->record->notices, $error);
 			}
+
+			$handler->setErrors(array());
 		}
 	}
 
@@ -673,6 +675,8 @@ class Record extends \Hubzero\Content\Import\Model\Record
 			{
 				array_push($this->record->notices, $error);
 			}
+
+			$handler->setErrors(array());
 		}
 	}
 


### PR DESCRIPTION
Handlers are loaded statically, so errors added to them after each use
can build up, falsely reporting errors for records that may not have
generated any. So, clear the error bag after each time the handler is
used.