### PR TITLE
PSC 127 fix

### DIFF
--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -172,7 +172,7 @@ class Assetgroups extends AdminController
 
 				$list[$id] = $v;
 				$list[$id]->treename = "$indent$txt";
-				$list[$id]->children = count(@$children[$id]);
+				$list[$id]->children = (@children[$id]) ? count(@$children[$id]) : 0;
 				$list = $this->treeRecurse($id, $indent . $spacer, $list, $children, $maxlevel, $level+1, $type);
 			}
 		}


### PR DESCRIPTION
This fixes a null pointer error occurring when creating a new asset group in a course - documents on Ticket #127 on PSC hub.