### PR TITLE
[fix] Only notify reviewers when grant info is set

### DIFF
--- a/core/components/com_projects/site/assets/css/edit.css
+++ b/core/components/com_projects/site/assets/css/edit.css
@@ -170,9 +170,3 @@
 	#hubForm ul {
 		list-style: none;
 	}
-
-	#hubForm input[type="radio"] {
-		float:left;
-		margin-top: 10px;
-		margin-right: 10px;
-	}

--- a/core/components/com_projects/site/assets/js/setup.js
+++ b/core/components/com_projects/site/assets/js/setup.js
@@ -96,6 +96,10 @@ HUB.ProjectSetup = {
 			}
 		}
 
+		$('[name=grant_info]').on('change', function(e){
+			$('#grant_info_block').toggleClass('hidden');
+		});
+
 		// Setup pre-screen
 		if ($('#f-restricted-no').length && $('#f-restricted-explain').length)
 		{
@@ -194,8 +198,7 @@ HUB.ProjectSetup = {
 						if (id == 'field-alias')
 						{
 							// Via AJAX
-							url = '/projects/verify/?no_html=1&ajax=1&text='
-							+ $(item).val() + '&pid=' + $('#pid').val();
+							url = $(item).attr('data-verify') + $(item).val() + '&pid=' + $('#pid').val();
 							$.post(url, {},
 								function (response) {
 
@@ -233,12 +236,14 @@ HUB.ProjectSetup = {
 
 	suggestAlias: function()
 	{
-		if ($('#field-alias').length && $('#field-alias').val() == ''
+		var alias = $('#field-alias');
+
+		if (alias.length && alias.val() == ''
 		&& $('#field-title').length && $('#field-title').val().length > 15)
 		{
-			var output = $('#field-alias').parent().find('.verification')[0];
+			var output = alias.parent().find('.verification')[0];
 			// Via AJAX
-			url = '/projects/suggestalias/?no_html=1&ajax=1&text=' + escape($('#field-title').val());
+			url = alias.attr('data-suggest') + escape($('#field-title').val());
 			$.post(url, {},
 				function (response) {
 					if (response)

--- a/core/components/com_projects/site/controllers/setup.php
+++ b/core/components/com_projects/site/controllers/setup.php
@@ -569,10 +569,18 @@ class Setup extends Base
 		{
 			$admingroup     = $this->config->get('admingroup', '');
 			$sdata_group    = $this->config->get('sdata_group', '');
-			$ginfo_group    = $this->config->get('ginfo_group', '');
 			$project_admins = Helpers\Html::getGroupMembers($admingroup);
-			$ginfo_admins   = Helpers\Html::getGroupMembers($ginfo_group);
 			$sdata_admins   = Helpers\Html::getGroupMembers($sdata_group);
+			$ginfo_admins   = array();
+
+			// Was grant information set?
+			if ($this->config->get('grantinfo', 0)
+			 && ($this->model->params->get('grant_title') || $this->model->params->get('grant_PI')))
+			{
+				// Notify the reviewer group
+				$ginfo_group  = $this->config->get('ginfo_group', '');
+				$ginfo_admins = Helpers\Html::getGroupMembers($ginfo_group);
+			}
 
 			$admins = array_merge($project_admins, $ginfo_admins, $sdata_admins);
 			$admins = array_unique($admins);

--- a/core/components/com_projects/site/controllers/setup.php
+++ b/core/components/com_projects/site/controllers/setup.php
@@ -511,7 +511,7 @@ class Setup extends Base
 			}
 
 			// Collect grant information
-			if ($this->config->get('grantinfo', 0))
+			if ($this->config->get('grantinfo', 0) && Request::getInt('grant_info', 0))
 			{
 				$grant_agency = Request::getString('grant_agency', '');
 				$grant_title  = Request::getString('grant_title', '');

--- a/core/components/com_projects/site/views/setup/tmpl/_edit_grant_info.php
+++ b/core/components/com_projects/site/views/setup/tmpl/_edit_grant_info.php
@@ -32,62 +32,100 @@
 defined('_HZEXEC_') or die();
 
 $approved = ($this->model->params->get('grant_status') == 1) ? 1 : 0;
+$hasGrantInfo = false;
+
+if ($this->model->params->get('grant_PI')
+|| $this->model->params->get('grant_title')
+|| $this->model->params->get('grant_agency')
+|| $this->model->params->get('grant_budget')
+|| $approved)
+{
+	$hasGrantInfo = true;
+}
 ?>
 
 <h5 class="terms-question">
 	<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO'); ?>
 </h5>
 
-<?php if ($approved): ?>
-	<p class="notice notice_passed">
-		<?php echo Lang::txt('COM_PROJECTS_GRANT_APPROVED_WITH_CODE'); ?>
-		<span class="prominent">
-			<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_approval', 'N/A'))); ?>
-		</span>
-	</p>
-<?php else: ?>
-	<p><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO_WHY'); ?></p>
-<?php endif; ?>
-
-<label for="param-grant_title" class="terms-label">
-	<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_TITLE'); ?>:
-	<?php if ($approved):  ?>
-		<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_title', 'N/A'))); ?></span>
-	<?php else: ?>
-		<input name="params[grant_title]" id="param-grant_title" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_title'))); ?>" class="long" />
-	<?php endif ?>
-</label>
-
-<label for="param-grant_PI" class="terms-label">
-	<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_PI'); ?>:
+<div class="form-group">
+	<div class="form-group form-check">
+		<label for="grant_info" class="form-check-label">
+			<input class="option form-check-input" name="grant_info" id="grant_info-no" type="radio" value="0" <?php if (!$hasGrantInfo) { echo 'checked="checked"'; } ?> />
+			<?php echo Lang::txt('JNO'); ?>
+		</label>
+	</div>
+	<div class="form-group form-check">
+		<label for="grant_info" class="form-check-label">
+			<input class="option form-check-input" name="grant_info" id="grant_info-yes" type="radio" value="1" <?php if ($hasGrantInfo) { echo 'checked="checked"'; } ?> />
+			<?php echo Lang::txt('JYES'); ?>
+		</label>
+	</div>
+</div>
+<div class="grant_info <?php if (!$hasGrantInfo) { echo 'hidden'; } ?>" id="grant_info_block">
 	<?php if ($approved): ?>
-		<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_PI', 'N/A'))); ?></span>
+		<p class="notice notice_passed">
+			<?php echo Lang::txt('COM_PROJECTS_GRANT_APPROVED_WITH_CODE'); ?>
+			<span class="prominent">
+				<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_approval', 'N/A'))); ?>
+			</span>
+		</p>
 	<?php else: ?>
-		<input name="params[grant_PI]" id="param-grant_PI" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_PI'))); ?>" class="long"  />
+		<p><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO_WHY'); ?></p>
 	<?php endif; ?>
-</label>
 
-<label for="param-grant_agency" class="terms-label">
-	<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_AGENCY'); ?>:
-	<?php if ($approved): ?>
-		<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_agency', 'N/A'))); ?></span>
-	<?php else: ?>
-		<input name="params[grant_agency]" id="param-grant_agency" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_agency'))); ?>" class="long" />
-	<?php endif ?>
-</label>
+	<div class="form-group">
+		<label for="param-grant_title" class="terms-label">
+			<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_TITLE'); ?>:
+			<?php if ($approved):  ?>
+				<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_title', 'N/A'))); ?></span>
+			<?php else: ?>
+				<input name="params[grant_title]" id="param-grant_title" class="form-control" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_title'))); ?>" class="long" />
+			<?php endif ?>
+		</label>
+	</div>
 
-<label for="param-grant_budget" class="terms-label">
-	<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_BUDGET'); ?>:
-	<?php if ($approved): ?>
-		<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_budget', 'N/A'))); ?></span>
-	<?php else: ?>
-		<input name="params[grant_budget]" id="param-grant_budget" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_budget'))); ?>" class="long"  />
+	<div class="form-group">
+		<label for="param-grant_PI" class="terms-label">
+			<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_PI'); ?>:
+			<?php if ($approved): ?>
+				<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_PI', 'N/A'))); ?></span>
+			<?php else: ?>
+				<input name="params[grant_PI]" id="param-grant_PI"class="form-control"  maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_PI'))); ?>" class="long"  />
+			<?php endif; ?>
+		</label>
+	</div>
+
+	<div class="form-group">
+		<label for="param-grant_agency" class="terms-label">
+			<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_AGENCY'); ?>:
+			<?php if ($approved): ?>
+				<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_agency', 'N/A'))); ?></span>
+			<?php else: ?>
+				<input name="params[grant_agency]" id="param-grant_agency" class="form-control" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_agency'))); ?>" class="long" />
+			<?php endif ?>
+		</label>
+	</div>
+
+	<div class="form-group">
+		<label for="param-grant_budget" class="terms-label">
+			<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_BUDGET'); ?>:
+			<?php if ($approved): ?>
+				<span class="prominent"><?php echo htmlentities(html_entity_decode($this->model->params->get('grant_budget', 'N/A'))); ?></span>
+			<?php else: ?>
+				<input name="params[grant_budget]" id="param-grant_budget" maxlength="250" type="text" value="<?php echo htmlentities(html_entity_decode($this->model->params->get('grant_budget'))); ?>" class="long"  />
+			<?php endif; ?>
+		</label>
+	</div>
+
+	<?php if (!$approved): ?>
+		<div class="form-group">
+			<div class="form-group form-check">
+				<label for="param-grant_status" class="form-check-label">
+					<input class="option form-check-input" name="params[grant_status]" id="param-grant_status" type="checkbox" value="0" <?php if ($this->model->params->get('grant_status') == 2) { echo 'checked="checked"'; } ?> />
+					<?php echo $this->model->params->get('grant_status') == 2 ? Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_RESUBMIT_FOR_APPROVAL'): Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_NOTIFY_ADMIN'); ?>
+				</label>
+			</div>
+		</div>
 	<?php endif; ?>
-</label>
-
-<?php if (!$approved): ?>
-	<label for="param-grant_status">
-		<input class="option" name="params[grant_status]" id="param-grant_status" type="checkbox" value="0" <?php if ($this->model->params->get('grant_status') == 2) { echo 'checked="checked"'; } ?> />
-		<?php echo $this->model->params->get('grant_status') == 2 ? Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_RESUBMIT_FOR_APPROVAL'): Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_NOTIFY_ADMIN') ; ?>
-	</label>
-<?php endif; ?>
+</div>

--- a/core/components/com_projects/site/views/setup/tmpl/describe.php
+++ b/core/components/com_projects/site/views/setup/tmpl/describe.php
@@ -95,7 +95,7 @@ $this->view('_title')
 				<p class="hint"><?php echo Lang::txt('COM_PROJECTS_HINTS_TITLE'); ?></p>
 				<label for="field-alias"><?php echo Lang::txt('COM_PROJECTS_ALIAS_NAME'); ?> <span class="required"><?php echo Lang::txt('JREQUIRED'); ?></span>
 					<span class="verification"></span>
-					<input name="name" maxlength="30" id="field-alias" type="text" value="<?php echo $this->model->get('alias'); ?>" <?php echo $this->model->get('id') ? ' disabled="disabled"' : ''; ?> class="verifyme" />
+					<input name="name" maxlength="30" id="field-alias" type="text" value="<?php echo $this->model->get('alias'); ?>" <?php echo $this->model->get('id') ? ' disabled="disabled"' : ''; ?> class="verifyme" data-verify="<?php echo Route::url('index.php?option=com_projects&task=verify&no_html=1&ajax=1&text='); ?>" data-suggest="<?php echo Route::url('index.php?option=com_projects&task=suggestalias&no_html=1&ajax=1&text='); ?>" />
 				</label>
 				<p class="hint"><?php echo Lang::txt('COM_PROJECTS_HINTS_NAME'); ?></p>
 				<div id="moveon" class="nogo">

--- a/core/components/com_projects/site/views/setup/tmpl/finalize.php
+++ b/core/components/com_projects/site/views/setup/tmpl/finalize.php
@@ -76,6 +76,16 @@ $ferpa       = $this->config->get('FERPAlink', 'http://www2.ed.gov/policy/gen/re
 	<div class="clear"></div>
 	<div class="setup-wrap">
 		<form id="hubForm" method="post" action="<?php echo Route::url('index.php?option=' . $this->option); ?>">
+			<?php 
+			// Display form fields
+			$this->view('_form')
+			     ->set('model', $this->model)
+			     ->set('step', $this->step)
+			     ->set('option', $this->option)
+			     ->set('controller', 'setup')
+			     ->set('section', $this->section)
+			     ->display();
+			?>
 			<div class="explaination">
 				<?php if ($this->config->get('restricted_data', 0)) { ?>
 				<h4><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PRIVACY_RULE'); ?></h4>
@@ -88,99 +98,118 @@ $ferpa       = $this->config->get('FERPAlink', 'http://www2.ed.gov/policy/gen/re
 				<?php } ?>
 			</div>
 			<fieldset>
-				<?php 
-				// Display form fields
-				$this->view('_form')
-				     ->set('model', $this->model)
-				     ->set('step', $this->step)
-				     ->set('option', $this->option)
-				     ->set('controller', 'setup')
-				     ->set('section', $this->section)
-				     ->display();
-				?>
 				<legend><?php echo Lang::txt('COM_PROJECTS_SETUP_BEFORE_COMPLETE'); ?></legend>
 				<p class="notice"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_WHY_ASK'); ?></p>
-				<?php if ($this->config->get('restricted_data', 0) == 1) { ?>
-				<h4 class="terms-question"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI'); ?><span class="required"><?php echo Lang::txt('REQUIRED'); ?></span></h4>
-				<label class="terms-label dark">
-					<input class="option restricted-answer" name="restricted" id="restricted-yes" type="radio" value="yes" <?php if ($this->model->params->get('restricted_data') == 'yes') { echo 'checked="checked"'; } ?> />
-					<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI_YES'); ?>
-				</label>
-				<div class="ipadded" id="restricted-choice">
-					<p class="hint prominent"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_MAKE_CHOICE'); ?></p>
-					<label class="terms-label">
-						<input class="option restricted-opt" name="export" id="export" type="checkbox" value="yes" <?php if ($this->model->params->get('export_data') == 'yes' ) { echo 'checked="checked"'; } ?> />
-						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_EXPORT_CONTROLLED'); ?>
-					</label>
-					<div id="stop-export" class="stopaction hidden"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_EXPORT'); ?></div>
-					<label class="terms-label">
-						<input class="option restricted-opt" name="irb" id="irb" type="checkbox" value="yes" <?php if ($this->model->params->get('irb_data') == 'yes' ) { echo 'checked="checked"'; } ?> />
-						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_IRB'); ?>
-					</label>
-					<div id="stop-irb" class="extraaction hidden">
-						<h5><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_MUST_ACKNOWLEDGE'); ?></h5>
-						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_IRB'); ?>
-						<label>
-							<input class="option" name="agree_irb" id="agree_irb" type="checkbox" value="1"  />
-							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_IRB_AGREE'); ?>
-						</label>
-					</div>
-					<label class="terms-label">
-						<input class="option restricted-opt" name="hipaa" id="hipaa" type="checkbox" value="yes" <?php if ($this->model->params->get('hipaa_data') == 'yes' ) { echo 'checked="checked"'; } ?> />
-						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_HIPAA'); ?>
-					</label>
-					<div id="stop-hipaa" class="stopaction hidden"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_HIPAA'); ?></div>
-					<label class="terms-label">
-						<input class="option restricted-opt" name="ferpa" id="ferpa" type="checkbox" value="yes" <?php if ($this->model->params->get('ferpa_data') == 'yes' ) { echo 'checked="checked"'; } ?> />
-						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_FERPA'); ?>
-					</label>
-					<div id="stop-ferpa" class="extraaction hidden">
-						<h5><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_MUST_ACKNOWLEDGE'); ?></h5>
-						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_FERPA'); ?>
-						<label>
-							<input class="option" name="agree_ferpa" id="agree_ferpa" type="checkbox" value="1"  />
-							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_FERPA_AGREE'); ?>
-						</label>
-					</div>
-				</div>
-				<label class="terms-label dark">
-					<input class="option restricted-answer" name="restricted" id="restricted-no" type="radio" value="no" <?php if ($this->model->params->get('restricted_data') == 'no' ) { echo 'checked="checked"'; } ?> />
-					<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI_NO'); ?>
-				</label>
 
+				<?php if ($this->config->get('restricted_data', 0) == 1) { ?>
+					<h4 class="terms-question"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI'); ?><span class="required"><?php echo Lang::txt('REQUIRED'); ?></span></h4>
+					<label class="terms-label dark">
+						<input class="option restricted-answer" name="restricted" id="restricted-yes" type="radio" value="yes" <?php if ($this->model->params->get('restricted_data') == 'yes') { echo 'checked="checked"'; } ?> />
+						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI_YES'); ?>
+					</label>
+					<div class="ipadded" id="restricted-choice">
+						<p class="hint prominent"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_MAKE_CHOICE'); ?></p>
+						<label class="terms-label">
+							<input class="option restricted-opt" name="export" id="export" type="checkbox" value="yes" <?php if ($this->model->params->get('export_data') == 'yes') { echo 'checked="checked"'; } ?> />
+							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_EXPORT_CONTROLLED'); ?>
+						</label>
+						<div id="stop-export" class="stopaction hidden"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_EXPORT'); ?></div>
+						<label class="terms-label">
+							<input class="option restricted-opt" name="irb" id="irb" type="checkbox" value="yes" <?php if ($this->model->params->get('irb_data') == 'yes') { echo 'checked="checked"'; } ?> />
+							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_IRB'); ?>
+						</label>
+						<div id="stop-irb" class="extraaction hidden">
+							<h5><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_MUST_ACKNOWLEDGE'); ?></h5>
+							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_IRB'); ?>
+							<label>
+								<input class="option" name="agree_irb" id="agree_irb" type="checkbox" value="1"  />
+								<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_IRB_AGREE'); ?>
+							</label>
+						</div>
+						<label class="terms-label">
+							<input class="option restricted-opt" name="hipaa" id="hipaa" type="checkbox" value="yes" <?php if ($this->model->params->get('hipaa_data') == 'yes') { echo 'checked="checked"'; } ?> />
+							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_HIPAA'); ?>
+						</label>
+						<div id="stop-hipaa" class="stopaction hidden"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_HIPAA'); ?></div>
+						<label class="terms-label">
+							<input class="option restricted-opt" name="ferpa" id="ferpa" type="checkbox" value="yes" <?php if ($this->model->params->get('ferpa_data') == 'yes') { echo 'checked="checked"'; } ?> />
+							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_PROJECT_WILL_INVOLVE_FERPA'); ?>
+						</label>
+						<div id="stop-ferpa" class="extraaction hidden">
+							<h5><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_MUST_ACKNOWLEDGE'); ?></h5>
+							<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_FERPA'); ?>
+							<label>
+								<input class="option" name="agree_ferpa" id="agree_ferpa" type="checkbox" value="1"  />
+								<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_RESTRICTED_STOP_FERPA_AGREE'); ?>
+							</label>
+						</div>
+					</div>
+					<label class="terms-label dark">
+						<input class="option restricted-answer" name="restricted" id="restricted-no" type="radio" value="no" <?php if ($this->model->params->get('restricted_data') == 'no') { echo 'checked="checked"'; } ?> />
+						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI_NO'); ?>
+					</label>
 				<?php } ?>
 				<?php if ($this->config->get('restricted_data', 0) == 2) { ?>
-				<h4 class="terms-question"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI'); ?><span class="required"><?php echo Lang::txt('REQUIRED'); ?></span></h4>
-				<label class="terms-label dark">
-					<input class="option" name="restricted" type="checkbox" value="no" />
-					<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_SENSITIVE_DATA_AGREE'); ?>
-				</label>
+					<h4 class="terms-question"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_QUESTION_PHI'); ?><span class="required"><?php echo Lang::txt('REQUIRED'); ?></span></h4>
+					<label class="terms-label dark">
+						<input class="option" name="restricted" type="checkbox" value="no" />
+						<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_SENSITIVE_DATA_AGREE'); ?>
+					</label>
 				<?php } ?>
 			</fieldset>
 			<div class="clear"></div>
-		<?php if ($this->config->get('grantinfo', 0)) { ?>
-			<div class="explaination">
-				<h4><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANTINFO_WHY'); ?></h4>
-				<p><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANTINFO_BECAUSE'); ?></p>
-			</div>
-			<fieldset>
-				<legend><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO'); ?></legend>
-				<p class="notice"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO_WHY'); ?></p>
-				<label class="terms-label"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_TITLE'); ?>:
-				 <input name="grant_title" maxlength="250" type="text" value="<?php echo $this->model->params->get('grant_title'); ?>" class="long" />
-				</label>
-				<label class="terms-label"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_PI'); ?>:
-				 <input name="grant_PI" maxlength="250" type="text" value="<?php echo $this->model->params->get('grant_PI'); ?>" class="long" />
-				</label>
-				<label class="terms-label"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_AGENCY'); ?>:
-				 <input name="grant_agency" maxlength="250" type="text" value="<?php echo $this->model->params->get('grant_agency'); ?>" class="long" />
-				</label>
-				<label class="terms-label"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_BUDGET'); ?>:
-				 <input name="grant_budget" maxlength="250" type="text" value="<?php echo $this->model->params->get('grant_budget'); ?>" class="long" />
-				</label>
-			</fieldset>
+
+			<?php if ($this->config->get('grantinfo', 0)) { ?>
+				<div class="explaination">
+					<h4><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANTINFO_WHY'); ?></h4>
+					<p><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANTINFO_BECAUSE'); ?></p>
+				</div>
+				<fieldset>
+					<legend><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO'); ?></legend>
+					<div class="form-group">
+						<div class="form-group form-check">
+							<label for="grant_info" class="form-check-label">
+								<input class="option form-check-input" name="grant_info" id="grant_info-no" type="radio" value="0" checked="checked" />
+								<?php echo Lang::txt('JNO'); ?>
+							</label>
+						</div>
+						<div class="form-group form-check">
+							<label for="grant_info" class="form-check-label">
+								<input class="option form-check-input" name="grant_info" id="grant_info-yes" type="radio" value="1" />
+								<?php echo Lang::txt('JYES'); ?>
+							</label>
+						</div>
+					</div>
+					<div class="grant_info hidden" id="grant_info_block">
+						<p class="notice"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_INFO_WHY'); ?></p>
+						<div class="form-group">
+							<label class="terms-label">
+								<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_TITLE'); ?>:
+								<input name="grant_title" maxlength="250" type="text" class="form-control" value="<?php echo $this->model->params->get('grant_title'); ?>" class="long" />
+							</label>
+						</div>
+						<div class="form-group">
+							<label class="terms-label">
+								<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_PI'); ?>:
+								<input name="grant_PI" maxlength="250" type="text" class="form-control" value="<?php echo $this->model->params->get('grant_PI'); ?>" class="long" />
+							</label>
+						</div>
+						<div class="form-group">
+							<label class="terms-label">
+								<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_AGENCY'); ?>:
+								<input name="grant_agency" maxlength="250" type="text" class="form-control" value="<?php echo $this->model->params->get('grant_agency'); ?>" class="long" />
+							</label>
+						</div>
+						<div class="form-group">
+							<label class="terms-label">
+								<?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_BUDGET'); ?>:
+								<input name="grant_budget" maxlength="250" type="text" class="form-control" value="<?php echo $this->model->params->get('grant_budget'); ?>" class="long" />
+							</label>
+						</div>
+					</div>
+				</fieldset>
+				<div class="clear"></div>
 			<?php } ?>
-			<div class="clear"></div>
 			<fieldset>
 				<legend><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS'); ?></legend>
 				<label class="terms-label">

--- a/core/templates/kimera/html/com_projects/edit.css
+++ b/core/templates/kimera/html/com_projects/edit.css
@@ -138,10 +138,3 @@
 	#hubForm ul {
 		list-style: none;
 	}
-
-	#hubForm input[type="radio"] {
-		float:left;
-		margin-top: 10px;
-		margin-right: 10px;
-	}
-


### PR DESCRIPTION
Only notify the sponsored projects reviewers when that info is set on a
project. This reduces noise for projects they may actually be concerned
with.

Refs: https://purr.purdue.edu/support/ticket/2011