### PR TITLE
[fix] Fixing how property is retrieved

### DIFF
--- a/core/components/com_resources/models/doi.php
+++ b/core/components/com_resources/models/doi.php
@@ -188,7 +188,7 @@ class Doi extends Relational
 		else
 		{
 			$this->set('doi', $doi);
-			$this->set('doi_shoulder', $service->configs()->get('doi_shoulder'));
+			$this->set('doi_shoulder', $service->configs()->shoulder);
 		}
 
 		// Register the DOI name and URL to complete the DOI registration.


### PR DESCRIPTION
DOI Service config is a stdClass, not a hubzero registry class. This
means retrieval via direct property rather than a getter.