### PR TITLE
[fix] specify HTMLPurifier tmp file location

### DIFF
--- a/core/components/com_groups/models/page/version.php
+++ b/core/components/com_groups/models/page/version.php
@@ -240,6 +240,7 @@ class Version extends Model
 
 		// Turn OFF linkify
 		$options['AutoFormat.Linkify'] = false;
+		$options['Cache.SerializerPath'] = App::get('config')->get('tmp_path');
 
 		// Run hubzero html sanitize
 		return \Hubzero\Utility\Sanitize::html($content, $options);


### PR DESCRIPTION
Permissions issues were occuring within the vendor directory for
HTMLPurifier. Set the configuration so it knows to put tmp files into
the CMS tmp directory.

refs: https://mygeohub.org/support/ticket/1332