### PR TITLE
[fix] Pass entire array to method

### DIFF
--- a/core/components/com_templates/admin/controllers/source.php
+++ b/core/components/com_templates/admin/controllers/source.php
@@ -130,7 +130,7 @@ class Source extends AdminController
 
 		$file = new File($fields['filename'], $fields['extension_id']);
 
-		if (!$file->save($fields['source']))
+		if (!$file->save($fields))
 		{
 			Notify::error($file->getError());
 		}


### PR DESCRIPTION
The method is expecting an array with a key of 'source', not a string.

Fixes: https://help.hubzero.org/support/ticket/11561