### PR TITLE
[fix] Better way of builing document's baseurl

### DIFF
--- a/core/bootstrap/Administrator/Providers/DocumentServiceProvider.php
+++ b/core/bootstrap/Administrator/Providers/DocumentServiceProvider.php
@@ -108,7 +108,14 @@ class DocumentServiceProvider extends Middleware
 				'directory' => dirname($this->app['template']->path),
 				'params'    => $this->app['template']->params
 			);
-			$params['baseurl'] = rtrim(\Request::root(true), '/') . rtrim(substr(dirname($params['directory']), strlen(PATH_ROOT)), '/');
+
+			// Path is <PATH>/[core|app]/templates
+			$basepath = dirname(dirname($params['directory']));
+
+			// Strip off the base path
+			$path = substr(dirname($params['directory']), strlen($basepath));
+
+			$params['baseurl'] = rtrim(\Request::root(true), '/') . rtrim($path, '/');
 		}
 
 		if (!$document->getTitle())

--- a/core/bootstrap/Site/Providers/DocumentServiceProvider.php
+++ b/core/bootstrap/Site/Providers/DocumentServiceProvider.php
@@ -115,7 +115,14 @@ class DocumentServiceProvider extends Middleware
 				'directory' => dirname($this->app['template']->path),
 				'params'    => $this->app['template']->params
 			);
-			$params['baseurl'] = rtrim(\Request::root(true), '/') . rtrim(substr(dirname($params['directory']), strlen(PATH_ROOT)), '/');
+
+			// Path is <PATH>/[core|app]/templates
+			$basepath = dirname(dirname($params['directory']));
+
+			// Strip off the base path
+			$path = substr(dirname($params['directory']), strlen($basepath));
+
+			$params['baseurl'] = rtrim(\Request::root(true), '/') . rtrim($path, '/');
 		}
 
 		if (!$document->getTitle())


### PR DESCRIPTION
We can't always rely on the path being a sub-directory of PATH_ROOT.
So, we need to take a different tact to building the baseurl.