### PR TITLE
fix misspelling of data-section-registration

### DIFF
--- a/core/plugins/members/account/views/overview/tmpl/default.php
+++ b/core/plugins/members/account/views/overview/tmpl/default.php
@@ -102,7 +102,7 @@ $this->css()
 		<div class="clear"></div>
 		<div class="sub-section-content">
 		<?php if ($this->passtype == 'changelocal' || $this->passtype == 'changehub') { ?>
-			<form action="index.php" method="post" data-section-registation="password" data-section-profile="password">
+			<form action="index.php" method="post" data-section-registration="password" data-section-profile="password">
 				<?php if (is_array($this->passinfo)) { ?>
 					<p class="<?php echo $this->passinfo['message_style']; ?>">
 						<?php echo Lang::txt('PLG_MEMBERS_ACCOUNT_PASSWORD_EXPIRATION_EXPLANATION', $this->passinfo['diff'], $this->passinfo['max']); ?>

--- a/core/plugins/members/profile/assets/js/profile.js
+++ b/core/plugins/members/profile/assets/js/profile.js
@@ -158,7 +158,7 @@ HUB.Members.Profile = {
 
 		//get the needed vars
 		var form = submit_button.parents("form"),
-			registration_field = form.attr("data-section-registation"),
+			registration_field = form.attr("data-section-registration"),
 			profile_field = form.attr("data-section-profile");
 
 		//disable submit button and show saving graphic

--- a/core/plugins/members/profile/views/edit/tmpl/default.php
+++ b/core/plugins/members/profile/views/edit/tmpl/default.php
@@ -11,7 +11,7 @@ if ($this->isUser) : ?>
 			<p class="notice warning"><?php echo Lang::txt('PLG_MEMBERS_PROFILE_READONLY', $this->title); ?></p>
 		<?php else : ?>
 			<div class="section-edit-content">
-				<form action="<?php echo Route::url('index.php?option=com_members'); ?>" method="post" data-section-registation="<?php echo $this->registration_field; ?>" data-section-profile="<?php echo $this->profile_field; ?>">
+				<form action="<?php echo Route::url('index.php?option=com_members'); ?>" method="post" data-section-registration="<?php echo $this->registration_field; ?>" data-section-profile="<?php echo $this->profile_field; ?>">
 					<span class="section-edit-errors"></span>
 
 					<div class="input-wrap">

--- a/core/plugins/members/profile/views/index/tmpl/default.php
+++ b/core/plugins/members/profile/views/index/tmpl/default.php
@@ -367,7 +367,7 @@ $legacy = array(
 						<br class="clear" />
 						<div class="section-edit-container">
 							<div class="section-edit-content">
-								<form action="<?php echo Route::url('index.php?option=com_members'); ?>" method="post" data-section-registation="password" data-section-profile="password">
+								<form action="<?php echo Route::url('index.php?option=com_members'); ?>" method="post" data-section-registration="password" data-section-profile="password">
 									<span class="section-edit-errors"></span>
 									<?php if ($passtype == 'changelocal' || $passtype == 'changehub'): ?>
 										<div class="input-wrap">


### PR DESCRIPTION
- JIRA Task: https://sdx-sdsc.atlassian.net/browse/PHARMA-30
- Summary of Issue: Editing email address in profile was not sending email confirmation or responding properly to a re-sent confirmation. 
- Summary of Fix: There were 4 occurrences of the form attribute data-section-registration being misspelled as data-section-registation, including the JavaScript handler of the form action.  Correcting the spelling appears to have fixed the problem.
- Summary of Testing:  tested on personal AWS dev machine by creating new account and changing its email address successfully
- Hotfix Required?  This affects all hubs, but there is an admin workaround until next rollout

