### PR TITLE
[fix] Use proper method for checking if is main license

### DIFF
--- a/core/components/com_publications/admin/views/licenses/tmpl/edit.php
+++ b/core/components/com_publications/admin/views/licenses/tmpl/edit.php
@@ -105,7 +105,7 @@ function submitbutton(pressbutton)
 					</tr>
 					<tr>
 						<th><?php echo Lang::txt('COM_PUBLICATIONS_FIELD_DEFAULT'); ?></th>
-						<td><?php echo $this->row->main == 1 ? Lang::txt('COM_PUBLICATIONS_LICENSE_YES') : Lang::txt('COM_PUBLICATIONS_LICENSE_NO') ; ?></td>
+						<td><?php echo $this->row->isMain() ? Lang::txt('COM_PUBLICATIONS_LICENSE_YES') : Lang::txt('COM_PUBLICATIONS_LICENSE_NO') ; ?></td>
 					</tr>
 				<?php if ($this->row->id) { ?>
 					<tr>

--- a/core/components/com_publications/admin/views/licenses/tmpl/edit.php
+++ b/core/components/com_publications/admin/views/licenses/tmpl/edit.php
@@ -105,7 +105,7 @@ function submitbutton(pressbutton)
 					</tr>
 					<tr>
 						<th><?php echo Lang::txt('COM_PUBLICATIONS_FIELD_DEFAULT'); ?></th>
-						<td><?php echo $this->row->isMain() ? Lang::txt('COM_PUBLICATIONS_LICENSE_YES') : Lang::txt('COM_PUBLICATIONS_LICENSE_NO') ; ?></td>
+						<td><?php echo $this->row->isMain() ? Lang::txt('COM_PUBLICATIONS_LICENSE_YES') : Lang::txt('COM_PUBLICATIONS_LICENSE_NO'); ?></td>
 					</tr>
 				<?php if ($this->row->id) { ?>
 					<tr>

--- a/core/components/com_publications/models/orm/license.php
+++ b/core/components/com_publications/models/orm/license.php
@@ -96,14 +96,14 @@ class License extends Relational
 	 */
 	public function automaticOrdering($data)
 	{
-		if (!isset($data['ordering']))
+		if (!isset($data['ordering']) || !$data['ordering'])
 		{
 			$last = self::all()
 				->select('ordering')
 				->order('ordering', 'desc')
 				->row();
 
-			$data['ordering'] = $last->ordering + 1;
+			$data['ordering'] = intval($last->get('ordering', 0)) + 1;
 		}
 
 		return $data['ordering'];


### PR DESCRIPTION
Can't directly call `main` like a property as it will, instead, call the
`main()` method. Use the `isMain()` method or getter.

Fixes: https://purr.purdue.edu/support/ticket/1983