### PR TITLE
Date Fields on Articles Behaving Strangely During Copy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Before you submit this pull request, please make sure:
+
+- [ ] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
+- [ ] Include a brief summary of the issue *in your own words*
+- [ ] Include a breif summary of the fix
+- [ ] Include a brief summary of your testing
+- [ ] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
+- [ ] Double check someone is assigned to review the ticket
+
+**Thanks!**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 # Before you submit this pull request, please make sure:
 
 - [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
-- [] Include a brief summary of the issue *in your own words*
-- [] Include a breif summary of the fix
-- [] Include a brief summary of your testing
+- [] Include a brief summary of the issue **in your own words**
+- [] Include a brief summary of the fix/changed code
+- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
 - [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
 - [] Double check someone is assigned to review the ticket
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 # Before you submit this pull request, please make sure:
 
-- [ ] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
-- [ ] Include a brief summary of the issue *in your own words*
-- [ ] Include a breif summary of the fix
-- [ ] Include a brief summary of your testing
-- [ ] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
-- [ ] Double check someone is assigned to review the ticket
+- [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
+- [] Include a brief summary of the issue *in your own words*
+- [] Include a breif summary of the fix
+- [] Include a brief summary of your testing
+- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
+- [] Double check someone is assigned to review the ticket
 
 **Thanks!**

--- a/core/components/com_courses/admin/controllers/units.php
+++ b/core/components/com_courses/admin/controllers/units.php
@@ -229,7 +229,7 @@ class Units extends AdminController
 	public function copyTask()
 	{
 		// Incoming
-		$ids = Request::getInt('id', 0);
+		$id = Request::getInt('id', 0);
 
 		// Get the single ID we're working with
 		if (is_array($id))

--- a/core/plugins/tags/groups/groups.php
+++ b/core/plugins/tags/groups/groups.php
@@ -61,6 +61,11 @@ class plgTagsGroups extends \Hubzero\Plugin\Plugin
 			$from = " JOIN #__xgroups_members AS m ON m.gidNumber=a.gidNumber AND m.uidNumber=" . (int)User::get('id', 0);
 		}
 
+		// Allow tag to be visible to public visitors, previously tag was visible only for registered and logged in users
+        if (User::isGuest()) {
+            $from = '';
+        }
+
 		// Build the query
 		$f_count = "SELECT COUNT(f.gidNumber) FROM (SELECT a.gidNumber, COUNT(DISTINCT t.tagid) AS uniques ";
 


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- https://sdx-sdsc.atlassian.net/browse/PLANTSCI-39
- https://plantingscience.org/support/ticket/286

**Brief summary of the issue**
Upon copying an existing article, the create date of the new article is wrong and not the current date. When user changes the start publishing and finish publishing date, the date jumps a few hours back from what was selected on the calendar icon. 

**Brief summary of the fix**
- Upon the copy of the original article, it will be saved with current date for the creation and publishing up date, the alias will also be unique
- The start publishing and finish publishing date will be set at UTC since the calendar selection is in UTC as well. The standardization from all the Hubzero dev will be UTC. 

**Brief summary of your testing**
Manual testing

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
No

**Double check someone is assigned to review the ticket**
Yes - Nick and David