### PR TITLE
add organization to doi metadata xml

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -459,9 +459,6 @@ class Doi extends Obj
 		$xmlfile.= '</description>
 			</descriptions>
 		</resource>';
-		
-
-		//file_put_contents("/var/log/xml", print_r($xmlfile, true));
 
 		return $xmlfile;
 	}

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -1155,6 +1155,7 @@ class Doi extends Obj
 		
 		if (!$result)
 		{
+			curl_close($ch);
 			return false;
 		}
 		
@@ -1164,6 +1165,7 @@ class Doi extends Obj
 		
 		if (($code != 201) && ($code != 200))
 		{
+			curl_close($ch);
 			return false;
 		}
 		
@@ -1175,11 +1177,9 @@ class Doi extends Obj
 			{
 				return $orgObj->id;
 			}
-			else
-			{
-				continue;
-			}
 		}
+		
+		curl_close($ch);
 		
 		return false;
 	}


### PR DESCRIPTION
The Research Organization Registry provides the unique identifier for the research organizations. The changes is to include the organization along with its Research Organization ID in the doi metadata set that is submitted to DataCite for minting DOI. By integrating the organization, it helps discover and track the research output by organization.