### PR TITLE
Mod articles category fix

### DIFF
--- a/core/components/com_publications/admin/publications.php
+++ b/core/components/com_publications/admin/publications.php
@@ -48,7 +48,7 @@ if (!file_exists(__DIR__ . DS . 'controllers' . DS . $controllerName . '.php'))
 	\Route::url('index.php?option=com_publications&controller=batchcreate'),
 	$controllerName == 'batchcreate'
 );
-require_once dirname(dirname(__DIR__)) . DS . 'com_plugins' . DS . 'helpers' . DS . 'plugins.php';
+require_once \Component::path('com_plugins') . DS . 'helpers' . DS . 'plugins.php';
 if (\Components\Plugins\Helpers\Plugins::getActions()->get('core.manage'))
 {
 	\Submenu::addEntry(

--- a/core/modules/mod_articles_category/helper.php
+++ b/core/modules/mod_articles_category/helper.php
@@ -340,8 +340,7 @@ class Helper extends Module
 				$item->catslug = '';
 				$item->displayCategoryTitle = '';
 			}
-			Log::debug("item->catslug: " . $item->catslug);
-
+			
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article


### PR DESCRIPTION
The helper.php file for mod_articles_category was out of date
compared to the current usage of core library classes. In some
cases it was applying unset filter attributes in a way that
ensured no content entries would match the query.
In other cases it was assuming attributes of the returned items
describing the category it belonged to were present but they no
longer are. The instigation of this fix were a couple of errors
related to the renaming of the old published column to state
and the use of the Query class with a mismatched set of
parameters to the whereRaw method. This commit should solve all
of those issues.