### PR TITLE
[fix] Quote text to guard against bad characters

### DIFF
--- a/core/assets/js/jquery.fancyselect.js
+++ b/core/assets/js/jquery.fancyselect.js
@@ -108,7 +108,7 @@
 	methods.selectText = function( value, callSelected ) {
 		return this.each(function(){
 			$('#fs-dropdown-' + $(this).data('fancyselect').id)
-				.find('.fs-dropdown-option a span:contains(' + value + ')')
+				.find('.fs-dropdown-option a span:contains("' + value.replace('"', '\"') + '")')
 				.parent('a')
 				.trigger('click', callSelected);
 		});


### PR DESCRIPTION
CSS selector text should be in quotes just in case it has things like
parentheses in it, which could truncate the selector statement. Example:
`.foo span:contains(bad (text))`

Fixes: https://qubeshub.org/support/ticket/1273