### PR TITLE
Allow groups to show in tag search results for public visitors

### DIFF
--- a/core/plugins/tags/groups/groups.php
+++ b/core/plugins/tags/groups/groups.php
@@ -61,6 +61,11 @@ class plgTagsGroups extends \Hubzero\Plugin\Plugin
 			$from = " JOIN #__xgroups_members AS m ON m.gidNumber=a.gidNumber AND m.uidNumber=" . (int)User::get('id', 0);
 		}
 
+		// Allow tag to be visible to public visitors, previously tag was visible only for registered and logged in users
+        if (User::isGuest()) {
+            $from = '';
+        }
+
 		// Build the query
 		$f_count = "SELECT COUNT(f.gidNumber) FROM (SELECT a.gidNumber, COUNT(DISTINCT t.tagid) AS uniques ";
 


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- https://sdx-sdsc.atlassian.net/browse/VHUB-9
- https://theghub.org/support/ticket/2601

**Brief summary of the issue**
When a user adds a tag to a group, and upon searching for a tag, that specific group won't appear in the search results for public visitors but will appear for registered and logged in users. 

An example is on the search results of https://theghub.org/tags/ghub. The ISMIP6 group has the associated "Ghub" tag. But that ISMIP6 group only shows up in the results when the user is registered and logged in. The issue is how we can make groups show up for specific tags in the search results for non-registered (public) users.

**Brief summary of the fix**
- The search SQL statement originally filtered out those groups, so removed the filter for public users. 

**Brief summary of your testing**
Manual testing

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
No

**Double check someone is assigned to review the ticket**
Yes - Nick and David