### PR TITLE
Fix broken links in automatic help index

### DIFF
--- a/core/components/com_help/site/views/help/tmpl/index.php
+++ b/core/components/com_help/site/views/help/tmpl/index.php
@@ -24,8 +24,12 @@ foreach ($this->pages as $component)
 		$content .= '<ul>';
 		foreach ($component['pages'] as $page)
 		{
-			$name = str_replace('.' . $this->layoutExt, '', $page);
-
+			// bug: broken links
+			// correct value for layoutExt not propagated all the way here, see attempt to set in site/controllers/help.php that results in empty string
+			// $name = str_replace('.' . $this->layoutExt, '', $page);
+			// default value is .phtml; use that for now so links work
+			$name = str_replace('.phtml', '', $page);
+			
 			$content .= '<li><a href="' . Route::url('index.php?option=com_help&component=' . str_replace('com_', '', $component['option']) . '&page=' . $name) . '">' . ucwords(str_replace('_', ' ', $name)) .'</a></li>';
 		}
 		$content .= '</ul>';

--- a/core/components/com_help/site/views/help/tmpl/index.php
+++ b/core/components/com_help/site/views/help/tmpl/index.php
@@ -29,7 +29,6 @@ foreach ($this->pages as $component)
 			// $name = str_replace('.' . $this->layoutExt, '', $page);
 			// default value is .phtml; use that for now so links work
 			$name = str_replace('.phtml', '', $page);
-			
 			$content .= '<li><a href="' . Route::url('index.php?option=com_help&component=' . str_replace('com_', '', $component['option']) . '&page=' . $name) . '">' . ucwords(str_replace('_', ' ', $name)) .'</a></li>';
 		}
 		$content .= '</ul>';


### PR DESCRIPTION
com_help generates an index automatically when a component doesn't provide one.  However, the links in the index were broken.   That's because com_help removes the file extension, and re-adds it when links are accessed, but the file extension information (layoutExt) was missing at the removal step, so it only removed a dot.