### PR TITLE
Strip tags from at a glance content

### DIFF
--- a/core/components/com_publications/site/views/view/tmpl/default.php
+++ b/core/components/com_publications/site/views/view/tmpl/default.php
@@ -66,7 +66,10 @@ else
 				<?php } ?>
 
 				<p class="ataglance">
-					<?php echo $this->publication->abstract ? \Hubzero\Utility\Str::truncate(stripslashes($this->publication->abstract), 250) : ''; ?>
+					<?php
+						$abstractSnippet = \Hubzero\Utility\Str::truncate(stripslashes(strip_tags($this->publication->abstract), 250));
+						echo $this->publication->abstract ?  $abstractSnippet : '';
+					?>
 				</p>
 
 				<?php


### PR DESCRIPTION
Truncated tags can interfere with the rendering of the page

related to: ext learn publication video embedding issue