### PR TITLE
Update controller.php

### DIFF
--- a/core/components/com_dataviewer/site/controller.php
+++ b/core/components/com_dataviewer/site/controller.php
@@ -38,24 +38,7 @@ function controller()
 	}
 }
 
-function task_file($db_id)
-{
-	$view = 'file';
-	$file = (__DIR__.DS."view".DS."$view.php");
-
-	if (file_exists($file)) {
-		require_once ($file);
-		view();
-	}
-}
-
-
-function task_stream_file($db_id)
-{
-	$hash = Request::getString('hash');
-	stream_file($hash);
-	exit;
-}
+/* functions task_file and task_stream_file removed 2/8/2021 due to multitude of severe vulnerabilities */
 
 function task_view($db_id)
 {


### PR DESCRIPTION
task_file was failing due to bugs, and logs showed it was not used, so it's no loss to remove it.  task_stream_file was unused according to logs.  Both have so many severe vulnerabilities due to a naive implementation that fixing them quickly is impractical.  Cauterization (turning the code into dead code) is my recommendation until and if someone gets the mandate to reimplement it safely and if there's actually demand for their use cases.