### PR TITLE
[fix] ensure project file preview doesn't appear offscreen

### DIFF
--- a/core/plugins/projects/files/assets/js/files.js
+++ b/core/plugins/projects/files/assets/js/files.js
@@ -1029,7 +1029,8 @@ HUB.ProjectFiles = {
 
 		if ($('.main-content').length) {
 			subtract = $('.main-content').offset();
-			subtract.left -= $('.main-content').css('margin-left').replace('px', '');
+			subtract.left -= $('.main-content').width() * .25;
+			subtract.top += $('.main-content').height() * .5;
 		}
 
 		if ($('#plg-content').length > 0 && div.length > 0)


### PR DESCRIPTION
The project file preview was occasionally showing out of view.

refs: https://purr.purdue.edu/support/ticket/1975