### PR TITLE
fix for STEMED ticket 1052 (unit duplication error)

### DIFF
--- a/core/components/com_courses/admin/controllers/units.php
+++ b/core/components/com_courses/admin/controllers/units.php
@@ -229,7 +229,7 @@ class Units extends AdminController
 	public function copyTask()
 	{
 		// Incoming
-		$ids = Request::getInt('id', 0);
+		$id = Request::getInt('id', 0);
 
 		// Get the single ID we're working with
 		if (is_array($id))


### PR DESCRIPTION
This fixes a bug in copying a course unit on the admin Course component.  See STEMED ticket 1052.