### PR TITLE
removing predis autoloader since this is already handled by composer

### DIFF
--- a/core/components/com_usage/helpers/verb.php
+++ b/core/components/com_usage/helpers/verb.php
@@ -11,8 +11,6 @@ use Exception;
 use App;
 use stdClass;
 
-require_once "Predis/Autoloader.php";
-
 /**
  * Usage verb class
  */


### PR DESCRIPTION
This fixed a /usage problem on nanohub.