### PR TITLE
[fix] Ensure returned value is an integer

### DIFF
--- a/core/components/com_wiki/site/controllers/pages.php
+++ b/core/components/com_wiki/site/controllers/pages.php
@@ -625,7 +625,7 @@ class Pages extends SiteController
 		}
 
 		$revision->set('page_id', $this->page->get('id'));
-		$revision->set('version', $revision->get('version') + 1);
+		$revision->set('version', intval($revision->get('version')) + 1);
 
 		if ($this->page->param('mode', 'wiki') == 'knol')
 		{


### PR DESCRIPTION
Fixes: https://help.hubzero.org/support/ticket/11659