### PR TITLE
[fix] Ensure proper input type is being used.

### DIFF
--- a/core/plugins/groups/forum/views/categories/tmpl/edit.php
+++ b/core/plugins/groups/forum/views/categories/tmpl/edit.php
@@ -95,7 +95,7 @@ if ($this->category->get('section_id') == 0)
 						<div class="form-check">
 							<label for="field-closed" id="comment-anonymous-label" class="form-check-label">
 								<?php echo Lang::txt('PLG_GROUPS_FORUM_FIELD_LOCKED'); ?><br />
-								<input class="option" type="checkbox form-check-input" name="fields[closed]" id="field-closed" value="3"<?php if ($this->category->get('closed')) { echo ' checked="checked"'; } ?> />
+								<input class="option form-check-input" type="checkbox" name="fields[closed]" id="field-closed" value="3"<?php if ($this->category->get('closed')) { echo ' checked="checked"'; } ?> />
 								<?php echo Lang::txt('PLG_GROUPS_FORUM_FIELD_CLOSED'); ?>
 							</label>
 						</div>


### PR DESCRIPTION
Locking a forum category was supposed to be a checkbox,
but it was showing as a text type.

fixes: https://qubeshub.org/support/ticket/1402