### PR TITLE
[fix] Group users with multiple sessions

### DIFF
--- a/core/modules/mod_whosonline/helper.php
+++ b/core/modules/mod_whosonline/helper.php
@@ -10,6 +10,7 @@ namespace Modules\Whosonline;
 use Hubzero\Module\Module;
 use Hubzero\Session\Helper as SessionHelper;
 use Hubzero\User\User;
+use App;
 
 /**
  * Module class for showing users online
@@ -78,7 +79,7 @@ class Helper extends Module
 	 */
 	public function displayAdmin()
 	{
-		if (!\App::isAdmin())
+		if (!App::isAdmin())
 		{
 			return;
 		}

--- a/core/modules/mod_whosonline/tmpl/default_admin.php
+++ b/core/modules/mod_whosonline/tmpl/default_admin.php
@@ -9,20 +9,24 @@ defined('_HZEXEC_') or die();
 
 $this->css();
 
-//get whos online summary
+// get whos online summary
 $siteUserCount  = 0;
 $adminUserCount = 0;
-foreach ($this->rows as $row)
-{
-	if ($row->client_id == 0)
-	{
+$found = array();
+foreach ($this->rows as $i => $row):
+	if ($row->userid && in_array($row->client_id . '.' . $row->userid, $found)):
+		unset($this->rows[$i]);
+		continue;
+	endif;
+
+	$found[] = $row->client_id . '.' . $row->userid;
+
+	if ($row->client_id == 0):
 		$siteUserCount++;
-	}
-	else
-	{
+	else:
 		$adminUserCount++;
-	}
-}
+	endif;
+endforeach;
 
 $editAuthorized = User::authorise('core.manage', 'com_members');
 ?>
@@ -49,9 +53,9 @@ $editAuthorized = User::authorise('core.manage', 'com_members');
 				<th scope="col"><?php echo Lang::txt('MOD_WHOSONLINE_COL_USER'); ?></td>
 				<th scope="col"><?php echo Lang::txt('MOD_WHOSONLINE_COL_LOCATION'); ?></th>
 				<th scope="col" class="priority-3"><?php echo Lang::txt('MOD_WHOSONLINE_COL_ACTIVITY'); ?></th>
-				<?php if ($editAuthorized) { ?>
+				<?php if ($editAuthorized): ?>
 					<th scope="col"><?php echo Lang::txt('MOD_WHOSONLINE_COL_LOGOUT'); ?></th>
-				<?php } ?>
+				<?php endif; ?>
 			</tr>
 		</thead>
 		<tbody>
@@ -65,14 +69,11 @@ $editAuthorized = User::authorise('core.manage', 'com_members');
 									$user = User::getInstance($row->username);
 
 									// Display link if we are authorized
-									if ($editAuthorized)
-									{
+									if ($editAuthorized):
 										echo '<a href="' . Route::url('index.php?option=com_members&task=edit&id='. $row->userid) . '" title="' . Lang::txt('MOD_WHOSONLINE_EDIT_USER') . '">' . $this->escape($user->get('name')) . ' [' . $this->escape($user->get('username')) . ']' . '</a>';
-									}
-									else
-									{
+									else:
 										echo $this->escape($user->get('name')) . ' [' . $this->escape($user->get('username')) . ']';
-									}
+									endif;
 								?>
 							</td>
 							<td>
@@ -84,13 +85,13 @@ $editAuthorized = User::authorise('core.manage', 'com_members');
 							<td class="priority-3">
 								<?php echo Lang::txt('MOD_WHOSONLINE_HOURS_AGO', (time() - $row->time)/3600.0); ?>
 							</td>
-							<?php if ($editAuthorized) { ?>
+							<?php if ($editAuthorized): ?>
 								<td>
 									<a class="force-logout" href="<?php echo Route::url('index.php?option=com_login&task=logout&uid=' . $row->userid .'&'. Session::getFormToken() .'=1'); ?>">
 										<span><?php echo Lang::txt('JLOGOUT'); ?></span>
 									</a>
 								</td>
-							<?php } ?>
+							<?php endif; ?>
 						</tr>
 					<?php endif; ?>
 				<?php endforeach; ?>


### PR DESCRIPTION
Users can have multiple sessions (unique session IDs tied to the same
userid) by logging in with multiple browsers, or private windows. Try
to group them so they only show up once in the list. This could also be
accomplished by removing the `session_id` column from the SQL `group by`
clause but there may be cases where you want the individual sessions, so
the query is left unchanged.

Fixes: https://qubeshub.org/support/ticket/1419