### PR TITLE
[fix] Set return value

### DIFF
--- a/core/components/com_login/site/controllers/auth.php
+++ b/core/components/com_login/site/controllers/auth.php
@@ -266,6 +266,7 @@ class Auth extends SiteController
 
 		$status = array();
 		$tpl = null;
+		$this->return = $return;
 
 		foreach ($plugins as $plugin)
 		{

--- a/core/components/com_users/site/controllers/auth.php
+++ b/core/components/com_users/site/controllers/auth.php
@@ -266,6 +266,7 @@ class Auth extends SiteController
 
 		$status = array();
 		$tpl = null;
+		$this->return = $return;
 
 		foreach ($plugins as $plugin)
 		{


### PR DESCRIPTION
This needs setting on `this` so 3rd-party authenitcator plugins can
add it to the service URL.

Fixes: https://purr.purdue.edu/support/ticket/2049