### PR TITLE
[fix] Ensure var is set before using

### DIFF
--- a/core/components/com_resources/admin/views/items/tmpl/edit.php
+++ b/core/components/com_resources/admin/views/items/tmpl/edit.php
@@ -118,7 +118,7 @@ $this->view('_edit_script')
 
 					$fields = $elements->getElements('nbtag');
 
-					if (count($fields) > 0)
+					if ($fields && count($fields) > 0)
 					{
 						foreach ($fields as $field)
 						{


### PR DESCRIPTION
When creating a new resource on the admin side, a 'type' hasn't been
chosen yet. Custom fields are associated with types, so the code that
gets the list of fields returns `false`.

Fixes: https://nanohub.org/support/ticket/347362