### PR TITLE
[fix] Update datatable config to fix search inputs

### DIFF
--- a/core/components/com_dataviewer/site/html/spreadsheet.js
+++ b/core/components/com_dataviewer/site/html/spreadsheet.js
@@ -68,7 +68,7 @@ jQuery(document).ready(function($) {
 		"aaData": dv_data.aaData,
 		"aoColumns": dv_data.aoColumns,
 		"bProcessing": true,
-		"bServerSide": dv_settings.serverside,
+		"bServerSide": false,
 		"sAjaxSource": (dv_settings.serverside)? dv_settings.data_url + '&type=json&format=raw': null,
 		"sDom": '<"H"lpf<"clear">>rt<"F"lip<"clear">>',
 		"sPaginationType": "full_numbers",
@@ -227,7 +227,7 @@ jQuery(document).ready(function($) {
 
 	$('tfoot input').each(function(i) {
 		$(this).data('filter-value', '');
- 
+
 		if (dv_settings.show_filter_options) {
 			$(this).autocomplete({
 				disabled: true,
@@ -326,7 +326,7 @@ jQuery(document).ready(function($) {
 				title: res.title,
 				modal: true
 			}).find('.dv_image').lazyload({failure_limit:1000});
-			
+
 		}
 	}
 
@@ -810,9 +810,9 @@ jQuery(document).ready(function($) {
 				$('#dv_filters_tabs').append(filter_div);
 				$('#dv_filters_tabs ul').append(tpl_title.supplant({'id': i, 'name': dv_data.filters[i].filter_name}));
 			}
-			
+
 		}
-		
+
 		$('#dv_filters_tabs').tabs("refresh").tabs( 'option', "active", 0);
 
 


### PR DESCRIPTION
fixes: https://purr.purdue.edu/support/ticket/1997

When `bServerSide` is true, column filters only include values present in the visible rows as opposed to showing the values for all rows.

It seems like a request associated with `bServerSide` being true fails.

![server_side_error](https://user-images.githubusercontent.com/16006163/53643385-e79d7280-3c01-11e9-8194-8e0d2b5ca3a5.PNG)
