### PR TITLE
PHP 7 compatibility

### DIFF
--- a/core/plugins/search/members/members.php
+++ b/core/plugins/search/members/members.php
@@ -229,7 +229,7 @@ class plgSearchMembers extends \Hubzero\Plugin\Plugin
 				u.access IN (" . implode(',', User::getAuthorisedViewLevels()) . ") AND " . join(' AND ', $addtl_where)
 		);
 		$assoc = $sql->to_associative();
-		if (!count($assoc))
+		if (!is_array($assoc) || !count($assoc))
 		{
 			return false;
 		}


### PR DESCRIPTION
This is another 

> count(): Parameter must be an array or an object that implements Countable'

 error fix.  There's probably a cleaner way to write it, but this is the safest thing that worked for me.