### PR TITLE
[refactor][fix] Prevent PHP 7.2+ from freaking out

### DIFF
--- a/core/components/com_courses/models/prerequisite.php
+++ b/core/components/com_courses/models/prerequisite.php
@@ -168,25 +168,23 @@ class Prerequisite extends Base
 					{
 						$asset = new Asset($prerequisite['scope_id']);
 
-						switch ($asset->get('type'))
+						if ($asset->get('type') == 'form')
 						{
-							case 'form':
-								if (!isset($this->grades[$prerequisite['scope_id']]))
-								{
-									$return = false;
-									continue;
-								}
-								break;
-
-							default:
-								if (!isset($this->views[$this->member_id])
-								 || !is_array($this->views[$this->member_id])
-								 || !in_array($prerequisite['scope_id'], $this->views[$this->member_id]))
-								{
-									$return = false;
-									continue;
-								}
-								break;
+							if (!isset($this->grades[$prerequisite['scope_id']]))
+							{
+								$return = false;
+								continue;
+							}
+						}
+						else
+						{
+							if (!isset($this->views[$this->member_id])
+							 || !is_array($this->views[$this->member_id])
+							 || !in_array($prerequisite['scope_id'], $this->views[$this->member_id]))
+							{
+								$return = false;
+								continue;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
The `switch`, with its `break`s would cause PHP 7.2+ to throw a
`"continue" targeting switch is equivalent to "break". Did you mean to
use "continue 2"?` error. The `switch` is also entirely unnecessary in
this case and refactoring to a simple `if` statement resolves the issue.