### PR TITLE
[fix] Removing ref to hard-coded non-existent shoulder

### DIFF
--- a/core/components/com_resources/site/controllers/resources.php
+++ b/core/components/com_resources/site/controllers/resources.php
@@ -2449,13 +2449,9 @@ class Resources extends SiteController
 
 			$rdoi = Doi::oneByResource($id, $revision);
 
-			if ($rdoi->get('doi') && $tconfig->get('doi_shoulder'))
+			if ($rdoi->get('doi') && ($rdoi->get('doi_shoulder') || $tconfig->get('doi_shoulder')))
 			{
-				$handle = 'doi:' . $tconfig->get('doi_shoulder') . DS . strtoupper($rdoi->doi);
-			}
-			else if ($rdoi->doi_label)
-			{
-				$handle = 'doi:10254/' . $tconfig->get('doi_prefix') . $id . '.' . $rdoi->doi_label;
+				$handle = 'doi:' . ($rdoi->get('doi_shoulder') ? $rdoi->get('doi_shoulder') : $tconfig->get('doi_shoulder')) . '/' . strtoupper($rdoi->doi);
 			}
 		}
 

--- a/core/components/com_resources/site/views/view/tmpl/tools.php
+++ b/core/components/com_resources/site/views/view/tmpl/tools.php
@@ -157,16 +157,9 @@ $revision = $this->revision;
 						}
 
 						// doi message
-						if ($revision != 'dev' && ($this->model->doi || $this->model->doi_label))
+						if ($revision != 'dev' && $this->model->doi && ($this->model->doi_shoulder || $tconfig->get('doi_shoulder')))
 						{
-							if ($this->model->doi && $tconfig->get('doi_shoulder'))
-							{
-								$doi = 'doi:' . ($this->model->doi_shoulder ? $this->model->doi_shoulder : $tconfig->get('doi_shoulder')) . '/' . strtoupper($this->model->doi);
-							}
-							else
-							{
-								$doi = 'doi:10254/' . $tconfig->get('doi_prefix') . $this->model->id . '.' . $this->model->doi_label;
-							}
+							$doi = 'doi:' . ($this->model->doi_shoulder ? $this->model->doi_shoulder : $tconfig->get('doi_shoulder')) . '/' . strtoupper($this->model->doi);
 
 							$html .= "\t\t".'<p class="doi">'.$doi.' <span><a href="'.Route::url($this->model->link() . '&active=about').'#citethis">'.Lang::txt('cite this').'</a></span></p>'."\n";
 						}

--- a/core/plugins/resources/about/views/index/tmpl/default.php
+++ b/core/plugins/resources/about/views/index/tmpl/default.php
@@ -183,17 +183,9 @@ $maintext = $this->model->description;
 						$tconfig = Component::params('com_tools');
 						$doi = '';
 
-						if ($this->model->doi)
+						if ($this->model->doi && ($this->model->doi_shoulder || $tconfig->get('doi_shoulder')))
 						{
 							$doi = ($this->model->doi_shoulder ? $this->model->doi_shoulder : $tconfig->get('doi_shoulder')) . '/' . strtoupper($this->model->doi);
-						}
-						else if ($this->model->doi_label)
-						{
-							$doi = '10254/' . $tconfig->get('doi_prefix') . $this->model->id . '.' . $this->model->doi_label;
-						}
-
-						if ($doi)
-						{
 							$cite->doi = $doi;
 						}
 


### PR DESCRIPTION
If a DOI isn't found for a resource/tool, this would fallback to
buling one with a shoulder of "10254". That shoulder doesn't seem to be
valid and currently can't find any information on where it came from.

Refs: https://nanohub.org/support/ticket/350118