### PR TITLE
[fix] Reverting change

### DIFF
--- a/core/components/com_resources/admin/views/items/tmpl/edit.php
+++ b/core/components/com_resources/admin/views/items/tmpl/edit.php
@@ -26,7 +26,8 @@ if ($this->row->standalone == 1)
 
 	$type = $this->row->type;
 
-	$data = $this->row->fields(); /*array();
+	//$data = $this->row->fields();
+	$data = array();
 	preg_match_all("#<nb:(.*?)>(.*?)</nb:(.*?)>#s", $this->row->fulltxt, $matches, PREG_SET_ORDER);
 	if (count($matches) > 0)
 	{
@@ -37,7 +38,7 @@ if ($this->row->standalone == 1)
 	}
 	$this->row->fulltxt = preg_replace("#<nb:(.*?)>(.*?)</nb:(.*?)>#s", '', $this->row->fulltxt);
 	$this->row->fulltxt = trim($this->row->fulltxt);
-	$this->row->fulltxt = ($this->row->fulltxt) ? trim(stripslashes($this->row->fulltxt)): trim(stripslashes($this->row->introtext));*/
+	$this->row->fulltxt = ($this->row->fulltxt) ? trim(stripslashes($this->row->fulltxt)): trim(stripslashes($this->row->introtext));
 }
 
 // Build the path for uploading files


### PR DESCRIPTION
The `fields()` method does some extra work on parsing vlaues that
inadvertently causes said values to not be in the needed state when
rendering the input elements. This particularly affects elements with
multiple sub-options such as lat/long and dates (y/m/d).

Fixes: https://habricentral.org/support/ticket/860