### PR TITLE
Fix the issue that wrong tags or null returned in OAI-PMH query result

### DIFF
--- a/core/plugins/oaipmh/publications/data/miner.php
+++ b/core/plugins/oaipmh/publications/data/miner.php
@@ -308,7 +308,7 @@ class Miner extends Obj implements Provider
 		$this->database->setQuery(
 			"SELECT DISTINCT t.raw_tag
 			FROM `#__tags` t, `#__tags_object` tos
-			WHERE t.id = tos.tagid AND tos.objectid=" . $this->database->quote($id) . " AND tos.tbl='publications' AND t.admin=0
+			WHERE t.id = tos.tagid AND tos.objectid=" . $this->database->quote($record->version_id) . " AND tos.tbl='publications' AND t.admin=0
 			ORDER BY t.raw_tag"
 		);
 		$record->subject = $this->database->loadColumn();


### PR DESCRIPTION
The OAI-PMH metadata record harvesting returns wrong tags for the dataset/publication or does not return any tags in metadata record. Details in ticket: https://purr.purdue.edu/support/ticket/2078