### PR TITLE
[fix] Set a max height on the module

### DIFF
--- a/core/modules/mod_members/assets/css/mod_members.css
+++ b/core/modules/mod_members/assets/css/mod_members.css
@@ -12,6 +12,8 @@
 		    -ms-box-sizing: border-box;
 		     -o-box-sizing: border-box;
 		        box-sizing: border-box;
+		max-height: 60em;
+		overflow-x: auto;
 	}
 
 	.mod_members .note {


### PR DESCRIPTION
Sometimes the list of unique domains gets rather long. So, set a max
height on the module and allow the overflow to scroll. A better way of
grouping small domain counts is needed...