### PR TITLE
[fix] Don't load or show deleted entries

### DIFF
--- a/core/plugins/members/blog/blog.php
+++ b/core/plugins/members/blog/blog.php
@@ -455,11 +455,13 @@ class plgMembersBlog extends \Hubzero\Plugin\Plugin
 				$alias = end($bits);
 			}
 
-			$row = \Components\Blog\Models\Entry::oneByScope(
-				$alias,
-				$this->model->get('scope'),
-				$this->model->get('scope_id')
-			);
+			$row = \Components\Blog\Models\Entry::all()
+				->whereEquals('alias', $alias)
+				->whereEquals('scope', $this->model->get('scope'))
+				->whereEquals('scope_id', $this->model->get('scope_id'))
+				->whereIn('state', array(\Components\Blog\Models\Entry::STATE_UNPUBLISHED, \Components\Blog\Models\Entry::STATE_PUBLISHED))
+				->order('state', 'desc')
+				->row();
 		}
 
 		if (!$row->get('id') || $row->isDeleted())

--- a/core/plugins/members/blog/views/entry/tmpl/default.php
+++ b/core/plugins/members/blog/views/entry/tmpl/default.php
@@ -144,7 +144,16 @@ $this->css()
 		<div class="container blog-popular-entries">
 			<h4><?php echo Lang::txt('PLG_MEMBERS_BLOG_POPULAR_ENTRIES'); ?></h4>
 			<?php
-			$popular = $this->archive->entries()
+			$filters = array(
+				'state' => array(Components\Blog\Models\Entry::STATE_PUBLISHED),
+				'access' => User::getAuthorisedViewLevels()
+			);
+			if (User::get('id') == $this->member->get('id'))
+			{
+				$filters['state'][] = Components\Blog\Models\Entry::STATE_UNPUBLISHED;
+				unset($filters['access']);
+			}
+			$popular = $this->archive->entries($filters)
 					->order('hits', 'desc')
 					->limit(5)
 					->rows();


### PR DESCRIPTION
This fixes an issue where, if there were two posts with the same alias
but one was marked as deleted, the system would sometimes attempt to
load the deleted entry. Also fixes an issue with displaying deleted
entries in the 'popular entries' list.

Fixes: https://nanohub.org/support/ticket/335993