### PR TITLE
[fix] Nested resource tags weren't appearing

### DIFF
--- a/core/components/com_resources/site/assets/css/create.css
+++ b/core/components/com_resources/site/assets/css/create.css
@@ -464,3 +464,14 @@
 		background: #fff url("../img/loading.gif") 50% 50% no-repeat;
 		background: rgba(255, 255, 255, 0.8) url("../img/loading.gif") 50% 50% no-repeat;
 	}
+
+/* Tags */
+	
+	#hubForm .fa label {
+		display: inline;
+		padding-left: .5em;
+	}
+
+	#hubForm fieldset .fa .option {
+		margin-left: .5em !important;
+	}

--- a/core/components/com_resources/site/assets/js/tags.js
+++ b/core/components/com_resources/site/assets/js/tags.js
@@ -16,7 +16,7 @@ jQuery(function($) {
 	var change = function(evt) {
 		nested_fa.css('display', 'none');
 		fas.each(function(idx, div) {
-			if ($(div.firstChild).attr('checked')) {
+			if ($(div.firstChild).prop('checked')) {
 				$(div).children().each(function(idx, el) {
 					if ($(el).hasClass('fa')) {
 						$(el).css('display', 'block');


### PR DESCRIPTION
Checking a tags category with children wasn't
properly displaying its children because of
changed behavior of jQuery .attr('checked')

fixes: https://habricentral.org/support/ticket/859