### PR TITLE
[fix] Get correct time

### DIFF
--- a/core/modules/mod_supporttickets/helper.php
+++ b/core/modules/mod_supporttickets/helper.php
@@ -109,8 +109,9 @@ class Helper extends Module
 
 		$this->offset = Config::get('offset');
 
-		$year  = Request::getInt('year', strftime("%Y", time()+($this->offset*60*60)));
-		$month = strftime("%m", time()+($this->offset*60*60));
+		$date = new \Hubzero\Utility\Date();
+		$year = $date->toLocal('Y');
+		$month = $date->toLocal('m');
 
 		$this->year = $year;
 		$this->opened = array();


### PR DESCRIPTION
7.2 was running into issues with the offset being non-numeric.  It's
saved as a string anymore, so since that change the offset here has
evaluated to 0 anyway.  Date utility should take configured offset into
account and provide the appropriate year and month here.