### PR TITLE
[fix] Fix new modules under strict mode DB

### DIFF
--- a/core/components/com_groups/admin/controllers/modules.php
+++ b/core/components/com_groups/admin/controllers/modules.php
@@ -217,7 +217,7 @@ class Modules extends AdminController
 		}
 
 		// bind request vars to module model
-		if (!$this->module->bind( $module ))
+		if (!$this->module->bind($module))
 		{
 			Notify::error($this->module->getError());
 			return $this->editTask();

--- a/core/components/com_groups/admin/controllers/modules.php
+++ b/core/components/com_groups/admin/controllers/modules.php
@@ -308,11 +308,15 @@ class Modules extends AdminController
 			// load modules
 			$module = new Module($moduleid);
 
+			// Disable content checks
+			// We're only changing state, so it's unnecessary processing
+			$module->set('page_trusted', 1);
+
 			//set to deleted state
 			$module->set('state', $module::APP_STATE_DELETED);
 
 			// save module
-			if (!$module->store(true))
+			if (!$module->store(true, true))
 			{
 				App::redirect(
 					Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&gid=' . $this->gid, false),

--- a/core/components/com_groups/admin/controllers/modules.php
+++ b/core/components/com_groups/admin/controllers/modules.php
@@ -209,7 +209,7 @@ class Modules extends AdminController
 
 		// if this is new module or were changing position,
 		// get next order possible for position
-		if (!isset($module['id']) || ($module['id'] == '')
+		if (!isset($module['id']) || !$module['id']
 			|| ($module['position'] != $this->module->get('position')))
 		{
 			$ordering = null;

--- a/core/components/com_groups/admin/controllers/modules.php
+++ b/core/components/com_groups/admin/controllers/modules.php
@@ -194,6 +194,7 @@ class Modules extends AdminController
 		// clean title & position
 		$module['title']    = preg_replace("/[^-_ a-zA-Z0-9]+/", '', $module['title']);
 		$module['position'] = preg_replace("/[^-_a-zA-Z0-9]+/", '', $module['position']);
+		$module['id']       = isset($module['id']) && $module['id'] ? intval($module['id']) : null;
 
 		// get the category object
 		$this->module = new Module($module['id']);


### PR DESCRIPTION
This mostly addresses an issue where creation of a new module would throw an under when using a database in strict mode. An empty string was being passed where strict mode expects the ID to be an integer or `null`.

PR includes some minor style and optimizations.