### PR TITLE
fix router to parse com_members api tasks

### DIFF
--- a/core/components/com_members/api/router.php
+++ b/core/components/com_members/api/router.php
@@ -61,7 +61,11 @@ class Router extends Base
 			else if (is_numeric($segments[0]))
 			{
 				$vars['id'] = $segments[0];
-				if (\App::get('request')->method() == 'GET')
+				if (isset($segments[1]))
+				{
+					$vars['task'] = $segments[1];
+				}
+				else if (\App::get('request')->method() == 'GET')
 				{
 					$vars['task'] = 'read';
 				}


### PR DESCRIPTION
The com_members api router doesn't parse for task, all requests go to profile. This blocked access to fetching a user's group memberships.