### PR TITLE
[fix] Fixing bug causing collected wiki to error

### DIFF
--- a/core/components/com_collections/models/item.php
+++ b/core/components/com_collections/models/item.php
@@ -44,9 +44,9 @@ use User;
 use Lang;
 
 require_once \Component::path('com_members') . DS . 'models' . DS . 'member.php';
-require_once(dirname(__DIR__) . DS . 'tables' . DS . 'item.php');
-require_once(__DIR__ . DS . 'asset.php');
-require_once(__DIR__ . DS . 'tags.php');
+require_once dirname(__DIR__) . DS . 'tables' . DS . 'item.php';
+require_once __DIR__ . DS . 'asset.php';
+require_once __DIR__ . DS . 'tags.php';
 
 /**
  * Collections model for an item
@@ -484,7 +484,7 @@ class Item extends Base
 	 */
 	public function vote()
 	{
-		require_once(dirname(__DIR__) . DS . 'tables' . DS . 'vote.php');
+		require_once dirname(__DIR__) . DS . 'tables' . DS . 'vote.php';
 
 		$vote = new Tables\Vote($this->_db);
 		$vote->loadByBulletin($this->get('id'), User::get('id'));
@@ -686,7 +686,7 @@ class Item extends Base
 						'pagename' => 'collections',
 						'pageid'   => 0,
 						'filepath' => '',
-						'domain'   => 'collection'
+						'domain'   => ''//'collection'
 					);
 
 					$content = stripslashes((string) $this->get('description', ''));
@@ -889,7 +889,7 @@ class Item extends Base
 
 		if ($id)
 		{
-			require_once(dirname(__DIR__) . DS . 'tables' . DS . 'post.php');
+			require_once dirname(__DIR__) . DS . 'tables' . DS . 'post.php';
 
 			$post = new Tables\Post($this->_db);
 			$post->load($id);


### PR DESCRIPTION
When collected wiki pages are displayed, they are passed through a
content prepare event. This ends up setting the wiki page's scope to
'collection', which is incorrect and throws an error.