### PR TITLE
[fix] Ensure course questions can be properly edited.

### DIFF
--- a/core/components/com_courses/site/views/form/tmpl/layout.php
+++ b/core/components/com_courses/site/views/form/tmpl/layout.php
@@ -72,25 +72,26 @@ $this->css('jquery.ui.css', 'system')
 						foreach ($layout[$idx - 1] as $group)
 						{
 							\Document::addstyleDeclaration('
-								#group-marker-'.$idx.' {
+								#group-marker-'.$qidx.' {
 									width: '.$group['width'].'px;
 									height: '.$group['height'].'px;
 									top: '.$group['top'].'px;
 									left: '.$group['left'].'px;
 								}
 							');
-							echo '<div class="group-marker" id="group-marker-'.$idx.'">';
+							echo '<div class="group-marker" id="group-marker-'.$qidx.'">';
 							echo '<div class="group-marker-header"></div>';
 							echo '<button class="remove">x</button>';
 							foreach ($group['answers'] as $aidx => $ans)
 							{
-								\Document::addstyleDeclaration('
-									#question-saved-'.$idx.'-'.$qidx.' {
+								$answerId = 'question-saved-' . $idx . '-' . $qidx . '-' . $aidx;
+								\Document::addstyleDeclaration(
+									'#' . $answerId . '{
 										top: '.($ans['top'] - $group['top'] - 5).'px;
 										left: '.($ans['left'] - $group['left'] - 26).'px;
 									}
 								');
-								echo '<div class="radio-container'.($ans['correct'] ? ' selected' : '').'" id="question-saved-'.$idx.'-'.$qidx.'">';
+								echo '<div class="radio-container'.($ans['correct'] ? ' selected' : '').'" id="' . $answerId . '">';
 								echo '<button class="remove">x</button>';
 								echo '<input name="question-saved-'.$idx.'-'.$qidx.'" value="'.$aidx.'" class="placeholder"'.($ans['correct'] ? ' checked="checked"' : '').' type="radio" />';
 								echo '</div>';


### PR DESCRIPTION
Editing a course quiz or viewing the preview as an instructor
would only show the choice marked as correct instead of all
choices.

As a result, if the quiz was then saved it was cause it to
save in this one option state.

fixes: https://smarteragriculture.org/support/ticket/258