### PR TITLE
[fix] Fixing how new page link is built

### DIFF
--- a/core/components/com_wiki/site/views/pages/tmpl/submenu.php
+++ b/core/components/com_wiki/site/views/pages/tmpl/submenu.php
@@ -40,11 +40,11 @@ if (!isset($this->controller))
 }
 
 if ($tmpl != 'component' && $this->sub) { ?>
-	<div id="<?php echo ($this->sub) ? 'sub-content-header-extra' : 'content-header-extra'; ?>">
-		<ul id="<?php echo ($this->sub) ? 'page_options' : 'useroptions'; ?>">
+	<div id="sub-content-header-extra">
+		<ul id="page_options">
 			<?php if (!User::isGuest() && $this->page->access('create')) { ?>
 				<li class="page-new">
-					<a class="icon-add add btn tooltips" title="<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>" href="<?php echo Route::url($this->page->link('base') . '&' . ($this->sub ? 'action' : 'task') . '=new'); ?>">
+					<a class="icon-add add btn tooltips" title="<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>" href="<?php echo Route::url($this->page->link('base') . '&action=new'); ?>">
 						<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>
 					</a>
 				</li>
@@ -102,7 +102,7 @@ if ($tmpl != 'component' && $this->sub) { ?>
 						<span class="icon-clock"><?php echo Lang::txt('COM_WIKI_TAB_HISTORY'); ?></span>
 					</a>
 				</li>
-			<?php if ($this->sub) {  ?>
+			<?php if ($this->page->get('scope') != 'site') { ?>
 				<li class="page-pdf">
 					<a href="<?php echo Route::url($this->page->link('pdf')); ?>" title="<?php echo Lang::txt('COM_WIKI_TAB_PDF'); ?>">
 						<span class="icon-download-alt"><?php echo Lang::txt('COM_WIKI_TAB_PDF'); ?></span>

--- a/core/components/com_wiki/site/views/pages/tmpl/wikimenu.php
+++ b/core/components/com_wiki/site/views/pages/tmpl/wikimenu.php
@@ -50,7 +50,7 @@ defined('_HZEXEC_') or die();
 
 		<div class="container">
 			<h3><?php echo Lang::txt('COM_WIKI'); ?></h3>
-			<ul id="<?php echo ($this->sub) ? 'page_options' : 'useroptions'; ?>">
+			<ul id="useroptions">
 				<li class="page-main">
 					<a href="<?php echo Route::url($this->page->link('base')); ?>">
 						<?php echo Lang::txt('COM_WIKI_MAIN_PAGE'); ?>
@@ -95,7 +95,7 @@ defined('_HZEXEC_') or die();
 				</li>
 				<?php if (!User::isGuest() && $this->page->access('create')) { ?>
 					<li class="page-new" data-title="<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>">
-						<a href="<?php echo Route::url($this->page->link('base') . '&' . ($this->sub ? 'action' : 'task') . '=new'); ?>">
+						<a href="<?php echo Route::url($this->page->link('base') . '&' . ($this->page->get('scope') != 'site' ? 'action' : 'task') . '=new'); ?>">
 							<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>
 						</a>
 					</li>
@@ -108,7 +108,7 @@ defined('_HZEXEC_') or die();
 				<h3><?php echo Lang::txt('COM_WIKI_TOOLS'); ?></h3>
 				<ul>
 					<li class="page-new" data-title="<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>">
-						<a href="<?php echo Route::url($this->page->link('base') . '&' . ($this->sub ? 'action' : 'task') . '=new'); ?>">
+						<a href="<?php echo Route::url($this->page->link('base') . '&' . ($this->page->get('scope') != 'site' ? 'action' : 'task') . '=new'); ?>">
 							<?php echo Lang::txt('COM_WIKI_NEW_PAGE'); ?>
 						</a>
 					</li>

--- a/core/components/com_wiki/site/views/pages/tmpl/wikimenu.php
+++ b/core/components/com_wiki/site/views/pages/tmpl/wikimenu.php
@@ -115,4 +115,4 @@ defined('_HZEXEC_') or die();
 				</ul>
 			</div>
 		<?php } ?>
-	<?php } ?>
+	<?php }


### PR DESCRIPTION
The `sub` flag used to determine if `action` or `task` was used in a
URL. But this can't be relied on as super group wikis had `sub` set to
`false` but need to use `action`, not `task`, in URLs.

Fixes: https://cdmhub.org/support/ticket/1800