### PR TITLE
[fix] Don't display deleted content

### DIFF
--- a/core/components/com_wiki/site/views/special/tmpl/filelist.php
+++ b/core/components/com_wiki/site/views/special/tmpl/filelist.php
@@ -63,6 +63,7 @@ $rows = \Components\Wiki\Models\Attachment::all()
 	->join($pages, $pages . '.id', $attach . '.page_id')
 	->whereEquals($pages . '.scope', $this->book->get('scope'))
 	->whereEquals($pages . '.scope_id', $this->book->get('scope_id'))
+	->whereEquals($pages . '.state', '1')
 	->paginated()
 	->rows();
 


### PR DESCRIPTION
The special view for listing all files in a wiki would show files from
deleted pages as well despite them not being accessible.

Fixes: https://nciphub.org/support/ticket/1539