### PR TITLE
[fix] Fixing issue with 'save & close'

### DIFF
--- a/core/components/com_menus/admin/controllers/items.php
+++ b/core/components/com_menus/admin/controllers/items.php
@@ -717,7 +717,9 @@ class Items extends AdminController
 			return $this->editTask($row);
 		}
 
-		$row->checkin();
+		$row
+			->purgeCache()
+			->checkin();
 
 		User::setState('com_menus.edit.item.data', null);
 		User::setState('com_menus.edit.item.type', null);


### PR DESCRIPTION
The `cancelTask()` method called after saving looks for a model it might
need to checkin. The model lookup is the same as in `saveTask()` before
the edited data is applied to the model. This means the data is cached
and the lookup in the cancel task is returning _old_ data that
overwrites the just-saved changes. So, we purge the cache before
cancelling.