### PR TITLE
 Updated get requests for groups and projects

### DIFF
--- a/core/components/com_groups/admin/controllers/manage.php
+++ b/core/components/com_groups/admin/controllers/manage.php
@@ -671,21 +671,10 @@ class Manage extends AdminController
 
 		// instantiate new gitlab client
 		$client = new Gitlab($gitlabUrl, $gitlabKey);
-
-		// get list of groups
-		$groups = $client->groups();
-
-		// attempt to get already existing group
-		$gitLabGroup = null;
-		foreach ($groups as $g)
-		{
-			if ($groupName == $g['name'])
-			{
-				$gitLabGroup = $g;
-				break;
-			}
-		}
-
+		
+		// Search for group in Gitlab
+		$gitLabGroup = $client->groups($groupName);
+		
 		// create group if doesnt exist
 		if ($gitLabGroup == null)
 		{
@@ -694,20 +683,24 @@ class Manage extends AdminController
 				'path' => strtolower($groupName)
 			));
 		}
-
-		//get groups projects
-		$projects = $client->projects();
-
-		// attempt to get already existing project
-		$gitLabProject = null;
-		foreach ($projects as $p)
+		elseif (sizeof($gitLabGroup) > 1)
+		{  // If search returns more than one match, return with error.
+			Notify::error(Lang::txt('COM_GROUPS_GITLAB_GET_GROUPS_MORE_THAN_ONE' . $groupName));
+			return;
+		} 
+		elseif (sizeof($gitLabGroup) == 1)
 		{
-			if ($projectName == $p['name'] && $p['namespace']['id'] == $gitLabGroup['id'])
-			{
-				$gitLabProject = $p;
-				break;
-			}
+			// Grab first element of array
+			$gitLabGroup = $gitLabGroup[0];
 		}
+		else
+		{  
+			Notify::error(Lang::txt('COM_GROUPS_GITLAB_GET_GROUPS_UNKNOWN_ERROR'));
+			return;
+		}
+
+		//Search for project in Gitlab
+		$gitLabProject = $client->projects($projectName);
 
 		// create project if doesnt exist
 		if ($gitLabProject == null)
@@ -722,7 +715,22 @@ class Manage extends AdminController
 				'snippets_enabled'       => true,
 			));
 		}
-
+		elseif (sizeof($gitLabProject) > 1)
+		{  // If search returns more than one match return with error.
+			Notify::error(Lang::txt('COM_GROUPS_GITLAB_PROJECTS_MORE_THAN_ONE' . $projectName));
+			return;
+		}
+		elseif (sizeof($gitLabProject) == 1)
+		{
+			// Grab first element of array
+			$gitLabProject = $gitLabProject[0];
+		}
+		else
+		{  
+			Notify::error(Lang::txt('COM_GROUPS_GITLAB_GET_PROJECTS_UNKNOWN_ERROR'));
+			return;
+		}
+		
 		// path to group folder
 		$uploadPath = PATH_APP . DS . trim($this->config->get('uploadpath', '/site/groups'), DS) . DS . $group->get('gidNumber');
 

--- a/core/components/com_groups/admin/controllers/manage.php
+++ b/core/components/com_groups/admin/controllers/manage.php
@@ -671,10 +671,10 @@ class Manage extends AdminController
 
 		// instantiate new gitlab client
 		$client = new Gitlab($gitlabUrl, $gitlabKey);
-		
+
 		// Search for group in Gitlab
 		$gitLabGroup = $client->groups($groupName);
-		
+
 		// create group if doesnt exist
 		if ($gitLabGroup == null)
 		{
@@ -683,18 +683,18 @@ class Manage extends AdminController
 				'path' => strtolower($groupName)
 			));
 		}
-		elseif (sizeof($gitLabGroup) > 1)
+		elseif (count($gitLabGroup) > 1)
 		{  // If search returns more than one match, return with error.
 			Notify::error(Lang::txt('COM_GROUPS_GITLAB_GET_GROUPS_MORE_THAN_ONE' . $groupName));
 			return;
-		} 
-		elseif (sizeof($gitLabGroup) == 1)
+		}
+		elseif (count($gitLabGroup) == 1)
 		{
 			// Grab first element of array
 			$gitLabGroup = $gitLabGroup[0];
 		}
 		else
-		{  
+		{
 			Notify::error(Lang::txt('COM_GROUPS_GITLAB_GET_GROUPS_UNKNOWN_ERROR'));
 			return;
 		}
@@ -715,22 +715,22 @@ class Manage extends AdminController
 				'snippets_enabled'       => true,
 			));
 		}
-		elseif (sizeof($gitLabProject) > 1)
+		elseif (count($gitLabProject) > 1)
 		{  // If search returns more than one match return with error.
 			Notify::error(Lang::txt('COM_GROUPS_GITLAB_PROJECTS_MORE_THAN_ONE' . $projectName));
 			return;
 		}
-		elseif (sizeof($gitLabProject) == 1)
+		elseif (count($gitLabProject) == 1)
 		{
 			// Grab first element of array
 			$gitLabProject = $gitLabProject[0];
 		}
 		else
