### PR TITLE
[fix] Save the citation URL

### DIFF
--- a/core/plugins/projects/links/views/selector/tmpl/edit.php
+++ b/core/plugins/projects/links/views/selector/tmpl/edit.php
@@ -191,7 +191,7 @@ $citationFormat = $this->publication->config('citation_format', 'apa');
 
 			<label for="uri">
 				<?php echo Lang::txt('PLG_PROJECTS_LINKS_SELECTOR_CITE_URL'); ?>:
-				<input type="text" name="cite[uri]" id="uri" size="30" maxlength="250" value="<?php echo $this->escape($this->row->url); ?>" />
+				<input type="text" name="cite[url]" id="uri" size="30" maxlength="250" value="<?php echo $this->escape($this->row->url); ?>" />
 			</label>
 		</div>
 		<div class="formatted-cite">


### PR DESCRIPTION
Update the form's URL field name to the correct one to be saved properly