### PR TITLE
[fix] Tags for versions where being deleted

### DIFF
--- a/core/components/com_publications/tables/publication.php
+++ b/core/components/com_publications/tables/publication.php
@@ -637,13 +637,6 @@ class Publication extends Table
 			$id = $this->id;
 		}
 
-		// Delete tag associations
-		$this->_db->setQuery("DELETE FROM `#__tags_object` WHERE tbl='publications' AND objectid=". $this->_db->quote($id));
-		if (!$this->_db->query())
-		{
-			echo $this->_db->getErrorMsg();
-			exit;
-		}
 		// Delete ratings
 		$this->_db->setQuery("DELETE FROM `#__publication_ratings` WHERE publication_id=" . $this->_db->quote($id));
 		if (!$this->_db->query())


### PR DESCRIPTION
Legacy code removed from when tags were associated with publications
  and not versions. This code was inadvertently deleting tags for
  versions with ids matching the removed publication id.