### PR TITLE
[fix] Fixing issues with reordering screenshots

### DIFF
--- a/core/components/com_resources/models/screenshot.php
+++ b/core/components/com_resources/models/screenshot.php
@@ -127,9 +127,9 @@ class Screenshot extends Relational
 			$alias = substr($alias . ' ', 0, 100);
 			$alias = substr($alias, 0, strrpos($alias, ' '));
 		}
-		$alias = str_replace(' ', '-', $alias);
+		$alias = str_replace(' ', '_', $alias);
 
-		return preg_replace("/[^a-zA-Z0-9\-_]/", '', strtolower($alias));
+		return preg_replace("/[^a-zA-Z0-9\-_\.]/", '', $alias);
 	}
 
 	/**
@@ -221,8 +221,9 @@ class Screenshot extends Relational
 	 */
 	public static function oneByFilename($filename, $resourceid=0, $versionid=0)
 	{
-		$query = self::all()
-			->whereEquals('filename', $filename);
+		$query = self::all();
+
+		$query->whereEquals('filename', $query->automaticFilename(array('filename' => $filename)));
 
 		if ($resourceid)
 		{

--- a/core/components/com_tools/migrations/Migration20181015161919ComTools.php
+++ b/core/components/com_tools/migrations/Migration20181015161919ComTools.php
@@ -1,0 +1,62 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration to fix file extensions on screenshots
+ **/
+
+class Migration20181015161919ComTools extends Base
+{
+	/**
+	 * Up;
+	 **/
+	public function up()
+	{
+		if ($this->db->tableExists('#__screenshots'))
+		{
+			$query = "SELECT * FROM `#__screenshots` WHERE LOWER(`filename`) NOT LIKE '%.png'
+					AND LOWER(`filename`) NOT LIKE '%.gif'
+					AND LOWER(`filename`) NOT LIKE '%.jpg'
+					AND LOWER(`filename`) NOT LIKE '%.bmp'
+					AND LOWER(`filename`) NOT LIKE '%.swf'
+					AND LOWER(`filename`) NOT LIKE '%.mov';";
+
+			$this->db->setQuery($query);
+			$rows = $this->db->loadObjectList();
+
+			foreach ($rows as $row)
+			{
+				if (!trim($row->filename))
+				{
+					continue;
+				}
+
+				if (substr($row->filename, -4) != '.')
+				{
+					$ext = substr($row->filename, -3);
+
+					if (in_array($ext, array('png', 'PNG', 'gif', 'GIF', 'jpg', 'JPG', 'bmp', 'BMP', )))
+					{
+						$filename = substr($row->filename, 0, -3) . '.' . $ext;
+
+						$query = "UPDATE `#__screenshots` SET `filename`=" . $this->db->quote($filename) . " WHERE `id`=" . $this->db->quote($row->id);
+						$this->db->setQuery($query);
+						$this->db->query();
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		// None
+	}
+}

--- a/core/components/com_tools/site/controllers/screenshots.php
+++ b/core/components/com_tools/site/controllers/screenshots.php
@@ -67,6 +67,8 @@ class Screenshots extends SiteController
 		$rconfig = Component::params('com_resources');
 		$this->rconfig = $rconfig;
 
+		$this->registerTask('order', 'reorder');
+
 		parent::execute();
 	}
 
@@ -92,7 +94,7 @@ class Screenshots extends SiteController
 		$this->_toolid = $obj->getToolIdFromResource($pid);
 
 		// make sure user is authorized to go further
-		if (!$this->check_access($this->_toolid))
+		if (!$this->_checkAccess($this->_toolid))
 		{
 			App::abort(403, Lang::txt('COM_TOOLS_ALERTNOTAUTH'));
 		}


### PR DESCRIPTION
This adjusts how filenames are being saved. Previously, the period
before the file extension (.png) was being stripped. This should fix
old, bad data, and prevent it from happening in the future.

Fixes: https://nanohub.org/support/ticket/333739