### PR TITLE
[fix] ensure publication symLink name is correct.

### DIFF
--- a/core/components/com_publications/models/curation.php
+++ b/core/components/com_publications/models/curation.php
@@ -2087,28 +2087,27 @@ class Curation extends Obj
 	 * @param	boolean	$includeVersionNum
 	 * @return  mixed  False on error, string on success
 	 */
-	public function getBundleName($includeVersionNum = false)
+	public function getBundleName($symLinkName = false)
 	{
 		if (empty($this->_pub))
 		{
 			return false;
 		}
-		$doi = $this->_pub->version->get('doi');
-		if ($doi != '')
+		$bundleName = Lang::txt('Publication') . '_' . $this->_pub->id;
+		if ($symLinkName)
 		{
-			$doi = str_replace('.', '_', $doi);
-			$doi = str_replace('/', '_', $doi);
-			$bundleName = $doi;
+			$bundleName .= '_' . $this->_pub->version->get('version_number');
 		}
 		else
 		{
-			$bundleName = Lang::txt('Publication') . '_' . $this->_pub->id;
-			if ($includeVersionNum)
+			$doi = $this->_pub->version->get('doi');
+			if ($doi != '')
 			{
-				$bundleName .= '_' . $this->_pub->version->get('version_number');
+				$doi = str_replace('.', '_', $doi);
+				$doi = str_replace('/', '_', $doi);
+				$bundleName = $doi;
 			}
 		}
-
 		return $bundleName . '.zip';
 	}
 

--- a/core/components/com_publications/models/curation.php
+++ b/core/components/com_publications/models/curation.php
@@ -2093,7 +2093,7 @@ class Curation extends Obj
 		{
 			return false;
 		}
-		$bundleName = Lang::txt('Publication') . '_' . $this->_pub->id;
+		$bundleName = 'Publication' . '_' . $this->_pub->id;
 		if ($symLinkName)
 		{
 			$bundleName .= '_' . $this->_pub->version->get('version_number');


### PR DESCRIPTION
New publications submitted would have the symlink automatically created
based on DOI, however the link creation is based on pubication Id/ version Id.