### PR TITLE
[refactor] Use native JSON lib instead of jQuery's

### DIFF
--- a/core/assets/js/core-uncompressed.js
+++ b/core/assets/js/core-uncompressed.js
@@ -767,7 +767,7 @@ document.addEventListener('DOMContentLoaded', function() {
 	/*$("a.move_up, a.move_down, a.grid_true, a.grid_false, a.trash")
 		.on("click", function(){
 			if ($(this).attr("rel")) {
-				args = jQuery.parseJSON($(this).attr("rel").replace(/\'/g, '"'));
+				args = JSON.parse($(this).attr("rel").replace(/\'/g, '"'));
 				Joomla.listItemTask(args.id, args.task);
 			}
 		});*/

--- a/core/components/com_activity/admin/assets/js/activity.js
+++ b/core/components/com_activity/admin/assets/js/activity.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function ($) {
 	$('.com_activity-chart').each(function(i, el){
 		var data = $('#' + $(el).attr('data-datasets')).html();
 
-		var datasets = jQuery.parseJSON(data);
+		var datasets = JSON.parse(data);
 
 		var com_activity_chart = $.plot($(el), datasets.datasets, {
 			series: {

--- a/core/components/com_answers/site/assets/js/answers.js
+++ b/core/components/com_answers/site/assets/js/answers.js
@@ -110,7 +110,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/components/com_blog/site/assets/js/blog.js
+++ b/core/components/com_blog/site/assets/js/blog.js
@@ -67,7 +67,7 @@ jQuery(document).ready(function (jq) {
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/components/com_collections/site/assets/js/fileupload.js
+++ b/core/components/com_collections/site/assets/js/fileupload.js
@@ -54,7 +54,7 @@ HUB.CollectionsFileUpload = {
 					);*/
 					//console.log($('#link-adder').attr('data-action') + $('#field-dir').val());
 					$.get($('#link-adder').attr('data-action') + $('#field-dir').val(), {}, function(data){
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (response.id != $('#field-dir').val()) {
 							$('#field-id').val(response.id);

--- a/core/components/com_courses/admin/assets/js/certificates.js
+++ b/core/components/com_courses/admin/assets/js/certificates.js
@@ -13,7 +13,7 @@ function Box() {
 jQuery(window).load(function() {
 
 	if ($('#field-properties').length) {
-		var props = jQuery.parseJSON($('#field-properties').val());
+		var props = JSON.parse($('#field-properties').val());
 
 		for (var i = 0; i < props.elements.length; i++)
 		{

--- a/core/components/com_courses/admin/assets/js/courses.js
+++ b/core/components/com_courses/admin/assets/js/courses.js
@@ -115,7 +115,7 @@ jQuery(document).ready(function($){
 			data = $('#offering-data');
 
 		if (data.length) {
-			offeringsections = jQuery.parseJSON(data.html());
+			offeringsections = JSON.parse(data.html());
 		}
 
 		offering_id.on('change', function(e){

--- a/core/components/com_courses/site/assets/js/courses.js
+++ b/core/components/com_courses/site/assets/js/courses.js
@@ -431,7 +431,7 @@ HUB.Courses = {
 					url: 'index.php?option=com_courses&task=courseavailability&no_html=1',
 					data: { 'course' : $(this).val() },
 					success: function(data) {
-						var availability = jQuery.parseJSON(data);
+						var availability = JSON.parse(data);
 						if(availability)
 						{
 							if(availability.available)

--- a/core/components/com_courses/site/assets/js/courses.overview.js
+++ b/core/components/com_courses/site/assets/js/courses.overview.js
@@ -55,7 +55,7 @@ jQuery(document).ready(function(jq) {
 							window.console && console.log(data);
 						}
 
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 						if (!response.success) {
 							alert(response.message);
 							return;

--- a/core/components/com_forum/site/assets/js/forum.js
+++ b/core/components/com_forum/site/assets/js/forum.js
@@ -64,7 +64,7 @@ jQuery(document).ready(function (jq) {
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/components/com_groups/site/assets/js/groups.js
+++ b/core/components/com_groups/site/assets/js/groups.js
@@ -321,7 +321,7 @@ HUB.Groups = {
 					url: 'index.php?option=com_groups&task=groupavailability&no_html=1',
 					data: { 'group' : $(this).val() },
 					success: function(data) {
-						var availability = jQuery.parseJSON(data);
+						var availability = JSON.parse(data);
 						if(availability)
 						{
 							if(availability.available)

--- a/core/components/com_kb/site/assets/js/kb.js
+++ b/core/components/com_kb/site/assets/js/kb.js
@@ -71,7 +71,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/components/com_members/site/assets/js/changepassword.js
+++ b/core/components/com_members/site/assets/js/changepassword.js
@@ -70,7 +70,7 @@ HUB.MembersChangePassword = {
 				success: function(data, status, xhr)
 				{
 					// Parse the returned json data
-					var returned = jQuery.parseJSON(data);
+					var returned = JSON.parse(data);
 
 					// If we successfully saved
 					if(returned.success)

--- a/core/components/com_members/site/assets/js/orcid.js
+++ b/core/components/com_members/site/assets/js/orcid.js
@@ -38,7 +38,7 @@ HUB.Orcid = {
 			url: $('#base_uri').val() + '/index.php?option=com_members&controller=orcid&task=fetch&no_html=1&fname=' + firstName + '&lname=' + lastName + '&return=1',
 			type: 'GET',
 			success: function(data, status, jqXHR) {
-				$('#section-orcid-results').html(jQuery.parseJSON(data));
+				$('#section-orcid-results').html(JSON.parse(data));
 			}
 		});
 	},
@@ -66,7 +66,7 @@ HUB.Orcid = {
 			url: uri,
 			type: 'GET',
 			success: function(data, status, jqXHR) {
-				var response = jQuery.parseJSON(data);
+				var response = JSON.parse(data);
 
 				if (response.success) {
 					if (response.orcid) {

--- a/core/components/com_members/site/assets/js/setpassword.js
+++ b/core/components/com_members/site/assets/js/setpassword.js
@@ -52,7 +52,7 @@ jQuery(document).ready(function (jq) {
 			success: function(data, status, xhr)
 			{
 				// Parse the returned json data
-				var returned = jQuery.parseJSON(data);
+				var returned = JSON.parse(data);
 
 				// If we successfully saved
 				if (returned.success)

--- a/core/components/com_newsletter/admin/assets/js/newsletter.js
+++ b/core/components/com_newsletter/admin/assets/js/newsletter.js
@@ -252,8 +252,8 @@ HUB.Administrator.Newsletter = {
 			//lets hide the us map for now
 			$('#us-map').hide();
 			
-			var worldData = jQuery.parseJSON( $('#world-map-data').attr('data-src') );
-			var usData = jQuery.parseJSON( $('#us-map-data').attr('data-src') );
+			var worldData = JSON.parse( $('#world-map-data').attr('data-src') );
+			var usData = JSON.parse( $('#us-map-data').attr('data-src') );
 			
 			//add World map
 			$('#world-map').vectorMap({

--- a/core/components/com_resources/site/views/view/tmpl/windowstools.php
+++ b/core/components/com_resources/site/views/view/tmpl/windowstools.php
@@ -141,7 +141,7 @@ if ($mode != 'preview')
 											e.preventDefault();
 
 											$.get(url.nohtml(), function(data){
-												var returned = jQuery.parseJSON(data);
+												var returned = JSON.parse(data);
 
 												if (returned.success) {
 													window.open(returned.message);
@@ -244,4 +244,4 @@ if ($mode != 'preview')
 		</aside><!-- / .aside extracontent -->
 		</div>
 	</section><!-- / .main section -->
-<?php } ?>
+<?php }

--- a/core/components/com_support/admin/assets/js/condition.builder.js
+++ b/core/components/com_support/admin/assets/js/condition.builder.js
@@ -327,7 +327,7 @@ jQuery(document).ready(function($){
 	var cdata = $('#conditions-data');
 
 	if (cdata.length) {
-		var data = jQuery.parseJSON(cdata.html());
+		var data = JSON.parse(cdata.html());
 
 		Conditions.option = data.conditions;
 	}

--- a/core/components/com_tags/admin/assets/js/tag_graph.js
+++ b/core/components/com_tags/admin/assets/js/tag_graph.js
@@ -10,7 +10,7 @@ jQuery(function(jq)
 		resourcetypes = $('#resource-types');
 
 	if (resourcetypes.length) {
-		var cdata = jQuery.parseJSON(resourcetypes.html());
+		var cdata = JSON.parse(resourcetypes.html());
 
 		window.resourceTypes = cdata.types;
 	}

--- a/core/components/com_tools/admin/assets/js/locations.js
+++ b/core/components/com_tools/admin/assets/js/locations.js
@@ -62,7 +62,7 @@ jQuery(document).ready(function($){
 		var k = 0;
 		continentcountry[k++] = new Array('', '', countrydata.attr('data-select'));
 
-		var cdata = jQuery.parseJSON($('#country-data').html());
+		var cdata = JSON.parse($('#country-data').html());
 
 		for (var i = 0; i < cdata.data.length; i++)
 		{

--- a/core/components/com_users/site/assets/js/login.js
+++ b/core/components/com_users/site/assets/js/login.js
@@ -72,7 +72,7 @@ HUB.User = {
 					var response = {};
 					try {
 						// Parse the returned json data
-						response = jQuery.parseJSON(data);
+						response = JSON.parse(data);
 					} catch (err) {
 						console.log(err);
 						password.val('');

--- a/core/components/com_wiki/site/assets/js/wiki.js
+++ b/core/components/com_wiki/site/assets/js/wiki.js
@@ -56,7 +56,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/components/com_wishlist/admin/assets/js/wishlist.js
+++ b/core/components/com_wishlist/admin/assets/js/wishlist.js
@@ -17,7 +17,7 @@ jQuery(document).ready(function($){
 		ownerdata = $('#owner-data');
 
 	if (ownerdata.length) {
-		var cdata = jQuery.parseJSON(ownerdata.html());
+		var cdata = JSON.parse(ownerdata.html());
 
 		for (var i = 0; i < cdata.data.length; i++)
 		{

--- a/core/components/com_wishlist/site/assets/js/wishlist.js
+++ b/core/components/com_wishlist/site/assets/js/wishlist.js
@@ -121,7 +121,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/modules/mod_collect/assets/js/mod_collect.js
+++ b/core/modules/mod_collect/assets/js/mod_collect.js
@@ -50,7 +50,7 @@ jQuery(document).ready(function(jq){
 						e.preventDefault();
 
 						$.post($(this).attr('action'), $(this).serialize(), function(data) {
-							var response = jQuery.parseJSON(data);
+							var response = JSON.parse(data);
 							if (!response.success) {
 								$('#sbox-content').html('<p class="error" style="margin-left: 1em; margin-right: 1em;">' + response.message + '</p>')
 							} else {

--- a/core/modules/mod_courses/assets/js/mod_courses.js
+++ b/core/modules/mod_courses/assets/js/mod_courses.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function ($) {
 	$('.mod_courses-chart').each(function(i, el){
 		var data = $('#' + $(el).attr('data-datasets')).html();
 
-		var datasets = jQuery.parseJSON(data);
+		var datasets = JSON.parse(data);
 
 		var mod_courses_chart = $.plot($(el), datasets.datasets, {
 			series: {

--- a/core/modules/mod_resources/assets/js/mod_resources.js
+++ b/core/modules/mod_resources/assets/js/mod_resources.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function ($) {
 
 	$('.mod_resources-chart').each(function(i, el){
 		var data = $('#' + $(el).attr('data-datasets')).html();
-		var datasets = jQuery.parseJSON(data);
+		var datasets = JSON.parse(data);
 		var mod_resources_chart = $.plot(
 			$(el),
 			datasets.datasets,

--- a/core/modules/mod_supporttickets/assets/js/mod_supporttickets.js
+++ b/core/modules/mod_supporttickets/assets/js/mod_supporttickets.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function ($) {
 	$('.mod_supporttickets-chart').each(function(i, el){
 		var data = $('#' + $(el).attr('data-datasets')).html();
 
-		var datasets = jQuery.parseJSON(data);
+		var datasets = JSON.parse(data);
 
 		var mod_supporttickets_chart = $.plot($(el), datasets.datasets, {
 			series: {

--- a/core/modules/mod_tools/assets/js/mod_tools.js
+++ b/core/modules/mod_tools/assets/js/mod_tools.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function ($) {
 
 	$('.mod_tools-chart').each(function(i, el){
 		var data = $('#' + $(el).attr('data-datasets')).html();
-		var datasets = jQuery.parseJSON(data);
+		var datasets = JSON.parse(data);
 		var mod_tools_chart = $.plot(
 			$(el),
 			datasets.datasets,

--- a/core/modules/mod_wishlist/assets/js/mod_wishlist.js
+++ b/core/modules/mod_wishlist/assets/js/mod_wishlist.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function ($) {
 
 	$('.mod_wishlist-chart').each(function(i, el){
 		var data = $('#' + $(el).attr('data-datasets')).html();
-		var datasets = jQuery.parseJSON(data);
+		var datasets = JSON.parse(data);
 		var mod_wishlist_chart = $.plot(
 			$(el),
 			datasets.datasets,

--- a/core/plugins/courses/announcements/assets/js/announcements.dashboard.js
+++ b/core/plugins/courses/announcements/assets/js/announcements.dashboard.js
@@ -31,7 +31,7 @@ jQuery(document).ready(function(jq){
 			.on('submit', '#announcementForm', function(e) {
 				e.preventDefault();
 				$.post($(this).attr('action').nohtml(), $(this).serialize(), function(response){
-					var json = jQuery.parseJSON(response);
+					var json = JSON.parse(response);
 					if (json.code == 0) {
 						/*$('<div class="hubzero_notification"></div>')
 							.text('Announcement posted.')

--- a/core/plugins/courses/discussions/assets/js/discussions.js
+++ b/core/plugins/courses/discussions/assets/js/discussions.js
@@ -259,8 +259,8 @@ HUB.Plugins.CoursesForum = {
 						dataType: 'json',
 						success: function(response, status) {
 							if (typeof response === "string" ) {
-								//data = jQuery.parseJSON(response.responseText);
-								var data = jQuery.parseJSON(response);
+								//data = JSON.parse(response.responseText);
+								var data = JSON.parse(response);
 							} else {
 								var data = response;
 							}
@@ -561,8 +561,8 @@ HUB.Plugins.CoursesForum = {
 									});
 								} else {
 									if (typeof response === "string" ) {
-										//data = jQuery.parseJSON(response.responseText);
-										var data = jQuery.parseJSON(response);
+										//data = JSON.parse(response.responseText);
+										var data = JSON.parse(response);
 									} else {
 										var data = response;
 									}

--- a/core/plugins/courses/discussions/assets/js/discussions.lecture.js
+++ b/core/plugins/courses/discussions/assets/js/discussions.lecture.js
@@ -257,8 +257,8 @@ HUB.Plugins.CoursesForum = {
 						dataType: 'json',
 						success: function(response, status) {
 							if (typeof response === "string" ) {
-								//data = jQuery.parseJSON(response.responseText);
-								var data = jQuery.parseJSON(response);
+								//data = JSON.parse(response.responseText);
+								var data = JSON.parse(response);
 							} else {
 								var data = response;
 							}
@@ -518,8 +518,8 @@ HUB.Plugins.CoursesForum = {
 									}
 
 									if (typeof response === "string" ) {
-										//data = jQuery.parseJSON(response.responseText);
-										var data = jQuery.parseJSON(response);
+										//data = JSON.parse(response.responseText);
+										var data = JSON.parse(response);
 									} else {
 										var data = response;
 									}

--- a/core/plugins/editors/ckeditor/assets/adapters/jquery.js
+++ b/core/plugins/editors/ckeditor/assets/adapters/jquery.js
@@ -31,7 +31,7 @@ if (typeof(jQuery) !== "undefined") {
 			var cfg = $('#' + $(el).attr('id') + '-ckeconfig'),
 				config = null;
 			if (cfg.length) {
-				config = jQuery.parseJSON(cfg.html());
+				config = JSON.parse(cfg.html());
 				if (typeof config.protectedSource != 'undefined') {
 					for (var i = 0; i < config.protectedSource.length; i++) {
 						var rg = regExpFromString(config.protectedSource[i]);
@@ -68,7 +68,6 @@ if (typeof(jQuery) !== "undefined") {
 		});
 	jQuery(document)
 		.on("ajaxLoad", function(e) {
-			console.log('triggered...')
 			jInitEditors();
 		})
 		.on("editorSave", function(e) {

--- a/core/plugins/groups/forum/assets/js/forum.js
+++ b/core/plugins/groups/forum/assets/js/forum.js
@@ -104,7 +104,7 @@ jQuery(document).ready(function(jq){
 				var response = {};
 				try {
 					// Parse the returned json data
-					response = jQuery.parseJSON(data);
+					response = JSON.parse(data);
 				} catch (err) {
 					// Print error
 					$('.response-message').addClass('error').html('Save failed!');

--- a/core/plugins/groups/wiki/assets/js/wiki.js
+++ b/core/plugins/groups/wiki/assets/js/wiki.js
@@ -56,7 +56,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/plugins/hubzero/comments/assets/js/comments.js
+++ b/core/plugins/hubzero/comments/assets/js/comments.js
@@ -78,7 +78,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/plugins/members/account/assets/js/account.js
+++ b/core/plugins/members/account/assets/js/account.js
@@ -122,7 +122,7 @@ HUB.Plugins.MembersAccount = {
 			success: function(data, status, xhr)
 			{
 				// Parse the returned json data
-				var returned = jQuery.parseJSON(data);
+				var returned = JSON.parse(data);
 
 				// If we successfully saved
 				if(returned.success)

--- a/core/plugins/members/profile/assets/js/profile.js
+++ b/core/plugins/members/profile/assets/js/profile.js
@@ -178,7 +178,7 @@ HUB.Members.Profile = {
 			{
 				console.log(data);
 				//parse the returned json data
-				var returned = jQuery.parseJSON(data);
+				var returned = JSON.parse(data);
 				
 				//remove saving indicator and enable save button
 				//form.find(".section-edit-saving").remove();
@@ -393,7 +393,7 @@ HUB.Members.Profile = {
 			};
 
 			$.post(url, params, function(data){ 
-				var returned = jQuery.parseJSON(data);
+				var returned = JSON.parse(data);
 
 				if (returned.success) {
 					if (pub == 1) {
@@ -506,7 +506,7 @@ HUB.Members.Profile = {
 
 						// save profile picture updates
 						$.post(form.attr("action"), form.serialize(), function(data){
-							var save = jQuery.parseJSON(data);
+							var save = JSON.parse(data);
 							if (save.success)
 							{
 								// load exact page to get results new profile pic sources
@@ -556,7 +556,7 @@ HUB.Members.Profile = {
 				url = url.replace("doajaxupload","getfileatts"); 
 
 				$.post(url, {file:response.file, dir:response.directory}, function(data) {
-					var upload = jQuery.parseJSON( data );
+					var upload = JSON.parse( data );
 					if (upload)
 					{
 						$("#ajax-upload-right").find("p.warning").remove();

--- a/core/plugins/publications/reviews/assets/js/reviews.js
+++ b/core/plugins/publications/reviews/assets/js/reviews.js
@@ -65,7 +65,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/plugins/resources/reviews/assets/js/reviews.js
+++ b/core/plugins/resources/reviews/assets/js/reviews.js
@@ -65,7 +65,7 @@ jQuery(document).ready(function(jq){
 				frm.on('submit', function(e) {
 					e.preventDefault();
 					$.post($(this).attr('action'), $(this).serialize(), function(data) {
-						var response = jQuery.parseJSON(data);
+						var response = JSON.parse(data);
 
 						if (!response.success) {
 							frm.prepend('<p class="error">' + response.message + '</p>');

--- a/core/templates/kimera/html/com_resources/view/windowstools.php
+++ b/core/templates/kimera/html/com_resources/view/windowstools.php
@@ -126,7 +126,7 @@ if ($mode != 'preview')
 										e.preventDefault();
 
 										$.get(url.nohtml(), function(data){
-											var returned = jQuery.parseJSON(data);
+											var returned = JSON.parse(data);
 
 											if (returned.success) {
 												window.open(returned.message);


### PR DESCRIPTION
The `jQuery.parseJSON()` method was deprecated as of jQuery 3.0. The
native `JSON.parse` has been available in all major browsers since IE 8.

Refs: https://api.jquery.com/jQuery.parseJSON/
Refs: https://www.w3schools.com/js/js_json_parse.asp