### PR TITLE
Series attachments fix

### DIFF
--- a/core/components/com_publications/models/attachments/publication.php
+++ b/core/components/com_publications/models/attachments/publication.php
@@ -395,7 +395,7 @@ class Publication extends Base
 			$ordering = $i + 1;
 
 			$row = new \Components\Publications\Tables\Version($this->_parent->_db);
-			if (!$row->loadVersion($identifier, 'current'))
+			if (!$row->load($identifier))
 			{
 				$this->setError(Lang::txt('PLG_PROJECTS_PUBLICATIONS_PUBLICATION_NOT_FOUND'));
 				return false;


### PR DESCRIPTION
Replace loadVersion() that looks up by `publication_id` with the `load` that looks up by `id`, since the view is providing the `id`s