### PR TITLE
Remove submitter from author list in search results

### DIFF
--- a/core/components/com_resources/models/entry.php
+++ b/core/components/com_resources/models/entry.php
@@ -315,7 +315,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 	 *
 	 * @return  string
 	 */
-	public function authorsList()
+	public function authorsList($solr=false)
 	{
 		$names = array();
 
@@ -330,7 +330,10 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 			$name = htmlentities($contributor->name);
 			if ($contributor->get('authorid') > 0)
 			{
-				$name = '<a href="' . Route::url('index.php?option=com_members&id=' . $contributor->get('authorid')) . '" data-rel="contributor" class="resource-contributor" title="View the profile of ' . $name . '">' . $name . '</a>';
+				if (!$solr)
+				{
+					$name = '<a href="' . Route::url('index.php?option=com_members&id=' . $contributor->get('authorid')) . '" data-rel="contributor" class="resource-contributor" title="View the profile of ' . $name . '">' . $name . '</a>';
+				}
 			}
 			if ($contributor->get('role'))
 			{
@@ -1685,10 +1688,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 		$obj->publish_up = Date::of($this->get('publish_up'))->format($solrDateFormat);
 		$obj->description = $this->searchableDescription();
 		$obj->author = $this
-			->authors()
-			->select('name')
-			->rows()
-			->fieldsbyKey('name');
+			->authorsList(true);
 
 		$obj->access_level = $this->access_level;
 		$groups = $this->getGroups();


### PR DESCRIPTION
Any author with the role 'submitter' has been removed from the
document generated and registered with Solr for resources. This
is at the request of nanohub on #379618.