### PR TITLE
[fix] Catching missed datetime column

### DIFF
--- a/core/components/com_support/migrations/Migration20190411000000ComSupport.php
+++ b/core/components/com_support/migrations/Migration20190411000000ComSupport.php
@@ -1,0 +1,70 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for changing DATETIME fields default to NULL for com_support
+ **/
+class Migration20190411000000ComSupport extends Base
+{
+	/**
+	 * List of tables and their datetime fields
+	 *
+	 * @var  array
+	 **/
+	public static $tables = array(
+		'#__support_tickets' => array(
+			'target_date'
+		)
+	);
+
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		foreach (self::$tables as $table => $fields)
+		{
+			foreach ($fields as $field)
+			{
+				if ($this->db->tableExists($table)
+				 && $this->db->tableHasField($table, $field))
+				{
+					$query = "ALTER TABLE `$table` CHANGE `$field` `$field` DATETIME  NULL  DEFAULT NULL";
+
+					$this->db->setQuery($query);
+					$this->db->query();
+
+					$query = "UPDATE `$table` SET `$field`=NULL WHERE `$field`='0000-00-00 00:00:00'";
+
+					$this->db->setQuery($query);
+					$this->db->query();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		foreach (self::$tables as $table => $fields)
+		{
+			foreach ($fields as $field)
+			{
+				if ($this->db->tableExists($table)
+				 && $this->db->tableHasField($table, $field))
+				{
+					$query = "ALTER TABLE `$table` CHANGE `$field` `$field` DATETIME  NOT NULL  DEFAULT '0000-00-00 00:00:00'";
+
+					$this->db->setQuery($query);
+					$this->db->query();
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This column should have had its default updated to `NULL` in a previous
migration but was missed.