### PR TITLE
[fix] Disable caching to free up memory

### DIFF
--- a/core/components/com_citations/site/controllers/import.php
+++ b/core/components/com_citations/site/controllers/import.php
@@ -187,8 +187,8 @@ class Import extends SiteController
 		if (!isset($citations[0]['no_attention']))
 		{
 			$citations[0]['no_attention'] = '';
-
 		}
+
 		if (!$this->importer->writeRequiresAttention($citations[0]['attention']))
 		{
 			Notify::error(Lang::txt('Unable to write temporary file.'));

--- a/core/plugins/citation/bibtex/bibtex.php
+++ b/core/plugins/citation/bibtex/bibtex.php
@@ -142,7 +142,7 @@ class plgCitationBibtex extends \Hubzero\Plugin\Plugin
 		// Make sure 0 is not the %
 		$title_match = ($title_match == 0) ? $default_title_match : $title_match;
 
-		$existingCitations = Citation::all();
+		$existingCitations = Citation::all()->purgeCache()->disableCaching();
 		if (!empty($scope))
 		{
 			$existingCitations->whereEquals('scope', $scope);
@@ -161,7 +161,7 @@ class plgCitationBibtex extends \Hubzero\Plugin\Plugin
 		}
 
 		// Loop through all current citations
-		foreach ($existingCitations->rows() as $r)
+		foreach ($existingCitations->rows()->toObject() as $r)
 		{
 			$id    = $r->id;
 			$title = $r->title;


### PR DESCRIPTION
For larger imports, PHP could run out of memory due to caching the
results from prior queries. They aren't needed int his case, so disable
and flush the cache before each lookup.

Fixes: https://help.hubzero.org/support/ticket/11851