### PR TITLE
[fix] Make sure method called returns an object

### DIFF
--- a/core/components/com_resources/models/author.php
+++ b/core/components/com_resources/models/author.php
@@ -36,7 +36,7 @@ use Components\Members\Models\Member;
 
 require_once __DIR__ . DS . 'author' . DS . 'role.php';
 require_once __DIR__ . DS . 'author' . DS . 'role' . DS . 'type.php';
-require_once(dirname(dirname(__DIR__)) . DS . 'com_members' . DS . 'models' . DS . 'member.php');
+require_once \Component::path('com_members') . DS . 'models' . DS . 'member.php';
 
 /**
  * Resource license model
@@ -153,7 +153,7 @@ class Author extends Relational
 	 */
 	public function populateFromProfile()
 	{
-		$profile = Member::one($this->profile->get('id'));
+		$profile = Member::oneOrNew($this->profile->get('id'));
 
 		if (!$profile->get('id'))
 		{


### PR DESCRIPTION
Using `Member::one()` will return a boolean if it fails to find a record
which wil throw an error on following lines that are expecting an object