### PR TITLE
[fix] Fix accidental reset of confirmation code

### DIFF
--- a/core/components/com_members/admin/controllers/members.php
+++ b/core/components/com_members/admin/controllers/members.php
@@ -481,11 +481,18 @@ class Members extends AdminController
 		$user->set('name', $name);
 		$user->set('modifiedDate', Date::toSql());
 
+		// Get their current activation code
+		$ac = $user->get('activation');
+
+		// If the incoming code is > zero, then the account being activated
+		// (unactivated accoutns have a negative-value code, e.g.: -123456)
 		if ($ec = Request::getInt('activation', 0, 'post'))
 		{
 			$user->set('activation', $ec);
 		}
-		else
+		// If the account was previously activated and we're de-activating
+		// reset the activation code.
+		elseif ($ac > 0)
 		{
 			$user->set('activation', Helpers\Utility::genemailconfirm());
 		}

--- a/core/components/com_members/admin/views/members/tmpl/edit_user.php
+++ b/core/components/com_members/admin/views/members/tmpl/edit_user.php
@@ -170,28 +170,28 @@ if (substr($this->profile->get('email'), -8) == '@invalid')
 				</tr>
 				<tr>
 					<th><?php echo Lang::txt('COM_MEMBERS_FIELD_REGISTERIP'); ?></th>
-					<th><?php echo $this->profile->get('registerIP'); ?></th>
+					<td><?php echo $this->profile->get('registerIP'); ?></td>
 				</tr>
 				<tr>
 					<th><?php echo Lang::txt('COM_MEMBERS_FIELD_REGISTERDATE'); ?></th>
-					<th><?php echo $this->profile->get('registerDate'); ?></th>
+					<td><?php echo $this->profile->get('registerDate'); ?></td>
 				</tr>
 				<tr>
 					<th><?php echo Lang::txt('COM_MEMBERS_FIELD_LASTVISITDATE'); ?></th>
-					<th><?php echo !$this->profile->get('lastvisitDate') || $this->profile->get('lastvisitDate') == '0000-00-00 00:00:00' ? Lang::txt('COM_MEMBERS_NEVER') : $this->profile->get('lastvisitDate'); ?></th>
+					<td><?php echo !$this->profile->get('lastvisitDate') || $this->profile->get('lastvisitDate') == '0000-00-00 00:00:00' ? Lang::txt('COM_MEMBERS_NEVER') : $this->profile->get('lastvisitDate'); ?></td>
 				</tr>
 				<tr>
 					<th><?php echo Lang::txt('COM_MEMBERS_FIELD_MODIFIED'); ?></th>
-					<th><?php echo !$this->profile->get('modifiedDate') || $this->profile->get('modifiedDate') == '0000-00-00 00:00:00' ? Lang::txt('COM_MEMBERS_NEVER') : $this->profile->get('modifiedDate'); ?></th>
+					<td><?php echo !$this->profile->get('modifiedDate') || $this->profile->get('modifiedDate') == '0000-00-00 00:00:00' ? Lang::txt('COM_MEMBERS_NEVER') : $this->profile->get('modifiedDate'); ?></td>
 				</tr>
 				<?php if ($incomplete) : ?>
 					<tr>
 						<th><?php echo Lang::txt('COM_MEMBERS_AUTHENTICATOR'); ?></th>
-						<th><?php echo $authenticator; ?></th>
+						<td><?php echo $authenticator; ?></td>
 					</tr>
 					<tr>
 						<th><?php echo Lang::txt('COM_MEMBERS_AUTHENTICATOR_STATUS'); ?></th>
-						<th><?php echo Lang::txt('COM_MEMBERS_INCOMPLETE'); ?></th>
+						<td><?php echo Lang::txt('COM_MEMBERS_INCOMPLETE'); ?></td>
 					</tr>
 				<?php endif; ?>
 			</tbody>


### PR DESCRIPTION
Saving an unconfirmed account would reset the activation code every
time. We only want to reset it when going from confirmed to unconfirmed.

Also fixing incorrect table cell type.

Fixes: https://help.hubzero.org/support/ticket/11781