### PR TITLE
[fix] Removing duplicate `class` attribute

### DIFF
--- a/core/components/com_content/admin/views/articles/tmpl/default.php
+++ b/core/components/com_content/admin/views/articles/tmpl/default.php
@@ -65,32 +65,32 @@ $saveOrder = $listOrder == 'ordering';
 			<button type="button" class="btn filter-clear"><?php echo Lang::txt('JSEARCH_FILTER_CLEAR'); ?></button>
 		</div>
 		<div class="filter-select fltrt">
-			<select name="filter_published" class="inputbox" class="filter filter-submit">
+			<select name="filter_published" class="filter filter-submit">
 				<option value=""><?php echo Lang::txt('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo Html::select('options', Html::grid('publishedOptions'), 'value', 'text', $this->filters['published'], true);?>
 			</select>
 
-			<select name="filter_category_id" class="inputbox" class="filter filter-submit">
+			<select name="filter_category_id" class="filter filter-submit">
 				<option value=""><?php echo Lang::txt('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo Html::select('options', Html::category('options', 'com_content'), 'value', 'text', $this->filters['category_id']); ?>
 			</select>
 
-			<select name="filter_level" class="inputbox" class="filter filter-submit">
+			<select name="filter_level" class="filter filter-submit">
 				<option value=""><?php echo Lang::txt('JOPTION_SELECT_MAX_LEVELS');?></option>
 				<?php echo Html::select('options', $this->f_levels, 'value', 'text', $this->filters['level']); ?>
 			</select>
 
-			<select name="filter_access" class="inputbox" class="filter filter-submit">
+			<select name="filter_access" class="filter filter-submit">
 				<option value=""><?php echo Lang::txt('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo Html::select('options', Html::access('assetgroups'), 'value', 'text', $this->filters['access']); ?>
 			</select>
 
-			<select name="filter_author_id" class="inputbox" class="filter filter-submit">
+			<select name="filter_author_id" class="filter filter-submit">
 				<option value=""><?php echo Lang::txt('JOPTION_SELECT_AUTHOR');?></option>
 				<?php echo Html::select('options', $this->authors, 'value', 'text', $this->filters['author_id']); ?>
 			</select>
 
-			<select name="filter_language" class="inputbox" class="filter filter-submit">
+			<select name="filter_language" class="filter filter-submit">
 				<option value=""><?php echo Lang::txt('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo Html::select('options', Html::contentlanguage('existing', true, true), 'value', 'text', $this->filters['language']); ?>
 			</select>


### PR DESCRIPTION
The duplicate attributes would cause the JS to not properly find select
elements that should auto-submit the form on change.