### PR TITLE
[fix] Change how authorids are generated

### DIFF
--- a/core/components/com_resources/models/author.php
+++ b/core/components/com_resources/models/author.php
@@ -293,7 +293,14 @@ class Author extends Relational
 		// If not account if found, use a negative timestamp
 		if ($uid == null)
 		{
-			$uid = -(time());
+			//$uid = -(time());
+			$uid = self::all()
+				->where('authorid', '<', 0)
+				->order('authorid', 'asc')
+				->limit(1)
+				->row()
+				->get('authorid');
+			$uid = -(abs($uid) + 1);
 		}
 
 		return $uid;


### PR DESCRIPTION
Records could be processed fast enough that `time()` won't change and
result in duplicate authorids.

Fixes: https://habricentral.org/support/ticket/849