### PR TITLE
[fix] Check for registered objects before use

### DIFF
--- a/core/bootstrap/Site/routes.php
+++ b/core/bootstrap/Site/routes.php
@@ -40,6 +40,11 @@
 */
 $router->rules('build')->append('content', function ($uri)
 {
+	if (!\App::has('menu.manager'))
+	{
+		return $uri;
+	}
+
 	// Set URI defaults
 	$menu = \App::get('menu.manager')->menu('site');
 
@@ -185,7 +190,7 @@ $router->rules('build')->append('component', function ($uri)
 
 	$built = false;
 
-	if (isset($query['Itemid']) && !empty($query['Itemid']))
+	if (isset($query['Itemid']) && !empty($query['Itemid']) && \App::has('menu.manager'))
 	{
 		$menu = \App::get('menu.manager')->menu('site');
 		$item = $menu->getItem($query['Itemid']);

--- a/core/components/com_projects/api/controllers/projectsv2_0.php
+++ b/core/components/com_projects/api/controllers/projectsv2_0.php
@@ -593,7 +593,7 @@ class Projectsv2_0 extends ApiController
 
 		if (!$row->save())
 		{
-			throw new Exception(Lang::txt('COM_PROJECTS_ERROR_SAVING_DATA'), 500);
+			throw new Exception($row->getError(), 500);
 		}
 
 		// Trigger after save event


### PR DESCRIPTION
This helps guard against cases where the site routes might be called
from a client type that doesn't have all services registered. Use case
might be the API calling `Route::urlForClient('site', $url)`.

Refs: https://mygeohub.org/support/ticket/1393