### PR TITLE
[refactor] Changing input type to 'email'

### DIFF
--- a/core/components/com_members/admin/views/members/tmpl/edit_user.php
+++ b/core/components/com_members/admin/views/members/tmpl/edit_user.php
@@ -76,7 +76,7 @@ if (substr($this->profile->get('email'), -8) == '@invalid')
 
 			<div class="input-wrap">
 				<label id="field_email-lbl" for="field_email" class="required"><?php echo Lang::txt('COM_MEMBERS_FIELD_EMAIL'); ?> <span class="required star"><?php echo Lang::txt('JOPTION_REQUIRED'); ?></span></label>
-				<input type="text" name="fields[email]" class="validate-email required" id="field_email" value="<?php echo $this->escape($this->profile->get('email')); ?>" />
+				<input type="email" name="fields[email]" class="validate-email required" id="field_email" value="<?php echo $this->escape($this->profile->get('email')); ?>" />
 			</div>
 
 			<fieldset>

--- a/core/components/com_members/site/views/register/tmpl/default.php
+++ b/core/components/com_members/site/views/register/tmpl/default.php
@@ -210,10 +210,10 @@ if ($form_redirect = Request::getString('return', '', 'get'))
 				<legend><?php echo Lang::txt('COM_MEMBERS_REGISTER_LOGIN_INFORMATION'); ?></legend>
 
 					<?php if ($this->registrationUsername == Field::STATE_READONLY) { ?>
-						<label for="login">
+						<label for="userlogin">
 							<?php Lang::txt('COM_MEMBERS_REGISTER_USER_LOGIN'); ?><br />
 							<?php echo $this->escape($this->registration['login']); ?>
-							<input name="login" id="login" type="hidden" value="<?php echo $this->escape($this->registration['login']); ?>" />
+							<input name="login" id="userlogin" type="hidden" value="<?php echo $this->escape($this->registration['login']); ?>" />
 						</label>
 					<?php } else if ($this->registrationUsername != Field::STATE_HIDDEN) { ?>
 						<label for="userlogin" <?php echo !empty($this->xregistration->_invalid['login']) ? 'class="fieldWithErrors"' : ''; ?>>
@@ -344,7 +344,7 @@ if ($form_redirect = Request::getString('return', '', 'get'))
 							<div class="col span6">
 								<label for="email"<?php echo !empty($this->xregistration->_invalid['email']) ? ' class="fieldWithErrors"' : ''; ?>>
 									<?php echo Lang::txt('COM_MEMBERS_REGISTER_VALID_EMAIL'); ?> <?php echo $this->registrationEmail == Field::STATE_REQUIRED ? '<span class="required">' . Lang::txt('COM_MEMBERS_REGISTER_FORM_REQUIRED') . '</span>' : ''; ?>
-									<input name="email" id="email" type="text" value="<?php echo $this->escape($this->registration['email']); ?>" />
+									<input name="email" id="email" type="email" value="<?php echo $this->escape($this->registration['email']); ?>" />
 									<?php echo !empty($this->xregistration->_invalid['email']) ? '<span class="error">' . $this->xregistration->_invalid['email'] . '</span>' : ''; ?>
 								</label>
 							</div>
@@ -359,7 +359,7 @@ if ($form_redirect = Request::getString('return', '', 'get'))
 								?>
 								<label for="email2"<?php echo !empty($this->xregistration->_invalid['confirmEmail']) ? ' class="fieldWithErrors"' : ''; ?>>
 									<?php echo Lang::txt('COM_MEMBERS_REGISTER_CONFIRM_EMAIL'); ?> <?php echo ($this->registrationConfirmEmail == Field::STATE_REQUIRED) ? '<span class="required">'.Lang::txt('COM_MEMBERS_REGISTER_FORM_REQUIRED').'</span>' : ''; ?>
-									<input name="email2" id="email2" type="text" value="<?php echo $this->escape($this->registration['confirmEmail']); ?>" />
+									<input name="email2" id="email2" type="email" value="<?php echo $this->escape($this->registration['confirmEmail']); ?>" />
 									<?php echo !empty($this->xregistration->_invalid['confirmEmail']) ? '<span class="error">' . $this->xregistration->_invalid['confirmEmail'] . '</span>' : ''; ?>
 								</label>
 							</div>
@@ -626,7 +626,7 @@ if ($form_redirect = Request::getString('return', '', 'get'))
 		<?php } ?>
 
 		<p class="submit">
-			<input type="submit" name="<?php echo $this->task; ?>" value="<?php echo Lang::txt('COM_MEMBERS_REGISTER_BUTTON_' . strtoupper($this->task)); ?>" />
+			<input type="submit" class="btn btn-success" name="<?php echo $this->task; ?>" value="<?php echo Lang::txt('COM_MEMBERS_REGISTER_BUTTON_' . strtoupper($this->task)); ?>" />
 		</p>
 
 		<input type="hidden" name="option" value="<?php echo $this->option; ?>" />

