### PR TITLE
[fix] Make sure query result is an array

### DIFF
--- a/core/modules/mod_incremental_registration/helper.php
+++ b/core/modules/mod_incremental_registration/helper.php
@@ -463,7 +463,16 @@ class Helper extends Module
 			}
 			else if (!preg_match('%^/members/' . $uid . '/profile%', $uri) && $hasCurl)
 			{
-				require $this->getLayoutPath('curl');
+				// check if there's anything we might ask about in the future. if so, show a curl tempting the user to be proactive and fill in more of their profile
+				list($allGroups) = $groups->getAllGroups();
+				$dbh->setQuery('SELECT '.implode(', ', $allGroups['cols']).' FROM #__profile_completion_awards WHERE user_id = '.$uid);
+				$row = $dbh->loadRow();
+				$row = is_array($row) ? $row : array();
+				if (array_filter($row, function($col) {
+					return $col === 0;
+				})) {
+					require $this->getLayoutPath('curl');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes an issue where the result of a query might be `NULL` and gets
passed to `array_filter`, which expects an array (surprise, surprise).

Also pulling in changes that were incorrectly committed on a dev hub
rather than properly added to core:

don't show page curl when the user's profile is substantially complete

Fixes: https://nanohub.org/support/ticket/333646
Fixes: https://nanohub.org/support/ticket/330407