### PR TITLE
exit search loop when forge logo file is found

### DIFF
--- a/core/components/com_tools/site/controllers/tools.php
+++ b/core/components/com_tools/site/controllers/tools.php
@@ -173,6 +173,7 @@ class Tools extends SiteController
 			if (file_exists($path))
 			{
 				$image = $path;
+				break;
 			}
 		}
 


### PR DESCRIPTION
Task looks for a valid logo file in template or component locations. When it finds one it should use it, as coded now it always chooses the last path in the list. This prevented the custom nanohub forge logo from working. This appears to have been broken since 2016, not sure how it was only reported this year and I am fairly sure I saw the nanohub forge logo long since then... but it clearly can't work the way it is.