### PR TITLE
update swiftmailer to 5.4.12 to fix subject crlf and security issues

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -28,7 +28,7 @@
         "facebook/graph-sdk": "^5.0",
         "tecnickcom/tcpdf": "6.0.017",
         "leafo/lessphp": "0.5.0",
-        "swiftmailer/swiftmailer": "v5.0.2",
+        "swiftmailer/swiftmailer": "~v5.4.12",
         "monolog/monolog": "1.17.0",
         "willdurand/geocoder": "2.8.*",
         "predis/predis": "0.8.6",

--- a/core/composer.lock
+++ b/core/composer.lock
@@ -3061,25 +3061,29 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.0.2",
+            "version": "v5.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "f3917ecef35a4e4d98b303eb9fee463bc983f379"
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/f3917ecef35a4e4d98b303eb9fee463bc983f379",
-                "reference": "f3917ecef35a4e4d98b303eb9fee463bc983f379",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.4"
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.1",
+                "symfony/phpunit-bridge": "~3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-master": "5.4-dev"
                 }
             },
             "autoload": {
@@ -3093,22 +3097,21 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "name": "Chris Corbyn"
                 },
                 {
-                    "name": "Chris Corbyn"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Swiftmailer, free feature-rich PHP mailer",
-            "homepage": "http://swiftmailer.org",
+            "homepage": "https://swiftmailer.symfony.com",
             "keywords": [
+                "email",
                 "mail",
                 "mailer"
             ],
-            "time": "2013-08-30T12:35:21+00:00"
+            "time": "2018-07-31T09:26:32+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
Update Swiftmailer package to 5.4.12 to fix stemedhub #721 (crlf corrupting subject header)
Selected last major version supporting PHP 5.6 (v5)
Selected last minor version without security flags (v5.4)
Selected latest revision.

