### PR TITLE
replace create_function() with new anonymous function syntax

### DIFF
--- a/core/components/com_resources/site/views/steps/tmpl/tags.php
+++ b/core/components/com_resources/site/views/steps/tmpl/tags.php
@@ -151,7 +151,9 @@ class RecommendedTags
 				}
 			}
 		}
-		usort($freq, create_function('$a, $b', 'return $a[\'count\'] === $b[\'count\'] ? 0 : ($a[\'count\'] > $b[\'count\'] ? -1 : 1);'));
+		usort($freq, function($a, $b) {
+			return $a['count'] === $b['count'] ? 0 : ($a['count'] > $b['count'] ? -1 : 1);
+		});
 		$this->tags = array_slice($freq, 0, $opts['count']);
 	}
 

--- a/core/components/com_search/models/basic/terms.php
+++ b/core/components/com_search/models/basic/terms.php
@@ -326,7 +326,10 @@ class Terms extends Obj
 		usort($chunks, function($a, $b) {
 			$al = strlen($a);
 			$bl = strlen($b);
-			if ($al == $bl) return 0;
+			if ($al == $bl)
+			{
+				return 0;
+			}
 			return $al > $bl ? -1 : 1;
 		});
 		return '(' . join('|', array_map('preg_quote', $chunks)) . '[[:alpha:]]*)';

--- a/core/components/com_search/models/basic/terms.php
+++ b/core/components/com_search/models/basic/terms.php
@@ -323,7 +323,12 @@ class Terms extends Obj
 	public function get_word_regex()
 	{
 		$chunks = $this->get_stemmed_chunks();
-		usort($chunks, create_function('$a, $b', '$al = strlen($a); $bl = strlen($b); if ($al == $bl) return 0; return $al > $bl ? -1 : 1;'));
+		usort($chunks, function($a, $b) {
+			$al = strlen($a);
+			$bl = strlen($b);
+			if ($al == $bl) return 0;
+			return $al > $bl ? -1 : 1;
+		});
 		return '(' . join('|', array_map('preg_quote', $chunks)) . '[[:alpha:]]*)';
 	}
 

--- a/core/components/com_tags/admin/controllers/relationships.php
+++ b/core/components/com_tags/admin/controllers/relationships.php
@@ -318,7 +318,9 @@ class Relationships extends AdminController
 			$this->database->execute();
 			$tag = $this->get_tag($tid);
 			$preload = $tag['raw_tag'];
-			$normalize = create_function('$a', 'return preg_replace(\'/[^a-zA-Z0-9]/\', \'\', strtolower($a));');
+			$normalize = function($a) {
+				return preg_replace('/[^a-zA-Z0-9]/', '', strtolower($a));
+			};
 			// reconcile post data with what we already know about a tag's relationships
 			foreach (array(
 				'labels'   => array(

--- a/core/plugins/search/publications/publications.php
+++ b/core/plugins/search/publications/publications.php
@@ -218,7 +218,10 @@ class plgSearchPublications extends \Hubzero\Plugin\Plugin
 			}
 		}
 
-		usort($rows, create_function('$a, $b', 'return (($res = $a->get_weight() - $b->get_weight()) == 0 ? 0 : $res > 0 ? -1 : 1);'));
+		usort($rows, function($a, $b) {
+			$res = $a->get_weight() - $b->get_weight();
+			return $res == 0 ? 0 : $res > 0 ? -1 : 1;
+		});
 		foreach ($rows as $row)
 		{
 			$row->set_link(Route::url($row->get_raw_link()));

--- a/core/plugins/search/resources/resources.php
+++ b/core/plugins/search/resources/resources.php
@@ -207,7 +207,10 @@ class plgSearchResources extends \Hubzero\Plugin\Plugin
 			}
 		}
 
-		usort($rows, create_function('$a, $b', 'return (($res = $a->get_weight() - $b->get_weight()) == 0 ? 0 : $res > 0 ? -1 : 1);'));
+		usort($rows, function($a, $b) {
+			$res = $a->get_weight() - $b->get_weight();
+			return $res == 0 ? 0 : $res > 0 ? -1 : 1;
+		});
 		foreach ($rows as $row)
 		{
 			$results->add($row);


### PR DESCRIPTION
As of PHP 7.2, [create_function() is deprecated](https://www.php.net/manual/en/function.create-function.php).  I've replaced all instances I could find and test with anonymous functions.  This should be compatible with >= 5.3.0 (see link).  I didn't see any guidance on formatting anonymous functions so I went with the style I've seen in Javascript.

I noticed that geshi also has an instance of create_function().  There is a newer version out, 1.0.9.0, but it hasn't gotten rid of create_function().  So you know.  It's an external dependency so I figured I shouldn't touch it.