### PR TITLE
Handling of emails on comments when submitter was not logged in

### DIFF
--- a/core/components/com_support/site/controllers/tickets.php
+++ b/core/components/com_support/site/controllers/tickets.php
@@ -1819,7 +1819,7 @@ class Tickets extends SiteController
 				if (!$rowc->isPrivate())
 				{
 					# Users can submit a ticket while not logged in and without a username, that has to be handled differently
-					if (empty($row->login) && (is_string($row->login) && strlen($row->login) == 0))
+					if (is_string($row->login) && strlen($row->login) == 0)
 					{
 						$rowc->addTo($row->email);
 					}

--- a/core/components/com_support/site/controllers/tickets.php
+++ b/core/components/com_support/site/controllers/tickets.php
@@ -1818,12 +1818,20 @@ class Tickets extends SiteController
 				// submitter regardless of the above setting
 				if (!$rowc->isPrivate())
 				{
-					$rowc->addTo(array(
-						'role'  => Lang::txt('COM_SUPPORT_COMMENT_SEND_EMAIL_SUBMITTER'),
-						'name'  => $row->submitter->get('name'),
-						'email' => $row->submitter->get('email'),
-						'id'    => $row->submitter->get('id')
-					));
+					# Users can submit a ticket while not logged in and without a username, that has to be handled differently
+					if (empty($row->login) && (is_string($row->login) && strlen($row->login) == 0))
+					{
+						$rowc->addTo($row->email);
+					}
+					else 
+					{
+						$rowc->addTo(array(
+							'role'  => Lang::txt('COM_SUPPORT_COMMENT_SEND_EMAIL_SUBMITTER'),
+							'name'  => $row->submitter->get('name'),
+							'email' => $row->submitter->get('email'),
+							'id'    => $row->submitter->get('id')
+						));
+					}
 				}
 			}
 


### PR DESCRIPTION
Related to ticket 2939 on Qubes and ticket 400081 on nanoHub, this will detect the condition when a user submitted a ticket while not logged in and did not provide a username.  When these tickets are commented on instead of reporting the submitter was emailed but actually not sending the email this change will cause the email address used when submitting the ticket to be sent an email. Subsequent work will need to validate replies to these emails are handled correctly.