### PR TITLE
[fix] Remove invalid characters from solr custom field key

### DIFF
--- a/core/components/com_resources/models/entry.php
+++ b/core/components/com_resources/models/entry.php
@@ -1688,7 +1688,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 		{
 			foreach ($fields as $key => $value)
 			{
-				$fieldName = $key . '_s';
+				$fieldName = str_replace(['"', ' ', '='], '', $key) . '_s';
 				$obj->$fieldName = $value;
 			}
 		}


### PR DESCRIPTION
Resources was not able to be indexed since an invalid character
existed in a customfield key.

refs: https://qubeshub.org/support/tickets/1312