### PR TITLE
[fix] Ensure member search includes all activated members

### DIFF
--- a/core/components/com_members/models/member.php
+++ b/core/components/com_members/models/member.php
@@ -550,7 +550,7 @@ class Member extends User implements \Hubzero\Search\Searchable
 			->start($offset)
 			->limit($limit)
 			->whereEquals('block', 0)
-			->whereEquals('activation', 1)
+			->where('activation', '>', 0)
 			->where('approved', '>', 0)
 			->rows();
 	}
@@ -564,7 +564,7 @@ class Member extends User implements \Hubzero\Search\Searchable
 	{
 		return self::all()
 			->whereEquals('block', 0)
-			->whereEquals('activation', 1)
+			->where('activation', '>', 0)
 			->where('approved', '>', 0)
 			->total();
 	}


### PR DESCRIPTION
Members wasn't indexing users with an "activation" value set
to greater than 1, which would often be the case for users
who created accounts via third party authenticator.

fixes: https://nanohub.org/support/ticket/349930