### PR TITLE
[fix] Force value to `null` if empty string

### DIFF
--- a/core/components/com_groups/site/controllers/pages.php
+++ b/core/components/com_groups/site/controllers/pages.php
@@ -283,6 +283,11 @@ class Pages extends Base
 		$depth  = ($parent->get('id')) ? $parent->get('depth') + 1 : 0;
 		$this->page->set('depth', $depth);
 
+		if (!$this->page->get('category'))
+		{
+			$this->page->set('category', null);
+		}
+
 		// make sure we can create both the page and version
 		if (!$this->page->check() || !$this->version->check())
 		{


### PR DESCRIPTION
This is a fix for MySQL strict mode. The database field is an integer
and should probably be changed to `NOT NULL DEFAULT'0'` at a later
point.