### PR TITLE
[fix] Updating .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ before_script:
   - composer require squizlabs/php_codesniffer:2.*
   - mkdir -p ~/build
   - git clone --branch hubzero-cms-2.1 --depth=1 https://github.com/hubzero/standards ~/build/standards
-  - FILES=`git diff --name-only $TRAVIS_COMMIT_RANGE`
-  - echo "Sniffing:"
-  - echo $FILES
+  - changes=`git diff --name-only $TRAVIS_COMMIT_RANGE`
+  - for f in $changes; do if [[ -f "$f" ]]; then files_exist="$files_exist $f"; else files_removed="$files_removed $f"; fi done
+  - echo $files_exist
+  - echo $files_removed
 script:
-- vendor/squizlabs/php_codesniffer/scripts/phpcs -np --standard=~/build/standards/Php/ruleset.xml $FILES
+- vendor/squizlabs/php_codesniffer/scripts/phpcs -np --standard=~/build/standards/Php/ruleset.xml $files_exist


### PR DESCRIPTION
When files are removed, the sniffer has problems scanning them.  This should filter files based on whether they exist or not before sending them to phpcs.