### PR TITLE
[fix] Fixing datetime regex to be stricter

### DIFF
--- a/core/components/com_citations/site/controllers/citations.php
+++ b/core/components/com_citations/site/controllers/citations.php
@@ -212,8 +212,8 @@ class Citations extends SiteController
 
 		// Convert upload dates to correct time format
 		if (!is_string($this->view->filters['startuploaddate'])
-		 || !preg_match("/([0-9]{4})-([0-9]{2})-([0-9]{2})[ ]([0-9]{2}):([0-9]{2}):([0-9]{2})/", $this->view->filters['startuploaddate'])
-		 || !preg_match('/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $this->view->filters['startuploaddate']))
+		 || !preg_match("/^([0-9]{4})-([0-9]{2})-([0-9]{2})[ ]([0-9]{2}):([0-9]{2}):([0-9]{2})$/", $this->view->filters['startuploaddate'])
+		 || !preg_match('/^([0-9]{4})-([0-9]{2})-([0-9]{2})$/', $this->view->filters['startuploaddate']))
 		{
 			$this->view->filters['startuploaddate'] = '0000-00-00 00:00:00';
 		}
@@ -229,8 +229,8 @@ class Citations extends SiteController
 		}
 
 		if (!is_string($this->view->filters['enduploaddate'])
-		 || !preg_match("/([0-9]{4})-([0-9]{2})-([0-9]{2})[ ]([0-9]{2}):([0-9]{2}):([0-9]{2})/", $this->view->filters['enduploaddate'])
-		 || !preg_match('/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $this->view->filters['enduploaddate']))
+		 || !preg_match("/^([0-9]{4})-([0-9]{2})-([0-9]{2})[ ]([0-9]{2}):([0-9]{2}):([0-9]{2})$/", $this->view->filters['enduploaddate'])
+		 || !preg_match('/^([0-9]{4})-([0-9]{2})-([0-9]{2})$/', $this->view->filters['enduploaddate']))
 		{
 			$this->view->filters['enduploaddate'] = '';
 		}


### PR DESCRIPTION
Previous regex would validate strings such as "2016-07-22 00:00:00'A"
which would the Date class would then throw an error as not being able
to parse.