### PR TITLE
[fix] Allow login from "/admin"

### DIFF
--- a/core/bootstrap/Administrator/routes.php
+++ b/core/bootstrap/Administrator/routes.php
@@ -24,8 +24,15 @@ $router->rules('build')->append('base', function ($uri)
 	// Get the path data
 	$route = $uri->getPath();
 
+	$base = \App::get('request')->base(true);
+	if (substr($base, -strlen(\App::get('client')->name)) != \App::get('client')->name
+	 && substr($base, -strlen(\App::get('client')->url)) != \App::get('client')->url)
+	{
+		$base .= '/' . \App::get('client')->name;
+	}
+
 	// Add basepath to the uri
-	$uri->setPath(\App::get('request')->base(true) . '/' . $route);
+	$uri->setPath($base . '/' . $route);
 
 	return $uri;
 });


### PR DESCRIPTION
Routes would not be correctly built when going to /admin, resulting in
the login form submitting to the front-end. This would result in failed
logins (usually a CSRF token error).