### PR TITLE
[fix] Remove IDs from URL paths

### DIFF
--- a/core/components/com_content/site/router.php
+++ b/core/components/com_content/site/router.php
@@ -55,7 +55,10 @@ class Router extends Base
 		for ($i = 0; $i < $total; $i++)
 		{
 			//$segments[$i] = str_replace(':', '-', $segments[$i]);
-			$segments[$i] = trim(strstr($segments[$i], ':'), ':');
+			if (strstr($segments[$i], ':'))
+			{
+				$segments[$i] = trim(strstr($segments[$i], ':'), ':');
+			}
 		}
 
 		return $segments;

--- a/core/components/com_content/site/router.php
+++ b/core/components/com_content/site/router.php
@@ -54,7 +54,8 @@ class Router extends Base
 
 		for ($i = 0; $i < $total; $i++)
 		{
-			$segments[$i] = str_replace(':', '-', $segments[$i]);
+			//$segments[$i] = str_replace(':', '-', $segments[$i]);
+			$segments[$i] = trim(strstr($segments[$i], ':'), ':');
 		}
 
 		return $segments;
@@ -138,7 +139,7 @@ class Router extends Base
 					if (strpos($query['id'], ':') === false)
 					{
 						$db = App::get('db');
-						$aquery = $db->setQuery(
+						$db->setQuery(
 							$db->getQuery()
 								->select('alias')
 								->from('#__content')


### PR DESCRIPTION
IDs in URL slugs are no longer needed as site routing was modified
awhile ago to support `/{category alias}/{article alias}`.