### PR TITLE
Fixes Comhub collection hash file download failure

### DIFF
--- a/core/components/com_collections/models/asset.php
+++ b/core/components/com_collections/models/asset.php
@@ -237,10 +237,12 @@ class Asset extends Base
 	 */
 	public function link($size = 'original')
 	{
-		$path  = $this->filespace() . DS . $this->get('item_id') . DS;
+		$base = Request::base();
+		Log::debug($base);
+		$path  = $base . 'app/site/collections/' . $this->get('item_id') . DS;
 		$path .= ltrim($this->file($size), DS);
 
-		return with(new \Hubzero\Content\Moderator($path, 'public'))->getUrl();
+		return $path;
 	}
 
 	/**

--- a/core/components/com_collections/models/asset.php
+++ b/core/components/com_collections/models/asset.php
@@ -238,7 +238,6 @@ class Asset extends Base
 	public function link($size = 'original')
 	{
 		$base = Request::base();
-		Log::debug($base);
 		$path  = $base . 'app/site/collections/' . $this->get('item_id') . DS;
 		$path .= ltrim($this->file($size), DS);
 


### PR DESCRIPTION
sha256 hash creates a URL greater than 255 characters on the communityhub.purdue.edu and attempting to download a file results failure (0Kb file).