### PR TITLE
[fix] Ensure course quiz deployment gets array.

### DIFF
--- a/core/components/com_courses/site/controllers/form.php
+++ b/core/components/com_courses/site/controllers/form.php
@@ -293,7 +293,7 @@ class Form extends SiteController
 	 */
 	public function createDeploymentTask()
 	{
-		if (!$deployment = Request::getString('deployment'))
+		if (!$deployment = Request::getArray('deployment'))
 		{
 			App::abort(422, Lang::txt('COM_COURSES_ERROR_MISSING_DEPLOYMENT'));
 		}
@@ -339,7 +339,7 @@ class Form extends SiteController
 	 */
 	public function updateDeploymentTask()
 	{
-		if (!$deployment = Request::getString('deployment'))
+		if (!$deployment = Request::getArray('deployment'))
 		{
 			App::abort(422, Lang::txt('COM_COURSES_ERROR_MISSING_DEPLOYMENT'));
 		}


### PR DESCRIPTION
The params were set to expect a string,
therefore array values couldn't be accessed.

fixes: https://nanohub.org/support/ticket/342375