### PR TITLE
[fix] Added check for local DOI before updating

### DIFF
--- a/core/components/com_publications/site/controllers/curation.php
+++ b/core/components/com_publications/site/controllers/curation.php
@@ -553,7 +553,9 @@ class Curation extends SiteController
 		// Get DOI service
 		$doiService = new \Components\Publications\Models\Doi($this->_pub);
 
-		if ($this->_pub->version->doi)
+		$updateDoiMetadata = ($this->_pub->version->doi ? preg_match("/" . $doiService->configs()->shoulder . "/", $this->_pub->version->doi) : false);
+
+		if ($updateDoiMetadata)
 		{
 			$doiService->update($this->_pub->version->doi, true);
 

--- a/core/plugins/projects/publications/publications.php
+++ b/core/plugins/projects/publications/publications.php
@@ -2210,8 +2210,10 @@ class plgProjectsPublications extends \Hubzero\Plugin\Plugin
 			}
 		}
 
+		$updateDoiMetadata = ($pub->version->doi ? preg_match("/" . $doiService->configs()->shoulder . "/", $pub->version->doi) : false);
+
 		// When dataset is automatically approved.
-		if (!$review && ($autoApprove || $this->_pubconfig->get('autoapprove') == 1) && $pub->version->get('doi'))
+		if (!$review && ($autoApprove || $this->_pubconfig->get('autoapprove') == 1) && $updateDoiMetadata)
 		{
 			// Update DOI metadata
 			$doiService->update($pub->version->get('doi'), true);
@@ -2234,7 +2236,7 @@ class plgProjectsPublications extends \Hubzero\Plugin\Plugin
 			}
 		}
 
-		if ($this->_task == 'revert' && $pub->version->doi && $originalStatus == 1)
+		if ($this->_task == 'revert' && $updateDoiMetadata && $originalStatus == 1)
 		{
 			$doiService->revert($pub->version->doi, $doiService::STATE_FROM_PUBLISHED_TO_DRAFTREADY);
 
@@ -2245,7 +2247,7 @@ class plgProjectsPublications extends \Hubzero\Plugin\Plugin
 			}
 		}
 
-		if ($this->_task == 'publish' && $pub->version->doi && $originalStatus == 4)
+		if ($this->_task == 'publish' && $updateDoiMetadata && $originalStatus == 4)
 		{
 			$doiService->revert($pub->version->doi, $doiService::STATE_FROM_DRAFTREADY_TO_PUBLISHED);
 


### PR DESCRIPTION
Added this to check if batch imported doi has a different namespace/shoulder from ones minted by the hub. If different, don't try and auto-update metadata (was throwing an error).