### PR TITLE
[fix] Adding registered' access to list

### DIFF
--- a/core/plugins/members/collections/collections.php
+++ b/core/plugins/members/collections/collections.php
@@ -1748,7 +1748,7 @@ class plgMembersCollections extends \Hubzero\Plugin\Plugin
 			return $this->_editcollection($collection);
 		}
 
-		if ($collection->get('access') != 0 && $collection->get('access') != 4)
+		if ($collection->get('access') != 0 && $collection->get('access') != 1 && $collection->get('access') != 4)
 		{
 			$collection->set('access', 0);
 		}


### PR DESCRIPTION
Not sure why this check is in place. Traced code back to 2015 and it's
still there. Fixing immediate issue for now but this needs
re-evaluating.

Fixes: https://hubicl.org/support/ticket/124