### PR TITLE
[fix] Ensure removing an import points to the correct Import model

### DIFF
--- a/core/components/com_resources/admin/controllers/imports.php
+++ b/core/components/com_resources/admin/controllers/imports.php
@@ -306,7 +306,7 @@ class Imports extends AdminController
 		$success = 0;
 		foreach ($ids as $id)
 		{
-			$resourceImport = Models\Import::oneOrFail($id);
+			$resourceImport = Import::oneOrFail($id);
 
 			// attempt to delete import
 			if (!$resourceImport->destroy())


### PR DESCRIPTION
The import model referenced when attempting to delete an import
was pointing to the wrong import namespace.

fixes: https://habricentral.org/support/ticket/848