### PR TITLE
 Ensure pending resources are not displayed in Solr search results

### DIFF
--- a/core/components/com_resources/models/entry.php
+++ b/core/components/com_resources/models/entry.php
@@ -1592,7 +1592,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 
 		if ($this->standalone == 1 && $this->isPublished())
 		{
-			switch ($this->access)
+			switch ($this->get('access'))
 			{
 				case 0:
 					$accessLevel = 'public';
@@ -1690,7 +1690,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 		$obj->author = $this
 			->authorsList(true);
 
-		$obj->access_level = $this->access_level;
+		$obj->access_level = $this->transformAccessLevel();
 		$groups = $this->getGroups();
 		$tags = $this->tags(false);
 

--- a/core/components/com_resources/models/entry.php
+++ b/core/components/com_resources/models/entry.php
@@ -571,7 +571,7 @@ class Entry extends Relational implements \Hubzero\Search\Searchable
 		}
 
 		// Make sure the resource is published and standalone
-		if (in_array($this->get('published'), array(self::STATE_UNPUBLISHED, self::STATE_DRAFT, self::STATE_TRASHED, self::STATE_DRAFT_INTERNAL)))
+		if (in_array($this->get('published'), array(self::STATE_UNPUBLISHED, self::STATE_PENDING, self::STATE_DRAFT, self::STATE_TRASHED, self::STATE_DRAFT_INTERNAL)))
 		{
 			return false;
 		}


### PR DESCRIPTION
## Summary

This PR addresses [issue #412067](https://nanohub.org/support/ticket/412067) reported by Nanohub users. Pending (unpublished) resources were appearing in search results. Only global site, solr searches (not legacy Resources component searches) were encountering this issue.

The com_resource component's Entry class, a subclass of Relational that implements Searchable, was found to have two bugs associated with the information sent to solr that contributed to this problem:

- An empty access level variable was sent to solr when indexing a Resource
- Indexing-time checks for state of Resource did not consider Pending state

## Testing

This fix was tested on a Hubzero 2021 VM. Prior to fix, solr search showed that guest users could search on Pending resources. Applying this fix and reindexing Resources for solr on the VM resulted in guest users being unable to return Pending resources in searches. This restores expected behavior.

Additionally, the search results displayed for an authorized user (owner of the resources) now display the correct resource state, Private, Public, or Restricted, for Solr searches (access level variable fix). This state is determined in transformAccessLevel(), which is now being called so that this information is populated and passed to Solr for indexing.

## Motivation

This PR addresses the following Nanohub ticket:

https://nanohub.org/support/ticket/412067

Associated Jira task:

https://sdx-sdsc.atlassian.net/browse/NCN-43