### PR TITLE
[fix] Check for controller existence before inc

### DIFF
--- a/core/components/com_newsletter/admin/newsletter.php
+++ b/core/components/com_newsletter/admin/newsletter.php
@@ -34,7 +34,7 @@ namespace Components\Newsletter\Admin;
 
 if (!\User::authorise('core.manage', 'com_newsletter'))
 {
-	return \App::abort(404, \Lang::txt('JERROR_ALERTNOAUTHOR'));
+	return \App::abort(403, \Lang::txt('JERROR_ALERTNOAUTHOR'));
 }
 
 // Include models
@@ -48,7 +48,11 @@ require_once dirname(__DIR__) . DS . 'helpers' . DS . 'permissions.php';
 
 // Instantiate controller
 $controllerName = \Request::getCmd('controller', 'newsletters');
-require_once(__DIR__ . DS . 'controllers' . DS . $controllerName . '.php');
+if (!file_exists(__DIR__ . DS . 'controllers' . DS . $controllerName . '.php'))
+{
+	return \App::abort(404, \Lang::txt('JERROR_INVALID_CONTROLLER'));
+}
+require_once __DIR__ . DS . 'controllers' . DS . $controllerName . '.php';
 $controllerName = __NAMESPACE__ . '\\Controllers\\' . ucfirst($controllerName);
 
 // Menu items


### PR DESCRIPTION
Found in error logs: Sometimes this would get passed an incorrect (old)
controller name (e.g., singular instead of plural) and the code would
blindly try to require any controller name given it. Now we check that
the file exists first.