-		{  
+		{
 			Notify::error(Lang::txt('COM_GROUPS_GITLAB_GET_PROJECTS_UNKNOWN_ERROR'));
 			return;
 		}
-		
+
 		// path to group folder
 		$uploadPath = PATH_APP . DS . trim($this->config->get('uploadpath', '/site/groups'), DS) . DS . $group->get('gidNumber');
 

--- a/core/components/com_groups/admin/language/en-GB/en-GB.com_groups.ini
+++ b/core/components/com_groups/admin/language/en-GB/en-GB.com_groups.ini
@@ -505,6 +505,10 @@ COM_GROUPS_PULL_SUCCESS="The following groups successfully merged in new code"
 COM_GROUPS_PULL_FAIL="The following groups failed to pull new code"
 COM_GROUPS_MERGE="Merge Changes"
 COM_GROUPS_MERGE_CODE="Merge Groups Code"
+COM_GROUPS_GITLAB_GET_GROUPS_MORE_THAN_ONE="More than one group found in Gitlab for group: "
+COM_GROUPS_GITLAB_GET_GROUPS_UNKNOWN_ERROR="Unknown Error getting Gitlab group, see Gitlab API."
+COM_GROUPS_GITLAB_PROJECTS_MORE_THAN_ONE="More than one project found in Gitlab for project: "
+COM_GROUPS_GITLAB_GET_PROJECTS_UNKNOWN_ERROR="Unknown Error getting Gitlab Projects, see Gitlab API."
 
 ; Configuration
 COM_GROUPS_CONFIG_FIELDSET_GENERAL="General"

--- a/core/components/com_groups/helpers/gitlab.php
+++ b/core/components/com_groups/helpers/gitlab.php
@@ -76,7 +76,7 @@ class Gitlab
 			'headers' => array('PRIVATE-TOKEN' => $token)
 		);
 		$this->client = new \GuzzleHttp\Client;
-		
+
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Gitlab
 		$resource = 'projects' . DS . $params['id'] . DS . 'repository' . DS . 'branches' . DS . $params['branch'] . DS . 'protect';
 		return $this->_putRequest($resource, array());
 	}
-	
+
 	/**
 	 * Generic Get Request
 	 * 
@@ -195,7 +195,7 @@ class Gitlab
 
 		$requestOptions = array_merge(array('query' => $params), $this->options);
 		$response = $this->client->request('POST', $this->url . DS . $resource, $requestOptions);
-	
+
 		return json_decode($response->getBody(), true);
 	}
 

--- a/core/components/com_groups/helpers/gitlab.php
+++ b/core/components/com_groups/helpers/gitlab.php
@@ -76,19 +76,17 @@ class Gitlab
 			'headers' => array('PRIVATE-TOKEN' => $token)
 		);
 		$this->client = new \GuzzleHttp\Client;
-
-		// Method removed in Guzzle 6.0
-		//$this->client->setDefaultOption('verify', false);
+		
 	}
 
 	/**
-	 * Get List of groups on Gitlab
+	 * Search List of groups on Gitlab
 	 * 
 	 * @return  array
 	 */
-	public function groups()
+	public function groups($groupName)
 	{
-		return $this->_getRequest('groups');
+		return $this->_getRequest('groups', $groupName);
 	}
 
 	/**
@@ -121,13 +119,13 @@ class Gitlab
 	}
 
 	/**
-	 * Get List of projects on gitlab
+	 * Search list of projects on gitlab
 	 * 
 	 * @return  array
 	 */
-	public function projects()
+	public function projects($projectName)
 	{
-		return $this->_getRequest('projects');
+		return $this->_getRequest('projects', $projectName);
 	}
 
 	/**
@@ -170,24 +168,17 @@ class Gitlab
 		$resource = 'projects' . DS . $params['id'] . DS . 'repository' . DS . 'branches' . DS . $params['branch'] . DS . 'protect';
 		return $this->_putRequest($resource, array());
 	}
-
+	
 	/**
 	 * Generic Get Request
 	 * 
 	 * @param   string  $url
 	 * @return  string
 	 */
-	private function _getRequest($resource)
+	private function _getRequest($resource, $ResourceName)
 	{
-		// add our auth header
-		$headers = array('PRIVATE-TOKEN' => $this->token);
-
-		// init get request
-		$response = $this->client->request('GET', $this->url . DS . $resource, $this->options);
-
-		// json() method removed in Guzzle 6.0
-		// return $response->json();
-
+		// Get response restricted by current owned, i.e. the current Gitlab users that owns the API key that is configured on this hub
+		$response = $this->client->request('GET', $this->url . DS . $resource . '?owned=true&search=' . $ResourceName, $this->options);
 		return json_decode($response->getBody(), true);
 	}
 
@@ -204,10 +195,7 @@ class Gitlab
 
 		$requestOptions = array_merge(array('query' => $params), $this->options);
 		$response = $this->client->request('POST', $this->url . DS . $resource, $requestOptions);
-
-		// json() method removed in Guzzle 6.0
-		// return $response->json();
-
+	
 		return json_decode($response->getBody(), true);
 	}
 
@@ -224,9 +212,6 @@ class Gitlab
 
 		// init post request
 		$response = $this->client->request('PUT', $this->url . DS . $resource, $requestOptions);
-
-		// json() method removed in Guzzle 6.0
-		// return $response->json();
 
 		return json_decode($response->getBody(), true);
 	}


### PR DESCRIPTION
 Updated get requests for groups and projects to use Gitlab's API search function and to only get groups or project for the current hub Gitlab user instead of all groups or project on Gitlab.

Fixes https://qubeshub.org/support/ticket/1349 .