### PR TITLE
[fix] Adding missing method

### DIFF
--- a/core/plugins/resources/reviews/helper.php
+++ b/core/plugins/resources/reviews/helper.php
@@ -344,29 +344,11 @@ class PlgResourcesReviewsHelper extends \Hubzero\Base\Obj
 		}
 
 		// Calculate the new average rating for the parent resource
-		$ratings = \Components\Resources\Reviews\Models\Review::all()
-			->whereEquals('resource_id', $this->resource->get('id'))
-			->rows()
-			->fieldsByKey('rating');
-
-		$totalcount = count($ratings);
-		$totalvalue = 0;
-
-		// Add the ratings up
-		foreach ($ratings as $rating)
-		{
-			$totalvalue = $totalvalue + $rating;
-		}
-
-		// Find the average of all ratings
-		$newrating = ($totalcount > 0) ? $totalvalue / $totalcount : 0;
-
-		// Round to the nearest half
-		$newrating = ($newrating > 0) ? round($newrating*2)/2 : 0;
+		$calculated = \Components\Resources\Reviews\Models\Review::averageByResource($this->resource->get('id'));
 
 		// Recalculate the average rating for the parent resource
-		$this->resource->set('rating', $newrating);
-		$this->resource->set('times_rated', $totalcount);
+		$this->resource->set('rating', $calculated['newrating']);
+		$this->resource->set('times_rated', $calculated['times_rated']);
 		$this->resource->save();
 
 		// Instantiate a helper object and get all the contributor IDs

--- a/core/plugins/resources/reviews/models/review.php
+++ b/core/plugins/resources/reviews/models/review.php
@@ -416,4 +416,39 @@ class Review extends Relational
 
 		return $link;
 	}
+
+	/**
+	 * Calculate the average rating for a resource
+	 *
+	 * @param   integer  $id
+	 * @return  array
+	 */
+	public static function averageByResource($id)
+	{
+		// Calculate the new average rating for the parent resource
+		$ratings = self::all()
+			->whereEquals('resource_id', $id)
+			->rows()
+			->fieldsByKey('rating');
+
+		$totalcount = count($ratings);
+		$totalvalue = 0;
+
+		// Add the ratings up
+		foreach ($ratings as $rating)
+		{
+			$totalvalue = $totalvalue + $rating;
+		}
+
+		// Find the average of all ratings
+		$newrating = ($totalcount > 0) ? $totalvalue / $totalcount : 0;
+
+		// Round to the nearest half
+		$newrating = ($newrating > 0) ? round($newrating*2)/2 : 0;
+
+		return array(
+			'rating' => $newrating,
+			'times_rated' => $totalcount
+		);
+	}
 }

--- a/core/plugins/support/resources/resources.php
+++ b/core/plugins/support/resources/resources.php
@@ -279,8 +279,8 @@ class plgSupportResources extends \Hubzero\Plugin\Plugin
 
 				// Recalculate the average rating for the parent resource
 				$resource = \Components\Resources\Models\Entry::oneOrFail($parentid);
-				$resource->set('rating', $rating[0]);
-				$resource->set('times_rated', $rating[1]);
+				$resource->set('rating', $rating['rating']);
+				$resource->set('times_rated', $rating['times_rated']);
 				if (!$resource->save())
 				{
 					$this->setError($resource->getError());


### PR DESCRIPTION
The Review model was missing a static method for calculating the
average review rating for a resource.

Fixes: https://nanohub.org/support/ticket/344660