### PR TITLE
[fix] com_whatsnew shouldn't have admin menu item

### DIFF
--- a/core/components/com_whatsnew/migrations/Migration20170831000000ComWhatsnew.php
+++ b/core/components/com_whatsnew/migrations/Migration20170831000000ComWhatsnew.php
@@ -15,7 +15,15 @@ class Migration20170831000000ComWhatsnew extends Base
 	 **/
 	public function up()
 	{
-		$this->addComponentEntry('whatsnew');
+		// Create component entry but do NOT create a menu item as
+		// com_plugins is purposely separate from the 'components' list.
+		//
+		// string  $name            Component name
+		// string  $option          com_xyz
+		// int     $enabled         Whether or not the component should be enabled
+		// string  $params          Component params (if already known)
+		// bool    $createMenuItem  Create an admin menu item for this component
+		$this->addComponentEntry('whatsnew', null, 1, '', false);
 	}
 
 	/**

--- a/core/components/com_whatsnew/migrations/Migration20190306000000ComWhatsnew.php
+++ b/core/components/com_whatsnew/migrations/Migration20190306000000ComWhatsnew.php
@@ -8,7 +8,7 @@ defined('_HZEXEC_') or die();
 /**
  * Migration script for removing items from 'components' menu (they have hard-coded menu links elsewhere)
  **/
-class Migration20190306000000ModAdminmenu extends Base
+class Migration20190306000000ComWhatsnew extends Base
 {
 	/**
 	 * List of tables
@@ -16,26 +16,7 @@ class Migration20190306000000ModAdminmenu extends Base
 	 * @var  array
 	 **/
 	public static $components = array(
-		'com_cache',
-		'com_categories',
-		'com_checkin',
-		'com_config',
-		'com_cpanel',
-		'com_groups',
-		'com_help',
-		'com_installer',
-		'com_languages',
-		'com_login',
-		'com_menus',
-		'com_mailto',
-		'com_members',
-		'com_media',
-		'com_modules',
-		'com_plugins',
-		'com_redirect',
-		'com_system',
-		'com_templates',
-		'com_users'
+		'com_whatsnew'
 	);
 
 	/**


### PR DESCRIPTION
Also, don't specify the checked_out_time column when inserting menu
entries. The default value has changed over time and it's better to let
the database handle it than specifying it in SQL.