### PR TITLE
[fix] Ensure var is an object

### DIFF
--- a/core/plugins/resources/coins/coins.php
+++ b/core/plugins/resources/coins/coins.php
@@ -67,6 +67,11 @@ class plgResourcesCoins extends \Hubzero\Plugin\Plugin
 	 */
 	public function coins($model)
 	{
+		if (!is_object($model))
+		{
+			return;
+		}
+
 		$title = array(
 			'ctx_ver=Z39.88-2004',
 			'rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal',  //info:ofi/fmt:kev:mtx:journal


### PR DESCRIPTION
It's possible that something other than an object can be passed to the
onResourcesList event.