### PR TITLE
Make the mobile menu in admin work as intended

### DIFF
--- a/core/templates/kameleon/js/index.js
+++ b/core/templates/kameleon/js/index.js
@@ -156,13 +156,21 @@ jQuery(document).ready(function($){
 		}
 	});
 
+	$('#header h1 a').on('click', function(e) {
+		e.preventDefault();
+
+		$('body').toggleClass('menu-opened');
+	});
+
 	// Mobile device fix
 	$('#toolbar ul').on('click', function(e){
 		$(this).toggleClass('active');
+		e.preventDefault();
 	});
 
 	$('.main-navigation li.node>a').on('click', function(e){
 		$(this).parent().toggleClass('active');
+		e.preventDefault();
 	});
 
 	// Display system messages in Growl-like way


### PR DESCRIPTION
Fixes non-working admin mobile menu. Fixes https://help.hubzero.org/support/ticket/11981