### PR TITLE
Add api endpoint for /api/v1.1/members/currentuser

### DIFF
--- a/core/components/com_members/api/controllers/profilesv1_1.php
+++ b/core/components/com_members/api/controllers/profilesv1_1.php
@@ -366,7 +366,23 @@ class Profilesv1_1 extends ApiController
 	 */
 	public function readTask()
 	{
-		$userid = Request::getInt('id', 0);
+		$id = Request::getCmd('id', '');
+
+		if (($id == 'currentuser'))
+		{
+			$user = User::getInstance();
+
+			if ($user->isGuest())
+			{
+	                        throw new Exception(Lang::txt('Not authorized'), 403);
+			}
+
+			$userid = $user->get('id');
+		}
+		else
+		{
+			$userid = Request::getInt('id', 0);
+		}
 
 		$result = Member::oneOrFail($userid);
 

--- a/core/components/com_members/api/router.php
+++ b/core/components/com_members/api/router.php
@@ -53,7 +53,12 @@ class Router extends Base
 
 		if (isset($segments[0]))
 		{
-			if (is_numeric($segments[0]))
+			if ( ($segments[0] == 'currentuser') && (\App::get('request')->method() == 'GET'))
+			{
+				$vars['id'] = $segments[0];
+				$vars['task'] = 'read';
+			}
+			else if (is_numeric($segments[0]))
 			{
 				$vars['id'] = $segments[0];
 				if (\App::get('request')->method() == 'GET')

--- a/core/libraries/Hubzero/Api/Guard.php
+++ b/core/libraries/Hubzero/Api/Guard.php
@@ -10,7 +10,8 @@ namespace Hubzero\Api;
 use Hubzero\Container\Container;
 use Hubzero\Oauth\Server;
 use Hubzero\Oauth\Storage\Mysql as MysqlStorage;
-use Hubzero\User\User;
+use Hubzero\Config\Registry;
+
 use Exception;
 use Event;
 
@@ -54,18 +55,51 @@ class Guard
 		return $this->token;
 	}
 
+
 	/**
-	 * Validates incoming request via OAuth2 specification
+         * Clear session variables while maintaining some internal
+	 * session state.
 	 *
-	 * @param   array  $params   Oauth server request parameters
-	 * @param   array  $options  OAuth server configuration options
+	 * @return void
+	 */
+	private function clear_session()
+	{
+		// @TODO: Ultimately I don't think any of this is necessary
+		// and will likely get removed in a future session refactoring
+		// patch. We do this here just in case its needed to maintain
+		// session integrity.
+
+		$session_timer_start = Session::get('session.timer.start');
+		$session_timer_last = Session::get('session.timer.last');
+		$session_timer_now = Session::get('session.timer.now');
+		$session_client_address = Session::get('session.client.address');
+		$session_client_forwarded = Session::get('session.client.forwarded');
+		$session_client_browser = Session::get('session.client.browser');
+		$session_token = Session::get('session.token');
+		$session_counter = Session::get('session.counter');
+
+		session_unset();
+
+		Session::set('session.timer.start', $session_timer_start);
+		Session::set('session.timer.last', $session_timer_last);
+		Session::set('session.timer.now', $session_timer_now);
+		Session::set('session.client.address', $session_client_address);
+		Session::set('session.client.forwarded', $session_client_forwarded);
+		Session::set('session.client.browser', $session_client_browser);
+		Session::set('session.token', $session_token);
+		Session::set('session.counter', $session_counter);
+	}
+
+
+	/**
+	 * Validates incoming request
+	 *
+	 * @param   array  $params   request parameters
+	 * @param   array  $options  configuration options
 	 * @return  array
 	 */
 	public function authenticate($params = array(), $options = array())
 	{
-		// Placeholder response
-		$response = ['user_id' => null];
-
 		// Fire before auth event
 		Event::trigger('before_auth');
 
@@ -74,28 +108,82 @@ class Guard
 		$oauthRequest  = \OAuth2\Request::createFromGlobals();
 		$oauthResponse = new \OAuth2\Response();
 
-		// Validate request via oauth
-		$oauthServer->verifyResourceRequest($oauthRequest, $oauthResponse);
-
-		// Store our token locally
-		$this->token = $oauthServer->getAccessTokenData($oauthRequest);
-
-		// See if we have a valid user
-		if (isset($this->token['uidNumber']))
+		if ( $oauthServer->verifyResourceRequest($oauthRequest, $oauthResponse) )
 		{
-			$response['user_id'] = $this->token['uidNumber'];
-			$user = User::oneOrNew($response['user_id']);
-			if ($user->get('id'))
+			// This request was successfully authenticated by OAuth2
+
+			// Store our token locally
+			$this->token = $oauthServer->getAccessTokenData($oauthRequest);
+
+			// See if we have a valid user
+			if (isset($this->token['uidNumber']))
 			{
-				$user->set('guest', false);
+				$user = User::oneOrNew($this->token['uidNumber']);
+
+				if ($user->get('id'))
+				{
+					$user->set('guest', false);
+				}
+				else
+				{
+					// We got a user_id from the Oauth2 Token
+					// But the user does not exist
+					// so we have to fail the request
+
+					$oauthResponse->setStatusCode(403);
+					$oauthResponse->setParameter('error','invalid_token');
+					$oauthResponse->setParameter('error_description','The access token refers to a non-existent user');
+					$oauthResponse->setParameter('code', $oauthResponse->getStatusCode());
+					$oauthResponse->send();
+					exit();
+				}
 			}
-			$this->app['session']->set('user', $user);
+			else
+			{
+				// Well we may be authenticated by OAuth2 but
+				// we are missing TokenData so we have to fail
+				// the request here
+
+				$oauthResponse->setStatusCode(403);
+				$oauthResponse->setParameter('error','invalid_token');
+				$oauthResponse->setParameter('error_description', 'The access token is missing user identification data');
+				$oauthResponse->setParameter('code', $oauthResponse->getStatusCode());
+				$oauthResponse->send();
+				exit();
+			}
 		}
+		else if ($oauthResponse->getParameters('error') != array())
+		{
+			// This request looked like OAuth2 but failed. We respond
+			// immediately with an error here because the client was expecting
+			// an authenticated response so returning a guest response would
+			// be unexpected.
+
+			$oauthResponse->setParameter('code', $oauthResponse->getStatusCode());
+			$oauthResponse->send();
+			exit();
+		}
+		else
+		{
+			// This request is authenticated by session data
+			// If this is a guest session we pass it through as such.
+			// It is up to the API call to check authorization.
+
+			$user = User::getInstance();
+		}
+
+		$userid = $user->get('id');
+
+		// Clear session data, API calls should not be using any session state data
+		$this->clear_session();
+
+		Session::set('registry', new Registry('session'));
+		Session::set('user', $user);
 
 		// Fire after auth event
 		Event::trigger('after_auth');
 
-		// Return the response
-		return $response;
+		// Return the user_id  (null == guest)
+		return array( 'user_id' => $userid ? $userid : null );
 	}
 }


### PR DESCRIPTION
currentuser endpoint resolves to the user id of the authenticated session user or oauth2 token. Oauth2 authentication takes priority if both are available. Session data is now cleared after authentication to prevent potential confusion if one were to do an oauth2 authentication for one user from within a session of another user.  Currently api calls do NOT persist session data changes between calls. A future patch will add a session keep-alive call while continuing to not persist session data. API calls should not want/try/succeed in persisting data via sessions.