### PR TITLE
[fix] remove declaring Date namespace to allow Facade to work.

### DIFF
--- a/core/plugins/groups/calendar/calendar.php
+++ b/core/plugins/groups/calendar/calendar.php
@@ -32,7 +32,6 @@
 
 // No direct access
 defined('_HZEXEC_') or die();
-use Hubzero\Utility\Date;
 
 /**
  * Groups Plugin class for calendar


### PR DESCRIPTION
Date was having issues statically calling Date::toSql() since
the Facade is what permitted this static call.

fixes: https://help.hubzero.org/support/ticket/11799