### PR TITLE
[PURR][#2007]Fixes to the issues of JSON+LD metadata elements

### DIFF
--- a/core/plugins/publications/jsonld/jsonld.php
+++ b/core/plugins/publications/jsonld/jsonld.php
@@ -65,18 +65,7 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 		$data['name'] = $publication->title;
 		$data['description'] = strip_tags($publication->abstract);
 		
-		if ((substr(Request::root(), -1) == '/') && (substr(Route::url($publication->link()), 0, 1) == '/'))
-		{
-			$data['url'] = rtrim(Request::root(), '/') . Route::url($publication->link());
-		}
-		elseif ((substr(Request::root(), -1) != '/') && (substr(Route::url($publication->link()), 0, 1) != '/'))
-		{
-			$data['url'] = Request::root() . '/' . Route::url($publication->link());
-		}
-		else
-		{
-			$data['url'] = Request::root() . Route::url($publication->link());
-		}
+		$data['url'] = rtrim(Request::root(), '/') . '/' . ltrim(Route::url($publication->link()), '/');
 		
 		$nullDate = '0000-00-00 00:00:00';
 
@@ -181,18 +170,7 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 
 			if ($contributor->user_id && $contributor->open)
 			{
-				if ((substr(Request::root(), -1) == '/') && (substr(Route::url('index.php?option=com_members&id=' . $contributor->user_id), 0, 1) == '/'))
-				{
-					$author['url'] = rtrim(Request::root(), '/') . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
-				}
-				elseif ((substr(Request::root(), -1) != '/') && (substr(Route::url('index.php?option=com_members&id=' . $contributor->user_id), 0, 1) != '/'))
-				{
-					$author['url'] = Request::root() . '/' . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
-				}
-				else
-				{
-					$author['url'] = Request::root() . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
-				}
+				$data['url'] = rtrim(Request::root(), '/') . '/' . ltrim(Route::url('index.php?option=com_members&id=' . $contributor->user_id), '/');
 			}
 
 			$authors[] = $author;

--- a/core/plugins/publications/jsonld/jsonld.php
+++ b/core/plugins/publications/jsonld/jsonld.php
@@ -64,8 +64,20 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 		$data['@type'] = 'Dataset';
 		$data['name'] = $publication->title;
 		$data['description'] = strip_tags($publication->abstract);
-		$data['url'] = Request::root() . Route::url($publication->link());
-
+		
+		if ((substr(Request::root(), -1) == '/') && (substr(Route::url($publication->link()), 0, 1) == '/'))
+		{
+			$data['url'] = rtrim(Request::root(), '/') . Route::url($publication->link());
+		}
+		elseif ((substr(Request::root(), -1) != '/') && (substr(Route::url($publication->link()), 0, 1) != '/'))
+		{
+			$data['url'] = Request::root() . '/' . Route::url($publication->link());
+		}
+		else
+		{
+			$data['url'] = Request::root() . Route::url($publication->link());
+		}
+		
 		$nullDate = '0000-00-00 00:00:00';
 
 		if ($publication->created && $publication->created != $nullDate)
@@ -169,7 +181,18 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 
 			if ($contributor->user_id && $contributor->open)
 			{
-				$author['url'] = Request::root() . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
+				if ((substr(Request::root(), -1) == '/') && (substr(Route::url('index.php?option=com_members&id=' . $contributor->user_id), 0, 1) == '/'))
+				{
+					$author['url'] = rtrim(Request::root(), '/') . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
+				}
+				elseif ((substr(Request::root(), -1) != '/') && (substr(Route::url('index.php?option=com_members&id=' . $contributor->user_id), 0, 1) != '/'))
+				{
+					$author['url'] = Request::root() . '/' . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
+				}
+				else
+				{
+					$author['url'] = Request::root() . Route::url('index.php?option=com_members&id=' . $contributor->user_id);
+				}
 			}
 
 			$authors[] = $author;
@@ -179,9 +202,7 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 		{
 			$data['author'] = $authors;
 		}
-
-		Document::addScriptDeclaration(json_encode($data), 'application/ld+json');
-
+		
 		$data['publisher'] = array(
 			'@type' => 'Organization',
 			'url' => Request::root(),
@@ -192,8 +213,10 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 		{
 			$data['publisher']['description'] = $desc;
 		}
-
-		$data['version'] = $publication->version->get('title');
+		
+		$data['version'] = $publication->version->get('version_number');
+		
+		Document::addScriptDeclaration(json_encode($data, JSON_UNESCAPED_SLASHES), 'application/ld+json');
 
 		/*
 		Example

--- a/core/plugins/publications/jsonld/jsonld.php
+++ b/core/plugins/publications/jsonld/jsonld.php
@@ -170,7 +170,7 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 
 			if ($contributor->user_id && $contributor->open)
 			{
-				$data['url'] = rtrim(Request::root(), '/') . '/' . ltrim(Route::url('index.php?option=com_members&id=' . $contributor->user_id), '/');
+				$author['url'] = rtrim(Request::root(), '/') . '/' . ltrim(Route::url('index.php?option=com_members&id=' . $contributor->user_id), '/');
 			}
 
 			$authors[] = $author;


### PR DESCRIPTION
[JSON+LD]Fixes to the issues of JSON+LD metadata elements
1. Extra forward slash exists in the dataset URL and author URL.
2. Escape character (\) exists in the strings of a few metadata elements, such as @context, dataset url, identifier, @id, sdLicense, and author url.
3. Add version number and publisher to JSON+LD.