### PR TITLE
[fix] Check if var is an empty string

### DIFF
--- a/core/components/com_users/site/views/login/view.html.php
+++ b/core/components/com_users/site/views/login/view.html.php
@@ -115,7 +115,7 @@ class UsersViewLogin extends JViewLegacy
 		}
 
 		// Set return if is isn't already
-		if (is_null($return) && is_object($active))
+		if (!$return && is_object($active))
 		{
 			$return = $defaultReturn;
 		}
@@ -181,16 +181,18 @@ class UsersViewLogin extends JViewLegacy
 			{
 				$myplugin = new $className($this,(array)$plugin);
 
-				if (method_exists($className,'status'))
+				if (method_exists($className, 'status'))
 				{
 					$status[$plugin->name] = $myplugin->status();
 					$this->status = $status;
 				}
 
 				if ($plugin->name != $authenticator)
+				{
 					continue;
+				}
 
-				if (method_exists($className,'display'))
+				if (method_exists($className, 'display'))
 				{
 					$result = $myplugin->display($this, $tpl);
 

--- a/core/components/com_users/site/views/login/view.html.php
+++ b/core/components/com_users/site/views/login/view.html.php
@@ -44,14 +44,16 @@ class UsersViewLogin extends JViewLegacy
 		}
 
 		// Check for errors.
-		if (count($errors = $this->get('Errors'))) {
+		if (count($errors = $this->get('Errors')))
+		{
 			App::abort(500, implode('<br />', $errors));
 			return false;
 		}
 
 		// Check for layout override
 		$active = \App::get('menu')->getActive();
-		if (isset($active->query['layout'])) {
+		if (isset($active->query['layout']))
+		{
 			$this->setLayout($active->query['layout']);
 		}
 
@@ -179,7 +181,7 @@ class UsersViewLogin extends JViewLegacy
 
 			if (class_exists($className))
 			{
-				$myplugin = new $className($this,(array)$plugin);
+				$myplugin = new $className($this, (array)$plugin);
 
 				if (method_exists($className, 'status'))
 				{


### PR DESCRIPTION
A few lines above, `Request::getString()` is forcing a return value of
a string, regardless of `null` being passed as a default value. So
the `is_null()` check fails every time.

Fixes: https://help.hubzero.org/support/ticket/11730