### PR TITLE
[fix] Set the `option` var used in asset helpers

### DIFF
--- a/core/components/com_groups/helpers/pages.php
+++ b/core/components/com_groups/helpers/pages.php
@@ -676,6 +676,7 @@ class Pages
 		$view->version    = $version;
 		$view->authorized = $authorized;
 		$view->config     = Component::params('com_groups');
+		$view->option     = 'com_groups';
 
 		// return rendered template
 		return $view->loadTemplate();


### PR DESCRIPTION
Fixes: https://qubeshub.org/support/ticket/1360