### PR TITLE
[fix] Reshaping path variable for Google Drive

### DIFF
--- a/core/plugins/filesystem/dropbox/dropbox.php
+++ b/core/plugins/filesystem/dropbox/dropbox.php
@@ -66,7 +66,9 @@ class plgFilesystemDropbox extends \Hubzero\Plugin\Plugin
 		$client = new DropboxClient($accessToken);
 
 		// Return the adapter
-		return new DropboxAdapter($client, Arr::getValue($params, 'path', ''));
+		$path = Arr::getValue($params, 'path', '');
+		$path = urldecode($path);
+		return new DropboxAdapter($client, $path);
 	}
 
 	/**

--- a/core/plugins/filesystem/googledrive/googledrive.php
+++ b/core/plugins/filesystem/googledrive/googledrive.php
@@ -89,6 +89,8 @@ class plgFilesystemGoogleDrive extends \Hubzero\Plugin\Plugin
 			App::redirect($client->createAuthUrl());
 		}
 		$path = Arr::getValue($params, 'path', null);
+		$path = explode('/', urldecode($path));
+		$path = end($path);
 		$client->setAccessToken($accessToken);
 		$service = new \Google_Service_Drive($client);
 		$adapter = new \Hypweb\Flysystem\GoogleDrive\GoogleDriveAdapter($service, $path);

--- a/core/plugins/projects/files/connections.php
+++ b/core/plugins/projects/files/connections.php
@@ -395,7 +395,7 @@ class connections
 	 */
 	public function setprefix()
 	{
-		$prefix = Request::getString('prefix', null);
+		$prefix = urldecode(Request::getString('prefix', ''));
 		$connection_params = json_decode($this->connection->params);
 		// Attempt to prevent URL tampering
 		// Don't set a prefix if one was set already, user must unset it from connections menu first


### PR DESCRIPTION
Drive adapter is not expecting subdirectories when instantiating.

Fixes: https://qubeshub.org/support/ticket/1269