### PR TITLE
[com_resources] Synchronize author data source

### DIFF
--- a/core/components/com_resources/models/entry.php
+++ b/core/components/com_resources/models/entry.php
@@ -50,7 +50,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 	protected $namespace = '';
 
 	/**
-	 * The table name, non-standard naming 
+	 * The table name, non-standard naming
 	 *
 	 * @var  string
 	 */
@@ -355,9 +355,11 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 
 		if ($idx == 'tool')
 		{
-			// UUUGGGGHHHHHHHHHH
-			// @TODO: Rewrite this
-			if ($this->isTool())
+			if ($this->isTool() && $this->revision == 'dev')
+			{
+				$contributors = $this->authors()->rows();
+			}
+			else if ($this->isTool())
 			{
 				$db = App::get('db');
 				$sql = "SELECT n.id, t.name AS name, n.name AS xname, NULL AS xorg, n.givenName, n.givenName AS firstname, n.middleName, n.middleName AS middlename, n.surname, n.surname AS lastname, t.organization, t.*, a.role"


### PR DESCRIPTION
A user noticed that the author list displayed on the Contributors step
of the tool pipeline did not agree with the preview displayed during the
Finalize step of the pipeline

This change synchronizes the data source used to retrieve the authors in
the mentioned steps

fixes: https://mygeohub.org/support/ticket/1600