### PR TITLE
[fix] Remove require_once to file that was removed.

### DIFF
--- a/core/components/com_events/models/event.php
+++ b/core/components/com_events/models/event.php
@@ -41,7 +41,6 @@ use Lang;
 use Date;
 // include tables
 require_once dirname(__DIR__) . DS . 'tables' . DS . 'event.php';
-require_once Component::path('com_events') . DS . 'models' . DS . 'eventdate.php';
 /**
  * Event model
  */


### PR DESCRIPTION
The eventdate.php file was removed since it was no longer needed,
but there was still a require_once attempting to load the file.