### PR TITLE
exit search loop when tool asset css file is found

### DIFF
--- a/core/components/com_tools/site/controllers/tools.php
+++ b/core/components/com_tools/site/controllers/tools.php
@@ -161,7 +161,7 @@ class Tools extends SiteController
 		$file = 'forge.png';
 
 		$paths = array(
-			\App::get('template')->path . DS . 'html' . DS . $this->_option . DS . 'images' . DS . $file,
+			\App::get('template')->path . DS . 'images' . DS . $file,
 			dirname(__DIR__) . DS . 'assets' . DS . 'img' . DS . $file,
 			dirname(__DIR__) . DS . 'images' . DS . $file
 		);
@@ -201,7 +201,7 @@ class Tools extends SiteController
 	public function cssTask($css = 'site_css.css')
 	{
 		$paths = array(
-			\App::get('template')->path . DS . 'html' . DS . $this->_option . DS . $css,
+			\App::get('template')->path . DS . 'css' . DS . $css,
 			dirname(__DIR__) . DS . 'assets' . DS . 'css' . DS . $css,
 			dirname(__DIR__) . DS . 'css' . DS . $css
 		);
@@ -213,6 +213,7 @@ class Tools extends SiteController
 			if (file_exists($path))
 			{
 				$file = $path;
+				break;
 			}
 		}
 


### PR DESCRIPTION
Just like the previous PR the search for the css file to serve doesn't stop at the first match like it should. Also it searches in the wrong path in the template directory (should be within a css directory). 

This task is only used when exportfile and importfile in a hub workspace is called. This triggers a pop up window which loads a file transfer dialog whose styling can be override by the css file delivered by this task. The task exists rather than direct access because it is awkward to pass in the hub template name for exportfile to use. For a long time we used the awkward method but it broke a while back and I came up with this method but never deployed it.  It is time to deploy it now. At least for nanohub which already has this fix in its com_tools component override.