### PR TITLE
update nao-pon/flysystem-google-drive to 1.1.13 to fix google API deprecation

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -46,7 +46,7 @@
         "hubzero/orcid-php": "0.*",
         "league/flysystem": "1.0.*",
         "hubzero/flysystem-github": "dev-develop",
-        "nao-pon/flysystem-google-drive": "~1.1",
+        "nao-pon/flysystem-google-drive": "~1.1.13",
         "php-amqplib/php-amqplib": "2.5.*",
         "league/flysystem-aws-s3-v2": "^1.0",
         "simplepie/simplepie": "1.5",

--- a/core/composer.lock
+++ b/core/composer.lock
@@ -1873,16 +1873,16 @@
         },
         {
             "name": "nao-pon/flysystem-google-drive",
-            "version": "1.1.3",
+            "version": "1.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nao-pon/flysystem-google-drive.git",
-                "reference": "160924abaedc5c2b39b1e873f5c66d34daf64b91"
+                "reference": "bb812339ecf06540ed096f71403f10fcbcc590f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nao-pon/flysystem-google-drive/zipball/160924abaedc5c2b39b1e873f5c66d34daf64b91",
-                "reference": "160924abaedc5c2b39b1e873f5c66d34daf64b91",
+                "url": "https://api.github.com/repos/nao-pon/flysystem-google-drive/zipball/bb812339ecf06540ed096f71403f10fcbcc590f3",
+                "reference": "bb812339ecf06540ed096f71403f10fcbcc590f3",
                 "shasum": ""
             },
             "require": {
@@ -1918,7 +1918,7 @@
                 }
             ],
             "description": "Flysystem adapter for Google Drive",
-            "time": "2016-09-23T02:36:58+00:00"
+            "time": "2020-07-30 01:26:26"
         },
         {
             "name": "paragonie/random_compat",


### PR DESCRIPTION
This is a minor revision update to nao-pon/flysystem-google-drive among the fixes includes a fix to remove deprecated API batch request.