### PR TITLE
[fix] Ensure project feed time is correctly coverted

### DIFF
--- a/core/components/com_projects/helpers/html.php
+++ b/core/components/com_projects/helpers/html.php
@@ -70,11 +70,11 @@ class Html extends Obj
 		}
 		elseif ($lapsed > 86400 && $current['year'] != $parsed['year'])
 		{
-			return Date::of($timestamp)->toLocal('M j, Y');
+			return Date::of($time)->toLocal('M j, Y');
 		}
 		elseif ($lapsed > 86400)
 		{
-			return Date::of($timestamp)->toLocal('M j') . ' at ' . Date::of($timestamp)->toLocal('h:ia');
+			return Date::of($time)->toLocal('M j \a\t h:i A');
 		}
 		else
 		{


### PR DESCRIPTION
Project Feed time was displaying in GMT instead of local time.
It seems there was an issue with it recieving a time string
ran through strtotime as well as an issue with the way the time was
combined.

refs: https://qubeshub.org/support/tickets/1326