### PR TITLE
fix for STEMED-7 regarding group blog RSS feeds

### DIFF
--- a/core/plugins/groups/blog/blog.php
+++ b/core/plugins/groups/blog/blog.php
@@ -434,7 +434,7 @@ class plgGroupsBlog extends \Hubzero\Plugin\Plugin
 			'scope_id'   => $this->group->get('gidNumber'),
 			'search'     => Request::getString('search', ''),
 			'created_by' => Request::getInt('author', 0),
-			'state'      => 'public'
+			'state'      => 1
 		);
 
 		$path = Request::path();


### PR DESCRIPTION
- Support ticket: [https://stemedhub.org/support/ticket/1001](https://stemedhub.org/support/ticket/1001)
- JIRA task: [https://sdx-sdsc.atlassian.net/browse/STEMED-7](https://sdx-sdsc.atlassian.net/browse/STEMED-7)
- Brief Summary: Group blog RSS feed not returning any entries
- Fix: Changed query filter value for 'state' from "public" to "1" in core/plugins/groups/blog/blog.php
- Test: Works after fix applied on jas.aws.hubzero.org for a test blog on a test group (blogtest)
- Hotfix required?  Probably.  Should ask stemedhub.org staff.

