### PR TITLE
Fixed relative require if com_publications is moved to app dir

### DIFF
--- a/core/components/com_publications/admin/publications.php
+++ b/core/components/com_publications/admin/publications.php
@@ -48,7 +48,7 @@ if (!file_exists(__DIR__ . DS . 'controllers' . DS . $controllerName . '.php'))
 	\Route::url('index.php?option=com_publications&controller=batchcreate'),
 	$controllerName == 'batchcreate'
 );
-require_once dirname(dirname(__DIR__)) . DS . 'com_plugins' . DS . 'helpers' . DS . 'plugins.php';
+require_once \Component::path('com_plugins') . DS . 'helpers' . DS . 'plugins.php';
 if (\Components\Plugins\Helpers\Plugins::getActions()->get('core.manage'))
 {
 	\Submenu::addEntry(


### PR DESCRIPTION
The com_publications admin used a relative require that failed to
load com_plugins if com_publications was copied to app for local
changes but com_plugins was not. This change uses the
Component::path method to get the correct location of com_plugins