### PR TITLE
[fix] Ensure onMemberContribs is passed array for publications

### DIFF
--- a/core/plugins/members/publications/publications.php
+++ b/core/plugins/members/publications/publications.php
@@ -158,7 +158,7 @@ class plgMembersPublications extends \Hubzero\Plugin\Plugin
 			$ars = $this->onMembersContributionsAreas();
 			if (!isset($areas[$this->_name])
 			 && !in_array($this->_name, $areas)
-			 && !array_intersect($areas, array_keys($ars['publications'])))
+			 && !array_intersect($areas, array_keys($ars)))
 			{
 				return array();
 			}


### PR DESCRIPTION
Publications was given a non array value in array_keys method
causing an error.

fixes: https://nanohub.org/support/ticket/341112