### PR TITLE
[fix] Create needed path for files to be copied to

### DIFF
--- a/core/components/com_publications/models/attachments/data.php
+++ b/core/components/com_publications/models/attachments/data.php
@@ -254,6 +254,16 @@ class Data extends Base
 		);
 		$newConfigs->servePath = Route::url('index.php?option=com_publications&id=' . $pub->id) . '/?vid=' . $newVersion->id . '&amp;task=serve';
 
+		// Create new version path
+		if (!is_dir($newConfigs->dataPath))
+		{
+			if (!Filesystem::makeDirectory($newConfigs->dataPath, 0755, true, true))
+			{
+				$this->_parent->setError(Lang::txt('PLG_PROJECTS_PUBLICATIONS_PUBLICATION_UNABLE_TO_CREATE_PATH'));
+				return false;
+			}
+		}
+
 		// Loop through attachments
 		foreach ($attachments as $att)
 		{


### PR DESCRIPTION
When creating a new version of a 'database', the `save()` method on the
`com_publications/models/attachments/data.php` model never gets invoked
and, consequently, doesn't create the needed directory for data to be
copied/written to. This causes file transfers to not produce anything.
The fix is to create the needed directory, if it doesn't exist, in the
`transferData` method of the same model.

Refs: https://purr.purdue.edu/support/ticket/1963