### PR TITLE
add accessgroups api endpoint to com_members

### DIFF
--- a/core/components/com_members/api/controllers/profilesv1_1.php
+++ b/core/components/com_members/api/controllers/profilesv1_1.php
@@ -466,6 +466,75 @@ class Profilesv1_1 extends ApiController
 	}
 
 	/**
+	 * Get a member's accessgroups
+	 *
+	 * @apiMethod GET
+	 * @apiUri    /members/{id}/accessgroups
+	 * @apiParameter {
+	 *		"name":        "id",
+	 *		"description": "Member identifier",
+	 *		"type":        "integer",
+	 *		"required":    true,
+	 *		"default":     null
+	 * }
+	 * @apiParameter {
+	 *		"name":        "inherited",
+	 *		"description": "include inherited user accessgroups",
+	 *		"type":        "boolean",
+	 *		"required":    false,
+	 *		"default":     false
+	 * }
+	 * @apiParameter {
+	 *		"name":        "titles",
+	 *		"description": "return accessgroup titles",
+	 *		"type":        "boolean",
+	 *		"required":    false,
+	 *		"default":     false
+	 * }
+	 * @apiParameter {
+	 *		"name":        "all",
+	 *		"description": "return accessgroup titles and ids as an associative array",
+	 *		"type":        "boolean",
+	 *		"required":    false,
+	 *		"default":     false
+	 * }
+	 * @return array of accessgroups member belongs to
+	 */
+
+	public function accessgroupsTask()
+	{
+		 $this->requiresAuthentication();
+
+		 $user = User::getInstance();
+
+		 $userid = Request::getInt('id', 0);
+
+		 if ($user->get('id') != $userid && !User::authorise('core.admin'))
+		 {
+			throw new Exception(Lang::txt('Access denied'), 400);
+		 }
+
+		 $titles = Request::getBool('titles',false);
+		 $inherited = Request::getBool('inherited',false);
+		 $all = Request::getBool('all',false);
+
+		 $result = User::getInstance($userid);
+
+		 if (!$result || !$result->get('id'))
+		 {
+			throw new Exception(Lang::txt('No such user'), 404);
+		 }
+
+		 $groups = \Hubzero\Access\Access::getGroupsByUser($userid, $inherited, $titles, $all);
+
+		 // Encode and return result
+		 $obj = new stdClass();
+		 $obj->accessgroups = $groups;
+
+		 $this->send($obj);
+	}
+
+	/**
 	 * Get a member's groups
 	 *
 	 * @apiMethod GET


### PR DESCRIPTION
Added some options to Access::getGroupsByUser to return accessgroups by title or a full associative array description for use by api call, default parameters are backward compatible.

Added /api/v1.1/members/{id}/accessgroups endpoint to obtain list of accessgroups for a user (Publisher, Registered, Super-User, etc)
