### PR TITLE
Remove unneed statement in com_newsletter migration

### DIFF
--- a/core/components/com_newsletter/migrations/Migration20180516000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20180516000000ComNewsletter.php
@@ -44,8 +44,6 @@ class Migration20180516000000ComNewsletter extends Base
 		if ($this->db->tableExists('#__newsletter_mailinglists') &&
 		    $this->db->tableHasField('#__newsletter_mailinglists', 'guest'))
 		{
-			$query = "DROP TABLE IF EXISTS `#__newsletter_mailinglists`;";
-
 			$query = "DELETE FROM `#__newsletter_mailinglists` WHERE `guest`='1';";
 			$this->db->setQuery($query);
 			$this->db->query();


### PR DESCRIPTION
I've been studying how existing components define their data models, and how their migration classes are involved.  I came across an assignment statement in one migration class of the newsletter component that appears to be unnecessary.  So recommending its deletion to tidy up the code a bit.