### PR TITLE
PHP 7 compatibility fixes

### DIFF
--- a/core/components/com_kb/site/views/articles/tmpl/article.php
+++ b/core/components/com_kb/site/views/articles/tmpl/article.php
@@ -105,7 +105,7 @@ Document::setTitle(Lang::txt('COM_KB') . ': ' . $this->category->get('title') . 
 							<a <?php if ($this->catid == $row->get('id')) { echo 'class="active" '; } ?> href="<?php echo Route::url($row->link()); ?>">
 								<?php echo $this->escape(stripslashes($row->get('title'))); ?> <span class="item-count"><?php echo $row->get('articles', 0); ?></span>
 							</a>
-							<?php if ($this->catid == $row->get('id') && count($row->children($filters)) > 0) { ?>
+							<?php if ($this->catid == $row->get('id') && is_countable($row->children($filters)) && count($row->children($filters)) > 0) { ?>
 								<ul class="categories">
 								<?php foreach ($row->children() as $cat) { ?>
 									<li>

--- a/core/components/com_wishlist/models/wishlist.php
+++ b/core/components/com_wishlist/models/wishlist.php
@@ -348,7 +348,7 @@ class Wishlist extends Relational
 					if (!$tbl->delete_owner($this->get('id'), $user_id, $this->config('group', 'hubadmin')))
 					{
 						$this->setError($tbl->getError());
-						continue;
+						continue 2;
 					}
 				break;
 
@@ -358,7 +358,7 @@ class Wishlist extends Relational
 					if (!$tbl->delete_owner_group($this->get('id'), $group_id, $this->config('group', 'hubadmin')))
 					{
 						$this->setError($tbl->getError());
-						continue;
+						continue 2;
 					}
 				break;
 			}

--- a/core/modules/mod_menu/helper.php
+++ b/core/modules/mod_menu/helper.php
@@ -111,7 +111,7 @@ class Helper extends Module
 					{
 						case 'separator':
 							// No further action needed.
-							continue;
+							continue 2;
 
 						case 'url':
 							if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false))

--- a/core/modules/mod_mytickets/tmpl/default.php
+++ b/core/modules/mod_mytickets/tmpl/default.php
@@ -62,7 +62,7 @@ $this->css();
 	<h4>
 		<?php echo Lang::txt('MOD_MYTICKETS_CONTRIBUTIONS'); ?>
 	</h4>
-	<?php if (count($this->rows3) <= 0) { ?>
+	<?php if (!is_countable($this->rows3) || count($this->rows3) <= 0) { ?>
 		<p><em><?php echo Lang::txt('MOD_MYTICKETS_NO_TICKETS'); ?></em></p>
 	<?php } else { ?>
 		<ul class="expandedlist">


### PR DESCRIPTION
continue; -> continue 2; -- in PHP 7 switch is a looping structure so continue; works on the switch; the '2' goes out 2 levels to the foreach.  No idea if this still works in PHP 5.

The is_countable() prevents the error where a value that is not an array or implements Countable is passed to count().  There may be a better fix for these, but this was the most direct.