### PR TITLE
Update groups.php

### DIFF
--- a/core/components/com_groups/site/controllers/groups.php
+++ b/core/components/com_groups/site/controllers/groups.php
@@ -1410,7 +1410,7 @@ class Groups extends Base
 			if (($access == 'members' && !in_array(User::get('id'), $group->get('members')))
 			 || ($access == 'registered' && User::isGuest()))
 			{
-				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH') . ' ' . $file);
+				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH'));
 			}
 
 			// Load wiki page from db
@@ -1439,7 +1439,7 @@ class Groups extends Base
 			// Check specific wiki page access
 			if ($page->get('access') == 1 && !in_array(User::get('id'), $group->get('members')) && $authorized != 'admin')
 			{
-				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH') . ' ' . $file);
+				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH'));
 				return;
 			}
 
@@ -1456,7 +1456,7 @@ class Groups extends Base
 			if (($access == 'members' && !in_array(User::get('id'), $group->get('members')))
 			 || ($access == 'registered' && User::isGuest()))
 			{
-				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH') . ' ' . $file);
+				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH'));
 			}
 
 			// Make sure we have a group id of the proper length
@@ -1478,7 +1478,7 @@ class Groups extends Base
 			if (($access == 'members' && !in_array(User::get('id'), $group->get('members')))
 			 || ($access == 'registered' && User::isGuest()))
 			{
-				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH') . ' ' . $file);
+				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH'));
 			}
 
 			// Build the path
@@ -1510,7 +1510,7 @@ class Groups extends Base
 		{
 			if ($alt_file_path == null || !file_exists(PATH_APP . DS . $alt_file_path))
 			{
-				$this->_errorHandler(404, Lang::txt('COM_GROUPS_ERROR_FILE_NOT_FOUND') . ' ' . $file);
+				$this->_errorHandler(404, Lang::txt('COM_GROUPS_ERROR_FILE_NOT_FOUND'));
 				return;
 			}
 			else
@@ -1526,7 +1526,7 @@ class Groups extends Base
 			// Make sure requested file is within acceptable dir
 			if (strpos($realPath, $pathCheck) === false)
 			{
-				$this->_errorHandler(404, Lang::txt('COM_GROUPS_ERROR_FILE_NOT_FOUND') . ' ' . $file);
+				$this->_errorHandler(403, Lang::txt('COM_GROUPS_ERROR_NOT_AUTH'));
 				return;
 			}
 		}


### PR DESCRIPTION
Prevent reflected XSS
Do not echo untrusted file name that may not exist and so could be arbitrary.
Also, send a 403 instead of 404 when the file exists but we deny access.