### PR TITLE
[fix] Always insert scope_id as integer

### DIFF
--- a/core/components/com_wiki/models/link.php
+++ b/core/components/com_wiki/models/link.php
@@ -160,10 +160,7 @@ class Link extends Relational
 			$row->set('page_id', intval($link['page_id']));
 			$row->set('timestamp', $timestamp);
 			$row->set('scope', $link['scope']);
-			if ($link['scope_id'])
-			{
-				$row->set('scope_id', intval($link['scope_id']));
-			}
+			$row->set('scope_id', intval($link['scope_id']));
 			$row->set('link', $link['link']);
 			$row->set('url', $link['url']);
 


### PR DESCRIPTION
When not setting scope_id, it tries to create a new record with a NULL
value. It should be entering an integer.

Fixes: https://help.hubzero.org/support/ticket/11741