### PR TITLE
The others variable needs to be an instance variable

### DIFF
--- a/core/components/com_config/admin/views/application/tmpl/default.php
+++ b/core/components/com_config/admin/views/application/tmpl/default.php
@@ -27,7 +27,7 @@ $ignore = array(
 	'mail', 'api', 'permissions', 'filters', 'rate_limit', 'asset_id'
 );
 
-$others = array();
+$this->others = array();
 foreach ($this->data as $section => $values):
 	if (in_array($section, $ignore)):
 		continue;


### PR DESCRIPTION
Presumed to be a PHP 7 compatibility bug, though I'm not sure how it worked properly before.  $others is initialized to an array right above a loop working with $this->others.  The default_navigation.php file also refers to $this->others.  The fix is to change the local variable to $this->others.