### PR TITLE
add option to allow dashes in external links

### DIFF
--- a/core/plugins/content/externalhref/externalhref.php
+++ b/core/plugins/content/externalhref/externalhref.php
@@ -80,6 +80,7 @@ class plgContentExternalhref extends \Hubzero\Plugin\Plugin
 
 		$mode   = $this->params->get('mode');
 		$target = $this->params->get('target');
+		$allow_dashes = $this->params->get('allow_dashes');
 		$classes = array();
 
 		if ($cls = $this->params->get('classes'))
@@ -102,7 +103,14 @@ class plgContentExternalhref extends \Hubzero\Plugin\Plugin
 			foreach ($links as $link)
 			{
 				// Get attributes
-				$pattern = "/(\w+)(\s*=\s*(?:\".*?\"|'.*?'|[^'\">\s]+))?/i";
+				if ($allow_dashes)
+				{
+					$pattern = "/([a-zA-Z_-]+)(\s*=\s*(?:\".*?\"|'.*?'|[^'\">\s]+))?/i";
+				}
+				else
+				{
+					$pattern = "/(\w+)(\s*=\s*(?:\".*?\"|'.*?'|[^'\">\s]+))?/i";
+				}
 				$attribs = array();
 				preg_match_all($pattern, $link[1], $attribs, PREG_SET_ORDER);
 

--- a/core/plugins/content/externalhref/externalhref.xml
+++ b/core/plugins/content/externalhref/externalhref.xml
@@ -32,6 +32,10 @@
 					<option value="2">PLG_CONTENT_EXTERNALHREF_PARAM_TARGET_PARENT</option>
 					<option value="3">PLG_CONTENT_EXTERNALHREF_PARAM_TARGET_NOCHANGE</option>
 				</field>
+				<field name="allow_dashes" type="list" default="1" label="PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_LABEL" description="PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_DESC">
+					<option value="0">PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_NO</option>
+					<option value="1">PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_YES</option>
+				</field>
 				<field name="classes" type="textarea" default="" label="PLG_CONTENT_EXTERNALHREF_PARAM_CSS_LABEL" description="PLG_CONTENT_EXTERNALHREF_PARAM_CSS_DESC" rows="10" cols="25" />
 			</fieldset>
 		</fields>

--- a/core/plugins/content/externalhref/language/en-GB/en-GB.plg_content_externalhref.ini
+++ b/core/plugins/content/externalhref/language/en-GB/en-GB.plg_content_externalhref.ini
@@ -22,3 +22,7 @@ PLG_CONTENT_EXTERNALHREF_PARAM_TARGET_PARENT="Open in parent window / frame (_pa
 PLG_CONTENT_EXTERNALHREF_PARAM_TARGET_NOCHANGE="Do not change"
 PLG_CONTENT_EXTERNALHREF_PARAM_CSS_LABEL="Ignore with CSS Classes"
 PLG_CONTENT_EXTERNALHREF_PARAM_CSS_DESC="Links with one or mroe of the specified classes will be ignored. Comma separated values."
+PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_LABEL="Allow attributes with dashes(-)"
+PLG_CONTENT_EXTERNALHREF_PARAM_ALLOwDASHES_DESC="Attributes containing dashes(-) will not be tokenized as separate attributes or dropped because of no value."
+PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_YES="Allow attributes containing dashes(-)."
+PLG_CONTENT_EXTERNALHREF_PARAM_ALLOWDASHES_NO="Attributes containing dashes(-) will be tokenized and potentially dropped."


### PR DESCRIPTION
### Original support ticket: 
- [QUBES #4821](https://qubeshub.org/support/ticket/4821)
### JIRA tasks: 
- [QUBES-29](https://sdx-sdsc.atlassian.net/browse/QUBES-29)
- [QUBES-35](https://sdx-sdsc.atlassian.net/browse/QUBES-35)
### Brief summary of issue:
Embedded HTML code for a Twitter timeline feed was having some of the HREF attributes, such as limit on number of posts, stripped before being processes. This was regardless of whether using the page macro, the mod_twitterfeed module, or hand-coding the embedded HTML.
### Brief summary of fix/changes:
Many potential avenues were explored, including the Sanitizer (HTMLPurifier), but it turned out to be the 'Content - External Links' plugin (plugins/content/externalhref) responding to a onContentPrepare event (trigger) that was parsing (tokenizing) attributes and treating dashes as separators. The fix was to modify the regex pattern to allow dashes in attributes (and not break them up). A plugin configuration option was also added to enable/disable this feature (allowing dashes in attributes for external links).
### Brief summary of testing:
The undesired behavior was replicated on both the QUBES production site (on a WebDev group page) and on my personal dev (AWS) machine and the externalhref fix above resolved the issue.
### Hot fix required?  No.
Fortunately, there is a workaround for this issue, by adding ‘twitter-timeline’ to the list of classes in the ‘Content - External Links’ plugin to exclude it from being processed. This was shared with the client and implemented on the QUBES production site.

