### PR TITLE
[fix] Use only the filename not path

### DIFF
--- a/core/components/com_installer/admin/views/migrations/tmpl/display.php
+++ b/core/components/com_installer/admin/views/migrations/tmpl/display.php
@@ -111,7 +111,7 @@ $this->css();
 				?>
 				<tr>
 					<td>
-						<input type="checkbox" name="migration[]" id="cb<?php echo $i; ?>" value="<?php echo $this->escape($row['entry']); ?>" class="checkbox-toggle" />
+						<input type="checkbox" name="migration[]" id="cb<?php echo $i; ?>" value="<?php echo $this->escape($row['file']); ?>" class="checkbox-toggle" />
 					</td>
 					<td>
 						<?php echo $component; ?><br />


### PR DESCRIPTION
muse expects only the filename and then searchs its own list of
directories for that file.