### PR TITLE
[fix] Redirect to correct root path

### DIFF
--- a/core/components/com_users/site/controllers/user.php
+++ b/core/components/com_users/site/controllers/user.php
@@ -343,11 +343,20 @@ class UsersControllerUser extends UsersController
 			}
 
 			// Get the return url from the request and validate that it is internal.
-			$return = Request::getString('return', '');
+			$return = Request::getString('return', 'index.php');
 			$return = base64_decode($return);
-			if (!JURI::isInternal($return))
+			// Assume redirect URLs that start with a slash are internal
+			// As such, we want to make sure the path has the appropriate root
+			$root = Request::root(true);
+			if (substr($return, 0, 1) == '/'
+			 && substr($return, 0, strlen($root)) != $root)
 			{
-				$return = '';
+				$return = rtrim($root, '/') . $return;
+			}
+
+			if (!$return || !JURI::isInternal($return))
+			{
+				$return = 'index.php';
 			}
 
 			// Redirect the user.

--- a/core/components/com_users/site/views/login/view.html.php
+++ b/core/components/com_users/site/views/login/view.html.php
@@ -62,11 +62,19 @@ class UsersViewLogin extends JViewLegacy
 
 		$this->prepareDocument();
 
-		$defaultReturn = Route::url('index.php?option=com_members&task=myaccount');
+		$defaultReturn = Route::url('index.php?option=com_members&task=myaccount', false);
 		$description = '';
 		if (isset($active->params) && is_object($active->params))
 		{
 			$defaultReturn = $active->params->get('login_redirect_url', $defaultReturn);
+			// Assume redirect URLs that start with a slash are internal
+			// As such, we want to make sure the path has the appropriate root
+			$root = Request::root(true);
+			if (substr($defaultReturn, 0, 1) == '/'
+			 && substr($defaultReturn, 0, strlen($root)) != $root)
+			{
+				$defaultReturn = rtrim($root, '/') . $defaultReturn;
+			}
 			$description = $active->params->get('login_description');
 		}
 		$defaultReturn = base64_encode($defaultReturn);


### PR DESCRIPTION
Fixes an issue with redirecting to the correct root path when running
a hub in a sub directory (e.g., https://localhost/hubzero/). Admittedly,
unusual, but gets things working and doesn't harm normal setups.