### PR TITLE
fix(plg_projects_files): Ensure array is not empty

### DIFF
--- a/core/plugins/projects/files/connections.php
+++ b/core/plugins/projects/files/connections.php
@@ -1312,7 +1312,7 @@ class connections
 		$metadata = Event::trigger('metadata.onMetadataGet', [$entity]);
 
 		$view->item     = $entity;
-		$view->metadata = $metadata[0];
+		$view->metadata = isset($metadata[0]) ? $metadata[0] : array();
 		$view->option   = $this->_option;
 		$view->model    = $this->model;
 		$view->ajax     = 1;


### PR DESCRIPTION
The expected return from the event trigger is an array of arrays (i.e., an array for each metadata plugin that responds). If no plugins are enabled or respond, this results in an empty array. The original line of code would assume a non-empty array.

As an aside, the line of code always takes the first respondent's metadata. If multiple plugins return data, you'll only get the first. I can't remember if this was intentional or not (Sam wrote that part, if memory serves). Still, it feels wrong. You'd probably want to merge all the returned data. Something to think about...