### PR TITLE
[fix] Adding guard against shoulder inc with DOI

### DIFF
--- a/core/components/com_resources/models/doi.php
+++ b/core/components/com_resources/models/doi.php
@@ -187,8 +187,15 @@ class Doi extends Relational
 		}
 		else
 		{
+			$shoulder = $service->configs()->shoulder;
+			if (strstr($doi, '/'))
+			{
+				$parts = explode('/', $doi);
+				$shoulder = $parts[0];
+				$doi = end($parts);
+			}
 			$this->set('doi', $doi);
-			$this->set('doi_shoulder', $service->configs()->shoulder);
+			$this->set('doi_shoulder', $shoulder);
 		}
 
 		// Register the DOI name and URL to complete the DOI registration.

--- a/core/components/com_resources/models/doi.php
+++ b/core/components/com_resources/models/doi.php
@@ -199,7 +199,7 @@ class Doi extends Relational
 		}
 
 		// Register the DOI name and URL to complete the DOI registration.
-		$result = $service->register(false, true, $doi);
+		$result = $service->register(false, true, $shoulder . '/' . $doi);
 
 		if ($service->getError())
 		{


### PR DESCRIPTION
This will handle a case where the returned registered DOI includes the
shoulder (e.g., shoulder/doi). Both parts are stored separately, so the
string needs to be broken into its parts.