### PR TITLE
[fix] jQuery's `live()` method is deprecated

### DIFF
--- a/core/components/com_courses/site/assets/js/plugins.js
+++ b/core/components/com_courses/site/assets/js/plugins.js
@@ -109,7 +109,7 @@ HUB.NanoHUBU = {
 	hubpresenterWindow: function()
 	{
 		//HUBpresenter open window
-		$jQ(".hubpresenter").live("click", function(e) {
+		$jQ(".hubpresenter").on("click", function(e) {
 			mobile = navigator.userAgent.match(/iPad|iPhone|iPod|Android/i) != null;
 			if(!mobile) {
 		 		HUBpresenter_window = window.open(this.href,'name','height=650,width=1100');
@@ -122,7 +122,7 @@ HUB.NanoHUBU = {
 	
 	youtubeLightbox: function()
 	{
-		$jQ(".videos a").live("click", function(e) {
+		$jQ(".videos a").on("click", function(e) {
 			e.preventDefault();
 			var url = this.href;
 		
@@ -306,7 +306,7 @@ HUB.NanoHUBU = {
 	{
 		if( $jQ("#to").length )
 		{
-			$jQ("#token-input-to").live("focus",function(e){
+			$jQ("#token-input-to").on("focus",function(e){
 				$jQ(".token-input-dropdown").width( $jQ(".token-input-list").outerWidth(true) );
 			});
 			

--- a/core/components/com_groups/site/assets/js/groups.js
+++ b/core/components/com_groups/site/assets/js/groups.js
@@ -193,7 +193,7 @@ HUB.Groups = {
 	{
 		var $ = this.jQuery;
 
-		$(".cancel_group_membership").live('click', function(e) {
+		$(".cancel_group_membership").on('click', function(e) {
 			e.preventDefault();
 
 			var answer = confirm('Are you sure you would like to cancel your group membership?');

--- a/core/components/com_publications/site/assets/js/video.js
+++ b/core/components/com_publications/site/assets/js/video.js
@@ -222,25 +222,22 @@ HUB.Video = {
 	
 	toggleControls: function()
 	{
-		$jQ("#video-container").live({
-			mouseenter: function(e) {
+		$jQ('body')
+			.on('mouseenter', "#video-container", function(e) {
 				if(!$jQ('#video-toolbar').is(":visible") ) {
 					$jQ('#video-toolbar').fadeIn('slow');
 				}
-			},
-			mouseleave: function(e)
-			{
+			})
+			.on('mouseleave', "#video-container", function(e) {
 				$jQ("#video-toolbar").stop(true).fadeOut("slow", function() {
 					$jQ(this).css('opacity', '');
 				});
-			},
-			mousemove: function(e) 
-			{
+			})
+			.on('mousemove', "#video-container", function(e) {
 				if(!$jQ('#video-toolbar').is(":visible") ) {
 					$jQ('#video-toolbar').fadeIn('slow');
 				}
-			}
-		});
+			});
 	},
 	
 	//-----
@@ -469,7 +466,7 @@ HUB.Video = {
 			}
 			
 			
-			$jQ("#subtitle-picker ul a").live("click", function(e) {
+			$jQ("#subtitle-picker ul a").on("click", function(e) {
 				track = this.rel;
 				
 				if(track != "") {

--- a/core/components/com_resources/site/assets/js/hubpresenter.js
+++ b/core/components/com_resources/site/assets/js/hubpresenter.js
@@ -961,17 +961,17 @@ HUB.Presenter = {
 		
 		jQ("#replay-details #title").html( "<span>Title:</span> " + jQ("#presenter-header #title").html() );
 		
-		jQ("#replay-link").live("click", function(e) {
+		jQ("#replay-link").on("click", function(e) {
 			this.select();
 			e.preventDefault();
 		});
 		
-		jQ("#replay-now").live("click", function(e) {
+		jQ("#replay-now").on("click", function(e) {
 			HUB.Presenter.doReplay("#replay");
 			e.preventDefault();
 		});
 		
-		jQ("#replay-back").live("click", function(e) {
+		jQ("#replay-back").on("click", function(e) {
 			window.close();
 			e.preventDefault();
 		});

--- a/core/components/com_resources/site/assets/js/video.js
+++ b/core/components/com_resources/site/assets/js/video.js
@@ -182,19 +182,19 @@ HUB.Video = {
 	controlBar: function()
 	{
 		//play pause functionality
-		$jQ('#play-pause').bind('click', function(e) {
+		$jQ('#play-pause').on('click', function(e) {
 			HUB.Video.playPause(true);
 			e.preventDefault();
 		});
 		
 		//play pause functionality
-		$jQ('#link').bind('click', function(e) {
+		$jQ('#link').on('click', function(e) {
 			HUB.Video.linkVideo();
 			e.preventDefault();
 		});
 		
 		//full screen mode
-		$jQ('#full-screen').bind('click', function(e) {
+		$jQ('#full-screen').on('click', function(e) {
 			HUB.Video.fullScreen();
 			e.preventDefault();
 		});
@@ -703,19 +703,19 @@ HUB.Video = {
 		$jQ("#replay-details #title").html( "<span>Title:</span> " + document.title );
 		
 		//auto-select replay link
-		$jQ("#replay-link").live("click", function(e) {
+		$jQ("#replay-link").on("click", function(e) {
 			this.select();
 			e.preventDefault();
 		});
 		
 		//replay video link
-		$jQ("#replay-now").live("click", function(e) {
+		$jQ("#replay-now").on("click", function(e) {
 			HUB.Video.doReplay("#replay");
 			e.preventDefault();
 		});
 		
 		//close video
-		$jQ("#replay-back").live("click", function(e) {
+		$jQ("#replay-back").on("click", function(e) {
 			window.close();
 			e.preventDefault();
 		});


### PR DESCRIPTION
Refactoring scripts to not use a deprecated method.

Fixes: https://help.hubzero.org/support/ticket/11806