### PR TITLE
Set the value of element "resourceType" to "Dataset series" in DOI's metadata record

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -277,7 +277,7 @@ class Doi extends Obj
 		$license = $pub->license();
 		$licenseTitle = is_object($license) ? $license->title : null;
 		$this->set('license', htmlspecialchars($licenseTitle));
-		
+
 		// Map related identifier
 		$lastPub = $pub->lastPublicRelease();
 		if ($lastPub && $lastPub->doi && $pub->version->version_number > 1)

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -251,11 +251,9 @@ class Doi extends Obj
 		$this->set('url', $this->_configs->livesite . DS . 'publications'. DS . $pub->id . DS . $pub->version->version_number);
 
 		// Set dates
-		$pubYear = $pub->version->published_up
-				&& $pub->version->published_up != $this->_db->getNullDate()
+		$pubYear = $pub->version->published_up && $pub->version->published_up != $this->_db->getNullDate()
 				? date('Y', strtotime($pub->version->published_up)) : date('Y');
-		$pubDate = $pub->version->published_up
-			&& $pub->version->published_up != $this->_db->getNullDate()
+		$pubDate = $pub->version->published_up && $pub->version->published_up != $this->_db->getNullDate()
 				? date('Y-m-d', strtotime($pub->version->published_up)) : date('Y-m-d');
 		$this->set('pubYear', $pubYear);
 		$this->set('datePublished', $pubDate);

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -271,25 +271,15 @@ class Doi extends Obj
 		// Map resource type
 		$category = $pub->category();
 		$dcType   = $category->dc_type ? $category->dc_type : 'Dataset';
-		//$categoryName = explode('/', $category->name);
-		//$categoryName = array_pop($categoryName);
-		if ($category->alias == "series")
-		{
-			$categoryName = "Dataset series";
-		}
-		else
-		{
-			$categoryName = $category->name;
-		}
-		
 		$this->set('resourceType', $dcType);
+		$categoryName = ($category->alias == "series") ? "Dataset series" : $category->name;
 		$this->set('resourceTypeTitle', htmlspecialchars($categoryName));
 
 		// Map license
 		$license = $pub->license();
 		$licenseTitle = is_object($license) ? $license->title : null;
 		$this->set('license', htmlspecialchars($licenseTitle));
-
+		
 		// Map related identifier
 		$lastPub = $pub->lastPublicRelease();
 		if ($lastPub && $lastPub->doi && $pub->version->version_number > 1)

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -271,8 +271,17 @@ class Doi extends Obj
 		// Map resource type
 		$category = $pub->category();
 		$dcType   = $category->dc_type ? $category->dc_type : 'Dataset';
-		$categoryName = explode('/', $category->name);
-		$categoryName = array_pop($categoryName);
+		//$categoryName = explode('/', $category->name);
+		//$categoryName = array_pop($categoryName);
+		if ($category->alias == "series")
+		{
+			$categoryName = "Dataset series";
+		}
+		else
+		{
+			$categoryName = $category->name;
+		}
+		
 		$this->set('resourceType', $dcType);
 		$this->set('resourceTypeTitle', htmlspecialchars($categoryName));
 


### PR DESCRIPTION
The value of element "resourceType" need to be changed to "Dataset series" in DOI's metadata record that associates with a series publication. The phrase "Dataset series" is defined in CASRAI vocabulary to describe the datasets collection and datasets aggregation, which confirms to the nature of the series on PURR where series serves as a collection of datasets.