### PR TITLE
[fix] Declaring namespaces

### DIFF
--- a/core/components/com_projects/models/orm/project.php
+++ b/core/components/com_projects/models/orm/project.php
@@ -32,7 +32,9 @@
 namespace Components\Projects\Models\Orm;
 
 use Hubzero\Database\Relational;
+use Request;
 use Event;
+use Route;
 use User;
 use Lang;
 use stdClass;

--- a/core/components/com_projects/models/project.php
+++ b/core/components/com_projects/models/project.php
@@ -48,6 +48,7 @@ use Hubzero\Base\Model;
 use Components\Projects\Tables;
 use Hubzero\Base\ItemList;
 use Component;
+use Route;
 use Date;
 use Lang;
 use User;


### PR DESCRIPTION
This fixes an issue with a namespace being declared as already in use.
Discovered when trying to change a project's associated image.