### PR TITLE
[fix] Fix class name not matching file name

### DIFF
--- a/core/migrations/Migration20200917000000AuthLinkIndex.php
+++ b/core/migrations/Migration20200917000000AuthLinkIndex.php
@@ -6,10 +6,13 @@ use Hubzero\Content\Migration\Base;
 defined('_HZEXEC_') or die();
 
 /**
- * Migration script for adding indexes to the #__auth_link table.
+ * Migration script for adding indexes to the `#__auth_link` table.
  **/
-class Migration202000171000000AuthLinkIndex extends Base
+class Migration20200917000000AuthLinkIndex extends Base
 {
+	/**
+	 * Up
+	 **/
 	public function up()
 	{
 		if ($this->db->tableExists('#__auth_link'))
@@ -30,6 +33,9 @@ class Migration202000171000000AuthLinkIndex extends Base
 		}
 	}
 
+	/**
+	 * Down
+	 **/
 	public function down()
 	{
 		if ($this->db->tableExists('#__auth_link'))
@@ -49,5 +55,4 @@ class Migration202000171000000AuthLinkIndex extends Base
 			}
 		}
 	}
-
 }

--- a/core/migrations/Migration20200917100000AuthDomainIndex.php
+++ b/core/migrations/Migration20200917100000AuthDomainIndex.php
@@ -6,10 +6,13 @@ use Hubzero\Content\Migration\Base;
 defined('_HZEXEC_') or die();
 
 /**
- * Migration script for adding indexes to the #__auth_domain table.
+ * Migration script for adding indexes to the `#__auth_domain` table.
  **/
-class Migration202000171000000AuthDomainIndex extends Base
+class Migration20200917100000AuthDomainIndex extends Base
 {
+	/**
+	 * Up
+	 **/
 	public function up()
 	{
 		if ($this->db->tableExists('#__auth_domain') &&
@@ -21,6 +24,9 @@ class Migration202000171000000AuthDomainIndex extends Base
 		}
 	}
 
+	/**
+	 * Down
+	 **/
 	public function down()
 	{
 		if ($this->db->tableExists('#__auth_domain') &&
@@ -31,5 +37,4 @@ class Migration202000171000000AuthDomainIndex extends Base
 			$this->db->query();
 		}
 	}
-
 }


### PR DESCRIPTION
Muse requires that file names and class names match. This also removes
an unnecessary extra blank line and adds the docblocks to the `up` and
`down` methods.