### PR TITLE
[feat] Autoapprove users based on email

### DIFF
--- a/core/plugins/user/autoapprove/autoapprove.php
+++ b/core/plugins/user/autoapprove/autoapprove.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * HUBzero CMS
+ *
+ * Copyright 2011-2012 Purdue University. All rights reserved.
+ *
+ * This file is part of: The HUBzero(R) Platform for Scientific Collaboration
+ *
+ * The HUBzero(R) Platform for Scientific Collaboration (HUBzero) is free
+ * software: you can redistribute it and/or modify it under the terms of
+ * the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * HUBzero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * HUBzero is a registered trademark of Purdue University.
+ *
+ * @package   hubzero-cms
+ * @copyright Copyright 2005-2011 Purdue University. All rights reserved.
+ * @license   http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+ */
+
+// No direct access.
+defined('_HZEXEC_') or die();
+
+/**
+ * Plugin for auto-approving users with specified email domains
+ */
+class plgUserAutoapprove extends \Hubzero\Plugin\Plugin
+{
+	/**
+	 * Utility method to act on a user after it has been saved.
+	 *
+	 * This method sends a registration email to new users created in the backend.
+	 *
+	 * @param   array    $user     Holds the new user data.
+	 * @param   boolean  $isnew    True if a new user is stored.
+	 * @param   boolean  $success  True if user was succesfully stored in the database.
+	 * @param   string   $msg      Message.
+	 * @return  void
+	 */
+	public function onUserAfterSave($user, $isnew, $success, $msg)
+	{
+		if ($isnew)
+		{
+			if (!isset($user['id']) || !$user['id'])
+			{
+				return;
+			}
+
+			$this->approveUser($user['id']);
+		}
+	}
+
+	/**
+	 * This method should handle any login logic and report back to the subject
+	 *
+	 * @param   array    $user     holds the user data
+	 * @param   array    $options  array holding options (remember, autoregister, group)
+	 * @return  boolean  True on success
+	 */
+	public function onLoginUser($user, $options = array())
+	{
+		return $this->onUserLogin($user, $options);
+	}
+
+	/**
+	 * This method should handle any login logic and report back to the subject
+	 *
+	 * @param   array    $user     holds the user data
+	 * @param   array    $options  array holding options (remember, autoregister, group)
+	 * @return  boolean  True on success
+	 */
+	public function onUserLogin($user, $options = array())
+	{
+		$userId = User::get('id');
+
+		return $this->approveUser($userId);
+	}
+
+	/**
+	 * Set user access groups based on profile choice
+	 *
+	 * @param   integer  $user
+	 * @return  boolean  True on success
+	 */
+	public function approveUser($userId)
+	{
+		if (!$userId)
+		{
+			return false;
+		}
+
+		$pattern = $this->params->get('email_pattern');
+
+		if (!$pattern)
+		{
+			return false;
+		}
+
+		$user = User::getInstance($userId);
+
+		if (!$user || !$user->get('email'))
+		{
+			return false;
+		}
+
+		if ($user->get('approved'))
+		{
+			return true;
+		}
+
+		if (preg_match("/$pattern/", $user->get('email')))
+		{
+			$query = $user->getQuery()
+				->update($user->getTableName())
+				->set(['approved' => 1])
+				->whereEquals('id', $user->get('id'))
+				->toString();
+
+			$db = App::get('db');
+			$db->setQuery($query);
+
+			if (!$db->query())
+			{
+				return false;
+			}
+
+			User::set('approved', 1);
+		}
+
+		return true;
+	}
+}

--- a/core/plugins/user/autoapprove/autoapprove.xml
+++ b/core/plugins/user/autoapprove/autoapprove.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+@package        hubzero-cms
+@file           plugins/user/autoapprove/autoapprove.xml
+@copyright      Copyright 2012-2018 HUBzero Foundation, LLC.
+@license        http://opensource.org/licenses/MIT MIT
+
+Copyright 2012-2018 HUBzero Foundation, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+HUBzero is a registered trademark of Purdue University.
+-->
+
+<extension version="2.2" type="plugin" group="user">
+	<name>PLG_USER_AUTOAPPROVE</name>
+	<author>HUBzero</author>
+	<creationDate>August 2018</creationDate>
+	<copyright>Copyright (C) 2008-2018 Purdue University.</copyright>
+	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
+	<authorEmail>support@hubzero.org</authorEmail>
+	<authorUrl>hubzero.org</authorUrl>
+	<version>1.0</version>
+	<description>PLG_USER_AUTOAPPROVE_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="autoapprove">autoapprove.php</filename>
+	</files>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field name="email_pattern" type="text" default=".*\.edu$" label="PLG_USER_AUTOAPPROVE_PARAM_PATTERN_LABEL" description="PLG_USER_AUTOAPPROVE_PARAM_PATTERN_DESC"/>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/core/plugins/user/autoapprove/language/en-GB/en-GB.plg_user_autoapprove.ini
+++ b/core/plugins/user/autoapprove/language/en-GB/en-GB.plg_user_autoapprove.ini
@@ -1,0 +1,13 @@
+; @package      hubzero-cms
+; @file         language/en-GB/en-GB.plg_user_autoapprove.ini
+; @copyright    Copyright 2005-2018 Purdue University. All rights reserved.
+; @license      http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_USER_AUTOAPPROVE="User - Auto-Approve"
+PLG_USER_AUTOAPPROVE_XML_DESCRIPTION="Plugin for auto-approving user accounts based on email address"
+
+; Params
+PLG_USER_AUTOAPPROVE_PARAM_PATTERN_LABEL="Email Regex Pattern"
+PLG_USER_AUTOAPPROVE_PARAM_PATTERN_DESC="Regular expression pattern that user account emails must match to be auto-approved."

--- a/core/plugins/user/autoapprove/language/en-GB/en-GB.plg_user_autoapprove.sys.ini
+++ b/core/plugins/user/autoapprove/language/en-GB/en-GB.plg_user_autoapprove.sys.ini
@@ -1,0 +1,9 @@
+; @package      hubzero-cms
+; @file         language/en-GB/en-GB.plg_user_autoapprove.sys.ini
+; @copyright    Copyright 2005-2018 Purdue University. All rights reserved.
+; @license      http://www.gnu.org/licenses/lgpl-3.0.html LGPLv3
+
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_USER_AUTOAPPROVE="User - Auto-Approve"
+PLG_USER_AUTOAPPROVE_XML_DESCRIPTION="Plugin for auto-approving user accounts based on email address"

--- a/core/plugins/user/autoapprove/migrations/Migration20180831000000PlgUserAutoapprove.php
+++ b/core/plugins/user/autoapprove/migrations/Migration20180831000000PlgUserAutoapprove.php
@@ -1,0 +1,28 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding User - Auto-approve plugin
+ **/
+class Migration20180831000000PlgUserAutoapprove extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$this->addPluginEntry('user', 'autoapprove');
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$this->deletePluginEntry('user', 'autoapprove');
+	}
+}


### PR DESCRIPTION
This plugin allows for auto-approving new accounts based on if their
email matches a specified regex. For exaple, any email that ends in
`.edu` could be considered trusted and autoapproved.