### PR TITLE
Strengthen input validation of component names

### DIFF
--- a/core/libraries/Hubzero/Api/Component/Loader.php
+++ b/core/libraries/Hubzero/Api/Component/Loader.php
@@ -25,13 +25,13 @@ class Loader extends Base
 	{
 		$lang = $this->app['language'];
 
+		$option = $this->canonical($option);
+		
 		if (empty($option))
 		{
 			// Throw 404 if no component
 			$this->app->abort(404, $lang->translate('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'));
 		}
-
-		$option = $this->canonical($option);
 
 		// Record the scope
 		$scope = $this->app->has('scope') ? $this->app->get('scope') : null;

--- a/core/libraries/Hubzero/Component/ApiController.php
+++ b/core/libraries/Hubzero/Component/ApiController.php
@@ -1011,15 +1011,8 @@ class ApiController implements ControllerInterface
 			$file = strtolower(end($file));
 
 			$path = \Component::path($this->_option) . '/models/' . $file . '.php';
-			$can_path = realpath($path);
-			if ($can_path != $path) {
-				App::abort(404, Lang::txt('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND', $model));
-			}
-			if (is_readable($path)) {
-				require_once $path;
-			} else {
-				App::abort(500, 'Required file is not readable', $model));
-			}
+
+			require_once $path;
 
 			if (!class_exists($model))
 			{

--- a/core/libraries/Hubzero/Component/ApiController.php
+++ b/core/libraries/Hubzero/Component/ApiController.php
@@ -1011,8 +1011,15 @@ class ApiController implements ControllerInterface
 			$file = strtolower(end($file));
 
 			$path = \Component::path($this->_option) . '/models/' . $file . '.php';
-
-			require_once $path;
+			$can_path = realpath($path);
+			if ($can_path != $path) {
+				App::abort(404, Lang::txt('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND', $model));
+			}
+			if (is_readable($path)) {
+				require_once $path;
+			} else {
+				App::abort(500, 'Required file is not readable', $model));
+			}
 
 			if (!class_exists($model))
 			{

--- a/core/libraries/Hubzero/Component/Loader.php
+++ b/core/libraries/Hubzero/Component/Loader.php
@@ -129,11 +129,21 @@ class Loader
 		}
 		// do not allow dots in component name to avoid directory traversal issues
 		$option = preg_replace('/[^A-Z0-9_-]/i', '', $option);
-		// prepend com_ to the name if it doesn't start with com_
 		// if option became empty due to the filtering, return an empty string
-		if ((strlen($option) > 0) && (substr($option, 0, strlen('com_')) != 'com_'))
+		if (strlen($option) > 0) 
 		{
-			$option = 'com_' . $option;
+			if (substr($option, 0, strlen('com_')) == 'com_')
+			{
+				// if option is just the prefix, make it empty because it's invalid
+				if ($option == 'com_')
+				{
+					$option = '';
+				}
+				// else it's presumably a good name and return that
+			} else {
+				// prepend com_ to the name if it doesn't start with com_
+				$option = 'com_' . $option;
+			}
 		}
 		return $option;
 	}


### PR DESCRIPTION
The path used with require_once may be invalid or manipulated with dots due to missing or incorrect input validation,  or the file may be unreadable.