### PR TITLE
[feat] Provide sample composer.json content

### DIFF
--- a/core/components/com_installer/admin/controllers/packages.php
+++ b/core/components/com_installer/admin/controllers/packages.php
@@ -2,7 +2,7 @@
 /**
  * HUBzero CMS
  *
- * Copyright 2005-2018 HUBzero Foundation, LLC.
+ * Copyright 2005-2015 HUBzero Foundation, LLC.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
  *
  * @package   hubzero-cms
  * @author    Zach Weidner <zweidner@purdue.edu>
- * @copyright Copyright 2005-2018 HUBzero Foundation, LLC.
+ * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
  * @license   http://www.gnu.org/licenses/gpl-2.0.html GPLv2
  */
 
@@ -43,6 +43,27 @@ include_once dirname(__DIR__) . '/helpers/cli.php';
  */
 class Packages extends AdminController
 {
+	/**
+	 * Execute a task
+	 *
+	 * @return  void
+	 */
+	public function execute()
+	{
+		if (!is_file(PATH_APP . '/composer.json'))
+		{
+			$view = new \Hubzero\Component\View(array(
+				'base_path' => dirname(__DIR__),
+				'name'      => 'warnings',
+				'layout'    => 'composer'
+			));
+			$view->display();
+			return;
+		}
+
+		parent::execute();
+	}
+
 	/**
 	 * Display a list of uninstalled extensions
 	 *

--- a/core/components/com_installer/admin/controllers/repositories.php
+++ b/core/components/com_installer/admin/controllers/repositories.php
@@ -2,7 +2,7 @@
 /**
  * HUBzero CMS
  *
- * Copyright 2005-2018 HUBzero Foundation, LLC.
+ * Copyright 2005-2015 HUBzero Foundation, LLC.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
  *
  * @package   hubzero-cms
  * @author    Zach Weidner <zweidner@purdue.edu>
- * @copyright Copyright 2005-2018 HUBzero Foundation, LLC.
+ * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
  * @license   http://www.gnu.org/licenses/gpl-2.0.html GPLv2
  */
 
@@ -48,6 +48,17 @@ class Repositories extends AdminController
 	 */
 	public function execute()
 	{
+		if (!is_file(PATH_APP . '/composer.json'))
+		{
+			$view = new \Hubzero\Component\View(array(
+				'base_path' => dirname(__DIR__),
+				'name'      => 'warnings',
+				'layout'    => 'composer'
+			));
+			$view->display();
+			return;
+		}
+
 		$this->registerTask('add', 'edit');
 
 		parent::execute();

--- a/core/components/com_installer/admin/controllers/warnings.php
+++ b/core/components/com_installer/admin/controllers/warnings.php
@@ -20,9 +20,8 @@
  * HUBzero is a registered trademark of Purdue University.
  *
  * @package   hubzero-cms
- * @author    Shawn Rice <zooley@purdue.edu>
+ * @author    Zach Weidner <zweidner@purdue.edu>
  * @copyright Copyright 2005-2015 HUBzero Foundation, LLC.
- * @copyright Copyright 2005-2014 Open Source Matters, Inc.
  * @license   http://www.gnu.org/licenses/gpl-2.0.html GPLv2
  */
 

--- a/core/components/com_installer/admin/helpers/installer.php
+++ b/core/components/com_installer/admin/helpers/installer.php
@@ -53,7 +53,7 @@ class Installer
 		Submenu::addEntry(
 			Lang::txt('COM_INSTALLER_SUBMENU_PACKAGES'),
 			Route::url('index.php?option=com_installer&controller=packages'),
-			$vName == 'repositories'
+			($vName == 'packages' || $vName == 'repositories')
 		);
 		Submenu::addEntry(
 			Lang::txt('COM_INSTALLER_SUBMENU_MIGRATIONS'),

--- a/core/components/com_installer/admin/language/en-GB/en-GB.com_installer.ini
+++ b/core/components/com_installer/admin/language/en-GB/en-GB.com_installer.ini
@@ -237,6 +237,8 @@ COM_INSTALLER_PACKAGES_REPOSITORY_DESCRIPTION="Description"
 COM_INSTALLER_PACKAGES_REPOSITORY_URL="URL"
 COM_INSTALLER_PACKAGES_REPOSITORY_TYPE="Type"
 COM_INSTALLER_PACKAGES_REPOSITORY_UPDATE="Update Repository"
+COM_INSTALLER_MSG_WARNINGS_MISSING_COMPOSER="No composer file found at %s. To learn more about Composer, read the <a href="_QQ_"https://getcomposer.org/"_QQ_">https://getcomposer.org/</a> &quot;Getting Started&quot; section."
+COM_INSTALLER_MSG_WARNINGS_MISSING_COMPOSER_SAMPLE="Create a <code>composer.json</code> file with the following contents to get started."
 
 COM_INSTALLER_MUSE_USER_LABEL="Muse username"
 COM_INSTALLER_MUSE_USER_DESC="The system user that the 'muse' command should be run as"

--- a/core/components/com_installer/admin/views/warnings/tmpl/composer.php
+++ b/core/components/com_installer/admin/views/warnings/tmpl/composer.php
@@ -27,7 +27,7 @@
 
 $canDo = \Components\Installer\Admin\Helpers\Installer::getActions();
 
-Toolbar::title(Lang::txt('COM_INSTALLER_HEADER_' . $this->getName()), 'install');
+Toolbar::title(Lang::txt('COM_INSTALLER_TITLE_PACKAGES'), 'install');
 if ($canDo->get('core.admin'))
 {
 	Toolbar::preferences('com_installer');
@@ -35,31 +35,32 @@ if ($canDo->get('core.admin'))
 }
 Toolbar::help('warnings');
 
-Document::setTitle(Lang::txt('COM_INSTALLER_TITLE_' . $this->getName()));
+$example = Component::path('com_installer') . '/config/composer.json.dist';
 ?>
 <div id="installer-warnings">
 	<form action="<?php echo Route::url('index.php?option=com_installer&controller=warnings'); ?>" method="post" name="adminForm" id="item-form">
-		<?php
-		if (!count($this->messages))
-		{
-			echo '<p class="nowarning">' . Lang::txt('COM_INSTALLER_MSG_WARNINGS_NONE') . '</p>';
-		}
-		else
-		{
-			echo Html::sliders('start', 'warning-sliders', array('useCookie' => 1));
-			foreach ($this->messages as $message)
-			{
-				echo Html::sliders('panel', $message['message'], str_replace(' ', '', $message['message']));
-				echo '<div class="warning">' . $message['description'] . '</div>';
-			}
-			echo Html::sliders('panel', Lang::txt('COM_INSTALLER_MSG_WARNINGFURTHERINFO'), 'furtherinfo-pane');
-			echo '<div class="warning">'. Lang::txt('COM_INSTALLER_MSG_WARNINGFURTHERINFODESC') .'</div>';
-			echo Html::sliders('end');
-		}
-		?>
-		<div class="clr"></div>
+		<div class="input-wrap">
+			<p class="error"><?php echo Lang::txt('COM_INSTALLER_MSG_WARNINGS_MISSING_COMPOSER', PATH_APP . '/composer.json'); ?></p>
+			<?php
+			if (file_exists($example)):
+				$contents = file_get_contents($example);
+				if ($contents):
+					?>
+					<label for="sample"><?php echo Lang::txt('COM_INSTALLER_MSG_WARNINGS_MISSING_COMPOSER_SAMPLE'); ?></label>
+					<textarea name="sample" id="sample" cols="100" rows="28"><?php
+					$site = preg_replace('/[^a-zA-Z0-9\-]/', '', strtolower(Config::get('sitename')));
 
-		<input type="hidden" name="boxchecked" value="0" />
-		<?php echo Html::input('token'); ?>
+					$contents = json_decode($contents);
+					$contents->name = $site . '/' . $site . '-app';
+					$contents = json_encode($contents, JSON_PRETTY_PRINT);
+					$contents = str_replace('\/', '/', $contents);
+
+					echo $contents;
+					?></textarea>
+					<?php
+				endif;
+			endif;
+			?>
+		</div>
 	</form>
 </div>

--- a/core/components/com_installer/config/composer.json.dist
+++ b/core/components/com_installer/config/composer.json.dist
@@ -1,0 +1,25 @@
+{
+	"name": "hubzero/hubzero-app",
+	"description": "App directory",
+	"repositories": {
+		"hz-installer": {
+			"type": "github",
+			"name": "Hubzero Extension Installer",
+			"description": "Custom installer for Hubzero extensions",
+			"url": "https://github.com/hubzero/extension-installer",
+			"options": {
+			}
+		}
+	},
+	"config": {
+		"github-protocols": ["https"],
+		"github-domains": ["www.github.com"],
+		"preferred-install": {
+			"*": "dist"
+		},
+		"cache-dir": "tmp/cache"
+	},
+	"require": {
+		"hubzero/extension-installer": "dev-master"
+	}
+}


### PR DESCRIPTION
Check for the required `composer.json` file first and, if not found, try
to provide a sample with the required `hubzero/extension-installer`.