### PR TITLE
[fix] Handle rare case method returns `false`

### DIFF
--- a/core/plugins/authentication/certificate/certificate.php
+++ b/core/plugins/authentication/certificate/certificate.php
@@ -227,9 +227,20 @@ class plgAuthenticationCertificate extends \Hubzero\Plugin\Plugin
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'certificate', $domain, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', $_SERVER['SSL_CLIENT_S_DN_Email']);
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', $_SERVER['SSL_CLIENT_S_DN_Email']);
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "certificate", %s, %s) returned false', $domain, $username));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/cilogon/cilogon.php
+++ b/core/plugins/authentication/cilogon/cilogon.php
@@ -273,9 +273,20 @@ class plgAuthenticationCILogon extends \Hubzero\Plugin\OauthClient
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'cilogon', null, $id);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', $email);
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', $email);
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "cilogon", null, %s) returned false', $id));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/facebook/facebook.php
+++ b/core/plugins/authentication/facebook/facebook.php
@@ -375,9 +375,20 @@ class plgAuthenticationFacebook extends \Hubzero\Plugin\OauthClient
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'facebook', null, $id);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', $email);
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', $email);
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "facebook", null, %s) returned false', $id));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/google/google.php
+++ b/core/plugins/authentication/google/google.php
@@ -314,9 +314,20 @@ class plgAuthenticationGoogle extends \Hubzero\Plugin\OauthClient
 			{
 				// Create the hubzero auth link
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'google', null, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', $user_profile['email']);
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', $user_profile['email']);
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "google", null, %s) returned false', $username));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/linkedin/linkedin.php
+++ b/core/plugins/authentication/linkedin/linkedin.php
@@ -420,9 +420,20 @@ class plgAuthenticationLinkedIn extends \Hubzero\Plugin\OauthClient
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'linkedin', null, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', (string) $profile->{'email-address'});
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', (string) $profile->{'email-address'});
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "linkedin", null, %s) returned false', $username));
+				}
 			}
 		}
 		else // no authorization

--- a/core/plugins/authentication/orcid/orcid.php
+++ b/core/plugins/authentication/orcid/orcid.php
@@ -246,9 +246,20 @@ class plgAuthenticationOrcid extends \Hubzero\Plugin\OauthClient
 			{
 				// Create the hubzero auth link
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'orcid', null, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', $orcid->email());
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', $orcid->email());
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "orcid", null, %s) returned false', $username));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/pucas/pucas.php
+++ b/core/plugins/authentication/pucas/pucas.php
@@ -339,9 +339,20 @@ class plgAuthenticationPUCAS extends \Hubzero\Plugin\OauthClient
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'pucas', null, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', phpCAS::getAttribute('email'));
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', phpCAS::getAttribute('email'));
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "pucas", null, %s) returned false', $username));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/scistarter/scistarter.php
+++ b/core/plugins/authentication/scistarter/scistarter.php
@@ -303,8 +303,19 @@ class plgAuthenticationSciStarter extends \Hubzero\Plugin\OauthClient
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'scistarter', null, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "scistarter", null, %s) returned false', $username));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/shibboleth/shibboleth.php
+++ b/core/plugins/authentication/shibboleth/shibboleth.php
@@ -611,10 +611,21 @@ class plgAuthenticationShibboleth extends \Hubzero\Plugin\Plugin
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'shibboleth', $status['idp'], $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->set('email', $status['email']);
-				self::log('setting link', $hzal);
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->set('email', $status['email']);
+					self::log('setting link', $hzal);
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "shibboleth", %s, %s) returned false', $status['idp'], $username));
+				}
 			}
 		}
 		else

--- a/core/plugins/authentication/twitter/twitter.php
+++ b/core/plugins/authentication/twitter/twitter.php
@@ -270,8 +270,19 @@ class plgAuthenticationTwitter extends \Hubzero\Plugin\OauthClient
 			else
 			{
 				$hzal = \Hubzero\Auth\Link::find_or_create('authentication', 'twitter', null, $username);
-				$hzal->set('user_id', User::get('id'));
-				$hzal->update();
+				// if `$hzal` === false, then either:
+				//    the authenticator Domain couldn't be found,
+				//    no username was provided,
+				//    or the Link record failed to be created
+				if ($hzal)
+				{
+					$hzal->set('user_id', User::get('id'));
+					$hzal->update();
+				}
+				else
+				{
+					Log::error(sprintf('Hubzero\Auth\Link::find_or_create("authentication", "twitter", null, %s) returned false', $username));
+				}
 			}
 		}
 		else


### PR DESCRIPTION
In some rare cases the `Hubzero\Auth\Link::find_or_create()` method
returns a boolean `false` instead of an object.