### PR TITLE
[fix] Escape shell arguments

### DIFF
--- a/core/components/com_projects/helpers/githelper.php
+++ b/core/components/com_projects/helpers/githelper.php
@@ -710,7 +710,7 @@ class Git extends Obj
 	 **/
 	public function getUntrackedFiles($subdir = '')
 	{
-		$cmd  = 'cd ' . DS . trim($this->_path, DS) . DS . trim($subdir, DS) . ' && ';
+		$cmd  = 'cd ' . escapeshellarg(DS . trim($this->_path, DS) . DS . trim($subdir, DS)) . ' && ';
 		$cmd .= $this->_gitpath . ' clean -nd | grep -v ".' . DS . '." | cut -c 14-';
 
 		$results = $this->_exec($cmd);
@@ -732,7 +732,7 @@ class Git extends Obj
 	 **/
 	public function getUntrackedDirectories($subdir = '')
 	{
-		$cmd  = 'cd ' . DS . trim($this->_path, DS) . DS . trim($subdir, DS) . ' && ';
+		$cmd  = 'cd ' . escapeshellarg(DS . trim($this->_path, DS) . DS . trim($subdir, DS)) . ' && ';
 		$cmd .= $this->_gitpath . ' clean -nd | grep ".' . DS . '$" | cut -c 14-';
 
 		$results = $this->_exec($cmd);


### PR DESCRIPTION
This fixes issues with directory names that have spaces in them.

Fixes: https://purr.purdue.edu/support/ticket/2064