### PR TITLE
[fix] Remember what page the comments list was for

### DIFF
--- a/core/components/com_wiki/admin/controllers/comments.php
+++ b/core/components/com_wiki/admin/controllers/comments.php
@@ -109,7 +109,7 @@ class Comments extends AdminController
 			)
 		);
 
-		$page = Page::oneOrFail($filters['page_id']);
+		$page = Page::oneOrNew($filters['page_id']);
 
 		$comments = Comment::all();
 

--- a/core/components/com_wiki/admin/views/comments/tmpl/display.php
+++ b/core/components/com_wiki/admin/views/comments/tmpl/display.php
@@ -146,7 +146,7 @@ Html::behavior('tooltip');
 				<td>
 					<?php echo $row->get('treename'); ?>
 					<?php if ($canDo->get('core.edit')) { ?>
-						<a href="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=edit&id=' . $row->get('id')); ?>">
+						<a href="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=edit&id=' . $row->get('id') . '&page_id=' . $this->filters['page_id'] . '&' . Session::getFormToken() . '=1'); ?>">
 							<?php echo \Hubzero\Utility\Str::truncate($this->escape(stripslashes($row->get('ctext'))), 90); ?>
 						</a>
 					<?php } else { ?>

--- a/core/components/com_wiki/admin/views/comments/tmpl/edit.php
+++ b/core/components/com_wiki/admin/views/comments/tmpl/edit.php
@@ -55,7 +55,7 @@ $this->js();
 
 <form action="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller); ?>" method="post" name="adminForm" id="item-form" class="editform form-validate" data-invalid-msg="<?php echo $this->escape(Lang::txt('JGLOBAL_VALIDATION_FORM_FAILED'));?>">
 	<div class="grid">
-		<div class="colspan7">
+		<div class="col span7">
 			<fieldset class="adminform">
 				<legend><span><?php echo Lang::txt('JDETAILS'); ?></span></legend>
 
@@ -94,7 +94,7 @@ $this->js();
 						<td>
 							<?php echo $this->row->get('page_id'); ?>
 							<input type="hidden" name="fields[page_id]" id="field-page_id" value="<?php echo $this->escape($this->row->get('page_id')); ?>" />
-							<input type="hidden" name="pageid" value="<?php echo $this->escape($this->row->get('page_id')); ?>" />
+							<input type="hidden" name="page_id" value="<?php echo $this->escape($this->row->get('page_id')); ?>" />
 						</td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
When editing a comment, it would sometimes drop page ID info and not
properly redirect back to the correct comments list. Also minor display fix.