### PR TITLE
Filter out requests for sensitive files

### DIFF
--- a/core/components/com_groups/site/controllers/groups.php
+++ b/core/components/com_groups/site/controllers/groups.php
@@ -1506,10 +1506,17 @@ class Groups extends Base
 		// If super group offer alt path outside uploads
 		if ($group->isSuperGroup())
 		{
-			$alt_file_path = str_replace('/uploads', '', $base_path) . DS . $file;
+			// do not serve gitignore or PHP files
+			if ($file != 'gitignore' && strpos($file, '.php') > 0)
+			{
+				// do not allow serving anything from config or .git directory
+				$replace_base = ['/uploads', '/config', '/.git'];
 
-			// If super group can serve files anywhere inside /site/groups/{group_id}
-			$altPathCheck  = PATH_APP . DS . ltrim($alt_file_path);
+				$alt_file_path = str_replace($replace_base, '', $base_path) . DS . $file;
+
+				// If super group can serve files anywhere inside /site/groups/{group_id}
+				$altPathCheck  = PATH_APP . DS . ltrim($alt_file_path);
+			}
 		}
 
 		// Ensure the file exist


### PR DESCRIPTION
Without this fix, the code will serve any file inside a supergroup's directory.  This forbids serving some files and directories.    Ref qubeshub.org Ticket #3911