--- a/core/components/com_support/admin/views/tickets/tmpl/add.php
+++ b/core/components/com_support/admin/views/tickets/tmpl/add.php
@@ -186,12 +186,12 @@ function submitbutton(pressbutton)
 		</div>
 	</div>
 
-	<input type="hidden" name="ticket[referrer]" value="<?php echo Request::getString('HTTP_REFERER', NULL, 'server'); ?>" />
+	<input type="hidden" name="ticket[referrer]" value="<?php echo Request::getString('HTTP_REFERER', null, 'server'); ?>" />
 	<input type="hidden" name="ticket[os]" value="<?php echo $browser->platform(); ?>" />
 	<input type="hidden" name="osver" value="<?php echo $browser->platformVersion(); ?>" />
 	<input type="hidden" name="ticket[browser]" value="<?php echo $browser->name(); ?>" />
 	<input type="hidden" name="browserver" value="<?php echo $browser->version(); ?>" />
-	<input type="hidden" name="ticket[hostname]" value="<?php echo gethostbyaddr(Request::getString('REMOTE_ADDR','','server')); ?>" />
+	<input type="hidden" name="ticket[hostname]" value="<?php echo gethostbyaddr(Request::getString('REMOTE_ADDR', '', 'server')); ?>" />
 	<input type="hidden" name="ticket[uas]" value="<?php echo Request::getString('HTTP_USER_AGENT', '', 'server'); ?>" />
 	<input type="hidden" name="ticket[open]" value="1" />
 

--- a/core/components/com_support/admin/views/tickets/tmpl/add.php
+++ b/core/components/com_support/admin/views/tickets/tmpl/add.php
@@ -79,7 +79,7 @@ function submitbutton(pressbutton)
 				</div>
 				<div class="input-wrap">
 					<label for="field-email"><?php echo Lang::txt('COM_SUPPORT_TICKET_FIELD_EMAIL'); ?>:</label>
-					<input type="text" name="ticket[email]" id="field-email" value="<?php echo $this->escape($this->row->get('email')); ?>" size="50" />
+					<input type="email" name="ticket[email]" id="field-email" value="<?php echo $this->escape($this->row->get('email')); ?>" size="50" />
 				</div>
 				<div class="input-wrap">
 					<label for="field-report"><?php echo Lang::txt('COM_SUPPORT_TICKET_FIELD_DESCRIPTION'); ?>:</label>

--- a/core/components/com_support/site/views/tickets/tmpl/new.php
+++ b/core/components/com_support/site/views/tickets/tmpl/new.php
@@ -100,7 +100,7 @@ if (User::isGuest())
 
 			<label for="reporter_email"<?php echo ($this->getError() && !$this->row->get('email')) ? ' class="fieldWithErrors"' : ''; ?>>
 				<?php echo Lang::txt('COM_SUPPORT_EMAIL'); ?> <span class="required"><?php echo Lang::txt('COM_SUPPORT_REQUIRED'); ?></span>
-				<input type="text" name="reporter[email]" value="<?php echo $this->escape($this->row->get('email', $this->row->submitter->get('email'))); ?>" id="reporter_email" />
+				<input type="email" name="reporter[email]" value="<?php echo $this->escape($this->row->get('email', $this->row->submitter->get('email'))); ?>" id="reporter_email" />
 			</label>
 			<?php if ($this->getError() && !$this->row->get('email')) { ?>
 				<p class="error"><?php echo Lang::txt('COM_SUPPORT_ERROR_MISSING_EMAIL'); ?></p>

--- a/core/modules/mod_rapid_contact/tmpl/default.php
+++ b/core/modules/mod_rapid_contact/tmpl/default.php
@@ -67,7 +67,7 @@ $this->css();
 					<?php echo $this->email_label; ?> <span class="required"><?php echo Lang::txt('JREQUIRED'); ?></span>
 				</label>
 				<span class="input">
-					<input type="text" id="contact-email<?php echo $this->module->id; ?>" name="rp[email]" value="<?php echo $this->escape($this->posted['email']); ?>" />
+					<input type="email" id="contact-email<?php echo $this->module->id; ?>" name="rp[email]" value="<?php echo $this->escape($this->posted['email']); ?>" />
 				</span>
 			</div>
 

--- a/core/modules/mod_reportproblems/tmpl/default.php
+++ b/core/modules/mod_reportproblems/tmpl/default.php
@@ -90,7 +90,7 @@ defined('_HZEXEC_') or die();
 						<?php if (!$this->guestOrTmpAccount) { ?>
 							<input type="hidden" name="reporter[email]" id="trEmail" value="<?php echo $this->escape(User::get('email')); ?>" /><br /><span class="info-block"><?php echo $this->escape(User::get('email')); ?></span>
 						<?php } else { ?>
-							<input type="text" name="reporter[email]" id="trEmail" value="" />
+							<input type="email" name="reporter[email]" id="trEmail" value="" />
 						<?php } ?>
 					</label>
 


### PR DESCRIPTION
The email input type offers better semantics, will prompt mobile devices
to use a keyboard more appropriate for typing addresses (easy access to
'@'), and falls back to standard 'text' field.