### PR TITLE
[VHUB-25] propagate group alias (group_cn) to author step in creating new group…

### DIFF
--- a/core/components/com_resources/site/views/steps/tmpl/attach.php
+++ b/core/components/com_resources/site/views/steps/tmpl/attach.php
@@ -28,11 +28,13 @@ $this->css('create.css')
 
 <section class="main section">
 	<?php
+		$this->group_cn = Request::getString('group','');
 		$this->view('steps')
 		     ->set('option', $this->option)
 		     ->set('step', $this->step)
 		     ->set('steps', $this->steps)
 		     ->set('id', $this->id)
+			 ->set('group_cn', $this->group_cn)
 		     ->set('resource', $this->row)
 		     ->set('progress', $this->progress)
 		     ->display();
@@ -40,7 +42,7 @@ $this->css('create.css')
 <?php if ($this->getError()) { ?>
 	<p class="warning"><?php echo $this->getError(); ?></p>
 <?php } ?>
-	<form action="<?php echo Route::url('index.php?option=' . $this->option . '&task=draft&step=' . $this->next_step . '&id=' . $this->id); ?>" method="post" id="hubForm">
+	<form action="<?php echo Route::url('index.php?option=' . $this->option . '&task=draft&step=' . $this->next_step . '&group=' . $this->group_cn . '&id=' . $this->id); ?>" method="post" id="hubForm">
 		<div class="explaination">
 			<h4><?php echo Lang::txt('COM_CONTRIBUTE_ATTACH_WHAT_ARE_ATTACHMENTS'); ?></h4>
 			<p><?php echo Lang::txt('COM_CONTRIBUTE_ATTACH_EXPLANATION'); ?></p>

--- a/core/components/com_resources/site/views/steps/tmpl/compose.php
+++ b/core/components/com_resources/site/views/steps/tmpl/compose.php
@@ -47,11 +47,13 @@ $this->css('create.css')
 
 <section class="main section">
 	<?php
+		$this->group_cn = Request::getString('group','');
 		$this->view('steps')
 		     ->set('option', $this->option)
 		     ->set('step', $this->step)
 		     ->set('steps', $this->steps)
 		     ->set('id', $this->id)
+			 ->set('group_cn', $this->group_cn)
 		     ->set('resource', $this->row)
 		     ->set('progress', $this->progress)
 		     ->display();
@@ -61,7 +63,7 @@ $this->css('create.css')
 		<p class="warning"><?php echo implode('<br />', $this->getErrors()); ?></p>
 	<?php } ?>
 
-	<form action="<?php echo Route::url('index.php?option=' . $this->option . '&task=draft&step=' . $this->next_step . '&id=' . $this->id); ?>" method="post" id="hubForm" accept-charset="utf-8">
+	<form action="<?php echo Route::url('index.php?option=' . $this->option . '&task=draft&step=' . $this->next_step . '&group=' . $this->group_cn . '&id=' . $this->id); ?>" method="post" id="hubForm" accept-charset="utf-8">
 		<div class="explaination">
 			<p><?php echo Lang::txt('COM_CONTRIBUTE_COMPOSE_EXPLANATION'); ?></p>
 

--- a/core/components/com_resources/site/views/steps/tmpl/steps.php
+++ b/core/components/com_resources/site/views/steps/tmpl/steps.php
@@ -36,6 +36,9 @@ if ($this->resource->get('id'))
 	$authors =  $this->resource->authors()->total();
 	$tags = count($this->resource->tags());
 }
+
+$this->group_cn = (isset($this->group_cn) ? $this->group_cn : Request::getString('group',''));
+
 ?>
 <div class="meta-container">
 	<table class="meta">
@@ -109,7 +112,7 @@ if ($this->resource->get('id'))
 		}
 		elseif ($this->progress[$this->steps[$i]] == 1 || $this->step > $i)
 		{
-			$html .= '<a href="'. Route::url('index.php?option='.$this->option.'&task=draft&step='.$i.'&id='.$this->id) .'">'.Lang::txt('COM_CONTRIBUTE_STEP_'.strtoupper($this->steps[$i])).'</a>';
+			$html .= '<a href="'. Route::url('index.php?option='.$this->option.'&task=draft&step='.$i.'&id='.$this->id.'&group='.$this->group_cn) .'">'.Lang::txt('COM_CONTRIBUTE_STEP_'.strtoupper($this->steps[$i])).'</a>';
 		}
 		else
 		{


### PR DESCRIPTION

- JIRA task: https://sdx-sdsc.atlassian.net/browse/VHUB-25
- Support ticket: https://theghub.org/support/ticket/2739
- Summary of issue: The group owner for a new group resource does not default to current group
- Summary of fix: The group alias (group_cn) is now propagated as a query parameter from step-to-step (compose through authors) to help set the default (selected) group in the drop down menu of groups in which the current user belongs
- Summary of testing: Tested on personal AWS development machine by creating a new group resource.  Current group is now selected by default where it was not before.  
- Hotfix required?  Possibly, if vhub/ghub (theghub.org) wishes to have it implemented before next rollout


