### PR TITLE
[fix] Add form field path for needed field type

### DIFF
--- a/core/modules/mod_menu/mod_menu.xml
+++ b/core/modules/mod_menu/mod_menu.xml
@@ -23,7 +23,7 @@
 	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_MENU" />
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset name="basic" addfieldpath="/core/components/com_menus/models/fields">
 				<field name="menutype" type="menu" label="MOD_MENU_FIELD_MENUTYPE_LABEL" description="MOD_MENU_FIELD_MENUTYPE_DESC" />
 				<field name="startLevel" type="list" default="1" label="MOD_MENU_FIELD_STARTLEVEL_LABEL" description="MOD_MENU_FIELD_STARTLEVEL_DESC">
 					<option value="1">J1</option>


### PR DESCRIPTION
This allows config field type of 'menu' to properly render when editing
modules of type mod_menu.