### PR TITLE
[fix] restore jQuery load where used for ajax requests.

### DIFF
--- a/core/components/com_groups/site/assets/js/groups.js
+++ b/core/components/com_groups/site/assets/js/groups.js
@@ -242,7 +242,7 @@ HUB.Groups = {
 
 			//load a refreshed version of the logo list
 			//reset option previously selected by user
-			$("#group-logo-label").on('load', window.location.href + ' #group-logo-label > select', function() {
+			$("#group-logo-label").load(window.location.href + ' #group-logo-label > select', function() {
 				$("#group_logo").val(current);
 			});
 		}
@@ -620,7 +620,7 @@ HUB.Groups = {
 							afterClose: function() {
 								if (newCategory != '')
 								{
-									$('.page-category-label').on('load', window.location.href + ' .page-category-label > *', function(){
+									$('.page-category-label').load(window.location.href + ' .page-category-label > *', function(){
 										HUB.Groups.pagesEditPageCategory();
 										$('.page-category').HUBfancyselect('selectText', newCategory);
 									});
@@ -845,7 +845,7 @@ HUB.Groups = {
 			},
 			success: function(data, status, jqXHR)
 			{
-				$('.pages').on('load', window.location.href + " .pages > *", function(){
+				$('.pages').load(window.location.href + " .pages > *", function(){
 					$('.pages').removeClass('rebuilding');
 					$('.page-order-actions').fadeOut("slow", function() {
 						$(this).remove();
@@ -860,7 +860,7 @@ HUB.Groups = {
 
 	pagesReorderPagesReset: function()
 	{
-		$('.pages').on('load', window.location.href + " .pages > *", function(){
+		$('.pages').load(window.location.href + " .pages > *", function(){
 			$('.page-order-actions').fadeOut("slow", function() {
 				$(this).remove();
 			});

--- a/core/components/com_members/site/assets/js/incremental.js
+++ b/core/components/com_members/site/assets/js/incremental.js
@@ -6,7 +6,7 @@
 
 jQuery(document).ready(function($)
 {
-	var inps = document.getElementById('hubForm').getElementsByTagName('input');
+	var inps = document.getElementById('profile').getElementsByTagName('input');
 	var wallet = document.getElementById('wallet').getElementsByTagName('span')[0];
 	var wallet_par = document.getElementById('wallet');
 	var showing = 0;

--- a/core/plugins/members/profile/assets/js/profile.js
+++ b/core/plugins/members/profile/assets/js/profile.js
@@ -313,12 +313,11 @@ HUB.Members.Profile = {
 			
 			//show updating overlay
 			HUB.Members.Profile.editShowUpdatingOverlay(".member_profile");
-
 			var url = $('#profile-page-content').attr('data-url');
 
-			$(".member_profile").on('load', url + " #profile-page-content", function() {
+			$(".member_profile").load(url + " #profile-page-content", function() {
 				//reload page header in case we edited name
-				$("#page_header").on('load', url +  " #page_header > *");
+				$("#page_header").load(url +  " #page_header > *");
 			
 				//show edit links
 				$(".section-edit a").show();


### PR DESCRIPTION
jQuery "load" used to be used in two different ways:
an Event listener shortcut (this was has been removed)
or a simple way to fetch data from a URL.
This way is still valid.

fixes: https://nanohub.org/support/ticket/350066