### PR TITLE
Check if the property exists before referencing it

### DIFF
--- a/core/plugins/resources/about/views/index/tmpl/default.php
+++ b/core/plugins/resources/about/views/index/tmpl/default.php
@@ -136,7 +136,7 @@ $maintext = $this->model->description;
 						{
 							$citations = $data[$field->name];
 						}
-						else if ($elements->display($field->type, $data[$field->name]) && $field->display == $tab )
+						else if ($elements->display($field->type, $data[$field->name]) && isset($field->display) && $field->display == $tab )
 						{
 							?>
 							<h4><?php echo $field->label; ?></h4>


### PR DESCRIPTION
Not checking for the property caused PHP error on dev nanohub. Live ignored it, since it was configured with different PHP error level.