### PR TITLE
Add parentheses to divide out units prior to function call

### DIFF
--- a/core/assets/less/variables.less
+++ b/core/assets/less/variables.less
@@ -327,8 +327,8 @@
 
 // Fluid grid
 // -------------------------
-@fluidGridColumnWidth:    percentage(@gridColumnWidth/@gridRowWidth);
-@fluidGridGutterWidth:    percentage(@gridGutterWidth/@gridRowWidth);
+@fluidGridColumnWidth:    percentage((@gridColumnWidth/@gridRowWidth));
+@fluidGridGutterWidth:    percentage((@gridGutterWidth/@gridRowWidth));
 
 // Breaking the grid
 // -------------------------


### PR DESCRIPTION
Ran into an issue compiling the lucent (https://gitlab.hubzero.org/hubzero/lucent-the-minimal-hubzero-template) template with `less`. The offending location is in the core file variables.less.

*Error message:* 
`ArgumentError: Error evaluating function `percentage`: argument must be a number in /core/assets/less/variables.less on line 337, column 27`

Same error was thrown on line 338, which performs same operation on related dimensions.

*`lessc` version*
used for compile:
lessc 4.1.2 (Less Compiler) [JavaScript]

*Fix:*
Add nested parentheses to indicate the division step should be performed prior to function call to percentage(). This ensures that the units are divided out of the argument passed to the function. The resulting argument is numeric and its percentage can be computed.

*Test:*
Verified that compilation of the less files into css proceeds without errors once this single change is made to lines 337 and 338