### PR TITLE
hubzero/standards doesn't exist in packagist and causes composer errors here

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -59,7 +59,6 @@
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-	"hubzero/standards": "dev-master",
 	"jakub-onderka/php-parallel-lint": "0.9.*",
 	"phpunit/dbunit": "1.4.*",
 	"phpunit/phpunit": "4.*",


### PR DESCRIPTION
This was a dev requirement in for hubzero/framework. It doesn't exist in packagist and throws a composer error when explicitly listed in this json file. (maybe this is new behavior in latest version of composer, unsure).

This PR will need to be applied before other vendor package updates currently pending in order for composer to actually run correctly.