### PR TITLE
[PLANTSCI-47] latest version of content router/parser

### DIFF
--- a/core/components/com_content/site/router.php
+++ b/core/components/com_content/site/router.php
@@ -278,7 +278,10 @@ class Router extends Base
 
 		for ($i = 0; $i < $count; $i++)
 		{
-			$segments[$i] = preg_replace('/-/', ':', $segments[$i], 1);
+			if (is_numeric($segments[$i][0]))
+			{
+				$segments[$i] = preg_replace('/-/', ':', $segments[$i], 1);
+			}
 		}
 
 		// Standard routing for articles.  If we don't pick up an Itemid then we get the view from the segments
@@ -286,7 +289,27 @@ class Router extends Base
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
-			$vars['id']   = $segments[$count - 1];
+			$id = $segments[$count - 1];
+			//if ($id+0 == 0) // check if an alias, not an integer id
+			if (preg_match('#[^0-9]#',$id))
+			{
+				if($vars['view'] == 'article')
+				{
+					$query = 'SELECT id FROM `#__content` WHERE alias = ' . $db->Quote($id);
+				}
+				else if($vars['view'] == 'category')
+				{
+					$query = 'SELECT id FROM `#__categories` WHERE alias = ' . $db->Quote($id);
+				}
+				else
+				{
+					$vars['id'] = (int)$id;
+					return $vars;
+				}
+				$db->setQuery($query);
+				$id = $db->loadResult();;
+			}
+			$vars['id'] = (int)$id;
 
 			return $vars;
 		}
@@ -300,7 +323,15 @@ class Router extends Base
 			if (strpos($segments[0], ':') === false)
 			{
 				$vars['view'] = 'article';
-				$vars['id']   = (int)$segments[0];
+				$id   = $segments[0];
+				//if ($id+0 == 0) // check if an alias, not an integer id
+				if (preg_match('#[^0-9]#',$id))
+				{
+					$query = 'SELECT id FROM `#__content` WHERE alias = ' . $db->Quote($id);
+					$db->setQuery($query);
+					$id = $db->loadResult();;
+				}
+				$vars['id'] = (int)$id;
 				return $vars;
 			}
 


### PR DESCRIPTION

- JIRA Task: https://sdx-sdsc.atlassian.net/browse/PLANTSCI-47
- This update to the content router/parser addresses several issues related to parsing of SEF URLs for articles and categories generated elsewhere in HUBzero code using Route::url(), including a /content/article or /content/category prefix, aliases including dashes (also used internally for slugs in place of colons), and aliases beginning with numeric digits (being confused with id portion of a slug).
- The parser changes include: looking up aliases in the database and replacing with ids, skipping the conversion of dashes to colons for cases where it's clearly not a slug, performing more rigorous (regex) test to discern alias beginning with numeric digit from an id.
- These changes have been rigorously tested on stage.plantingscience.org.
- These changes have already been patched on plantingscience.org production site.
- **This PR supersedes PR 1607,** which is still pending, and will be withdrawn. 


**Thanks!**
