### PR TITLE
[fix] Query for publication id when attaching the citation

### DIFF
--- a/core/plugins/projects/links/links.php
+++ b/core/plugins/projects/links/links.php
@@ -434,6 +434,7 @@ class plgProjectsLinks extends \Hubzero\Plugin\Plugin
 			->join($a, $a . '.cid', $c . '.id', 'inner')
 			->whereEquals($a . '.tbl', 'publication')
 			->whereEquals($c . '.doi', $doi)
+			->whereEquals($a . '.oid', $pid)
 			->row();
 
 		if ($citation->get('id'))


### PR DESCRIPTION
Currently the query returns true (citation ID) if it is attached to any publication, not just the one you are trying to attach it. 