### PR TITLE
[fix] Adding missing ID attribute on form

### DIFF
--- a/core/components/com_newsletter/admin/views/newsletters/tmpl/send.php
+++ b/core/components/com_newsletter/admin/views/newsletters/tmpl/send.php
@@ -54,7 +54,7 @@ $this->js();
 	}
 ?>
 
-<form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm">
+<form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="col span12">
 		<?php if ($this->newsletter->id != null) : ?>
 			<a name="distribution"></a>


### PR DESCRIPTION
The JS was looking for a specific ID and, not finding it, couldn't
submit the form.

Fixes: https://qubeshub.org/support/ticket/1382