### PR TITLE
[fix] remove Solr term Suggester due to issues

### DIFF
--- a/core/components/com_search/site/views/solr/tmpl/display.php
+++ b/core/components/com_search/site/views/solr/tmpl/display.php
@@ -34,8 +34,7 @@ defined('_HZEXEC_') or die();
 
 $this->css('search-enhanced')
 	->css('jquery.datetimepicker.css', 'system');
-$this->js('suggest')
-	->js('solr')
+$this->js('solr')
 	->js('jquery.datetimepicker', 'system');
 
 $terms = isset($this->terms) ? $this->terms : '';


### PR DESCRIPTION
The termSuggester was being flagged as having potential
sql injection attacks anytime a query with multiple quoted words
was separated with the words "AND" or "OR".

refs: https://habricentral.org/support/ticket/840