### PR TITLE
[fix] Set positioning against body element

### DIFF
--- a/core/plugins/projects/files/assets/js/files.js
+++ b/core/plugins/projects/files/assets/js/files.js
@@ -1008,6 +1008,7 @@ HUB.ProjectFiles = {
 		// Preview files
 		var preview = $('.preview');
 		var div = $('#preview-window');
+		div.appendTo('body');
 		var keyupTimer2 = '';
 		var preview_open = 0;
 		var in_preview = 0;
@@ -1045,10 +1046,12 @@ HUB.ProjectFiles = {
 			{
 				e.preventDefault();
 				var coord = $(item).offset();
-				if (subtract) {
+				coord.top += $(item).height();
+				coord.left += $(item).width();
+				/*if (subtract) {
 					coord.top -= subtract.top;
 					coord.left -= subtract.left;
-				}
+				}*/
 
 				if (keyupTimer2) {
 					clearTimeout(keyupTimer2);


### PR DESCRIPTION
The various cotnent containers could have `position: relative` on them
which can alter how `position: absolute` co-ordinates display. So, we
move the preview box to be a child of `body` and set coordinates based
on that. This keeps the popup the same across varying templates.

Fixes: https://purr.purdue.edu/support/ticket/2024