### PR TITLE
[fix] Skip plugins that don't have files

### DIFF
--- a/core/components/com_search/models/basic/result/set.php
+++ b/core/components/com_search/models/basic/result/set.php
@@ -365,6 +365,11 @@ class Set extends Obj implements Iterator
 		{
 			foreach ($plugins as $plugin)
 			{
+				if (!is_dir(Plugin::path('search', $plugin->name)))
+				{
+					continue;
+				}
+
 				if (Plugin::isEnabled('search', $plugin->name))
 				{
 					$refl = new ReflectionClass("plgSearch$plugin->name");
@@ -384,6 +389,11 @@ class Set extends Obj implements Iterator
 
 		foreach ($plugins as $plugin)
 		{
+			if (!is_dir(Plugin::path('search', $plugin->name)))
+			{
+				continue;
+			}
+
 			if (!Plugin::isEnabled('search', $plugin->name))
 			{
 				continue;
@@ -424,6 +434,11 @@ class Set extends Obj implements Iterator
 		$plugin_types = array_keys($weighters);
 		foreach ($plugins as $plugin)
 		{
+			if (!is_dir(Plugin::path('search', $plugin->name)))
+			{
+				continue;
+			}
+
 			if (!Plugin::isEnabled('search', $plugin->name))
 			{
 				continue;


### PR DESCRIPTION
This gets the plugin lsit from the database. In some rare/odd cases, the
actual plugin files may be missing and a 500 will get thrown. So, skip
plugins that don't have files.