### PR TITLE
alternate approach to fixing article/category route parsing bug

### DIFF
--- a/core/components/com_content/site/router.php
+++ b/core/components/com_content/site/router.php
@@ -286,8 +286,26 @@ class Router extends Base
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
-			$vars['id']   = $segments[$count - 1];
-
+			$id = $segments[$count - 1];
+			if ($id+0 == 0) // check if an alias, not an integer if
+			{
+				if($vars['view'] == 'article')
+				{
+					$query = 'SELECT id FROM `#__content` WHERE alias = ' . $db->Quote($id);
+				}
+				else if($vars['view'] == 'category')
+				{
+					$query = 'SELECT id FROM `#__categories` WHERE alias = ' . $db->Quote($id);
+				}
+				else
+				{
+					$vars['id'] = (int)$id;
+					return $vars;
+				}
+				$db->setQuery($query);
+				$id = $db->loadResult();;
+			}
+			$vars['id'] = (int)$id;
 			return $vars;
 		}
 
@@ -300,7 +318,14 @@ class Router extends Base
 			if (strpos($segments[0], ':') === false)
 			{
 				$vars['view'] = 'article';
-				$vars['id']   = (int)$segments[0];
+				$id   = $segments[0];
+				if ($id+0 == 0) // check if an alias, not an integer id
+				{
+					$query = 'SELECT id FROM `#__content` WHERE alias = ' . $db->Quote($id);
+					$db->setQuery($query);
+					$id = $db->loadResult();;
+				}
+				$vars['id'] = (int)$id;
 				return $vars;
 			}
 


### PR DESCRIPTION
This PR supercedes PR 1594 to fix parsing issues with routes like content/article/category-alias/article-alias or content/category/category-alias, which don't have numerical item ids.  This approach only involves the parser within the Content component, not the parsing rules generated during bootstrap.