### PR TITLE
[fix] Updating documentaiton to use https

### DIFF
--- a/core/plugins/content/formathtml/macros/video.php
+++ b/core/plugins/content/formathtml/macros/video.php
@@ -63,21 +63,21 @@ class Video extends Macro
 		$txt = array();
 		$txt['wiki'] = 'Embeds a video into the Page';
 		$txt['html'] = '<p>Embeds a video into the Page. Accepts either full video URL (YouTube, Vimeo, Kaltura, Blip TV) or a file name or path.</p>
-						<p><strong>Youtube URL:</strong> http://www.youtube.com/watch?v=<span class="highlight">FgfGOEpZEOw</span></p>
+						<p><strong>Youtube URL:</strong> https://www.youtube.com/watch?v=<span class="highlight">FgfGOEpZEOw</span></p>
 						<p>Examples:</p>
 						<ul>
 							<li><code>[[Video(MyVideo.m4v)]]</code></li>
-							<li><code>[[Video(http://www.youtube.com/watch?v=FgfGOEpZEOw)]]</code></li>
-							<li><code>[[Video(http://blip.tv/play/hNNNg4uIDAI.x?p=1)]]</code></li>
-							<li><code>[[Video(http://player.vimeo.com/video/67115692)]]</code></li>
+							<li><code>[[Video(https://www.youtube.com/watch?v=FgfGOEpZEOw)]]</code></li>
+							<li><code>[[Video(https://blip.tv/play/hNNNg4uIDAI.x?p=1)]]</code></li>
+							<li><code>[[Video(https://player.vimeo.com/video/67115692)]]</code></li>
 						</ul>
 						<p>Size attributes may be given as single numeric values or with units (%, em, px). When an attribute name is given (e.g., width=600, height=338), order does not matter. Attribute values may be quoted but are not required to be. When a name attribute is not give (e.g., 600, 338), the first value will be set as width and the second value as height.</p>
 						<p>Examples:</p>
 						<ul>
 							<li><code>[[Video(MyVideo.m4v, width="600", height="338")]]</code></li>
-							<li><code>[[Video(http://www.youtube.com/watch?v=FgfGOEpZEOw, width=600px, height=338px)]]</code></li>
-							<li><code>[[Video(http://blip.tv/play/hNNNg4uIDAI.x?p=1, 640, 380)]]</code> - width 640px, height 380px</li>
-							<li><code>[[Video(http://player.vimeo.com/video/67115692, 100%)]]</code> - width of 100%</li>
+							<li><code>[[Video(https://www.youtube.com/watch?v=FgfGOEpZEOw, width=600px, height=338px)]]</code></li>
+							<li><code>[[Video(https://blip.tv/play/hNNNg4uIDAI.x?p=1, 640, 380)]]</code> - width 640px, height 380px</li>
+							<li><code>[[Video(https://player.vimeo.com/video/67115692, 100%)]]</code> - width of 100%</li>
 						</ul>';
 
 		return $txt['html'];

--- a/core/plugins/wiki/parserdefault/macros/video.php
+++ b/core/plugins/wiki/parserdefault/macros/video.php
@@ -62,21 +62,21 @@ class VideoMacro extends WikiMacro
 		$txt = array();
 		$txt['wiki'] = 'Embeds a video into the Page';
 		$txt['html'] = '<p>Embeds a video into the Page. Accepts either full video URL (YouTube, Vimeo, Kaltura, Blip TV) or a file name or path.</p>
-						<p><strong>Youtube URL:</strong> http://www.youtube.com/watch?v=<span class="highlight">FgfGOEpZEOw</span></p>
+						<p><strong>Youtube URL:</strong> https://www.youtube.com/watch?v=<span class="highlight">FgfGOEpZEOw</span></p>
 						<p>Examples:</p>
 						<ul>
 							<li><code>[[Video(MyVideo.m4v)]]</code></li>
-							<li><code>[[Video(http://www.youtube.com/watch?v=FgfGOEpZEOw)]]</code></li>
-							<li><code>[[Video(http://blip.tv/play/hNNNg4uIDAI.x?p=1)]]</code></li>
-							<li><code>[[Video(http://player.vimeo.com/video/67115692)]]</code></li>
+							<li><code>[[Video(https://www.youtube.com/watch?v=FgfGOEpZEOw)]]</code></li>
+							<li><code>[[Video(https://blip.tv/play/hNNNg4uIDAI.x?p=1)]]</code></li>
+							<li><code>[[Video(https://player.vimeo.com/video/67115692)]]</code></li>
 						</ul>
 						<p>Size attributes may be given as single numeric values or with units (%, em, px). When an attribute name is given (e.g., width=600, height=338), order does not matter. Attribute values may be quoted but are not required to be. When a name attribute is not give (e.g., 600, 338), the first value will be set as width and the second value as height.</p>
 						<p>Examples:</p>
 						<ul>
 							<li><code>[[Video(MyVideo.m4v, width="600", height="338")]]</code></li>
-							<li><code>[[Video(http://www.youtube.com/watch?v=FgfGOEpZEOw, width=600px, height=338px)]]</code></li>
-							<li><code>[[Video(http://blip.tv/play/hNNNg4uIDAI.x?p=1, 640, 380)]]</code> - width 640px, height 380px</li>
-							<li><code>[[Video(http://player.vimeo.com/video/67115692, 100%)]]</code> - width of 100%</li>
+							<li><code>[[Video(https://www.youtube.com/watch?v=FgfGOEpZEOw, width=600px, height=338px)]]</code></li>
+							<li><code>[[Video(https://blip.tv/play/hNNNg4uIDAI.x?p=1, 640, 380)]]</code> - width 640px, height 380px</li>
+							<li><code>[[Video(https://player.vimeo.com/video/67115692, 100%)]]</code> - width of 100%</li>
 						</ul>';
 
 		return $txt['html'];


### PR DESCRIPTION
Help text used http links for examples. This caused confusion with
allowed URLs (mixed source content is blocked by browsers under https).

Refs: https://qubeshub.org/support/ticket/1285