### PR TITLE
[fix] Try getting extension from file name

### DIFF
--- a/core/components/com_groups/site/views/media/tmpl/filelist.php
+++ b/core/components/com_groups/site/views/media/tmpl/filelist.php
@@ -135,15 +135,18 @@ $ckeditorQuery = '&type=' . $type . '&CKEditor=' . $ckeditor . '&CKEditorFuncNum
 				// formatted results
 				if (isset($fileinfo['extension']))
 				{
-
 					$extension = $fileInfo['extension'];
 				}
 				else
 				{
-	
-					$fileContent = file_get_contents($filePath);
-					$mimeType = \Hubzero\Filesystem\Util\MimeType::detectByContent($fileContent);
-					$extension = array_search($mimeType, $mimeTypes);
+					$extension = Filesystem::extension($file);
+
+					if (!$extension)
+					{
+						$fileContent = file_get_contents($filePath);
+						$mimeType = \Hubzero\Filesystem\Util\MimeType::detectByContent($fileContent);
+						$extension = array_search($mimeType, $mimeTypes);
+					}
 				}
 
 				$formattedFilesize   = \Hubzero\Utility\Number::formatBytes($filesize);


### PR DESCRIPTION
Try getting the extensionf romt he file name before resorting to content
type detection. The latter method can be especially process heavy with
larger files.

Fixes: https://mygeohub.org/support/ticket/1303