### PR TITLE
Add reregister() function

### DIFF
--- a/core/libraries/Hubzero/Session/Manager.php
+++ b/core/libraries/Hubzero/Session/Manager.php
@@ -582,7 +582,17 @@ class Manager extends Obj
 
 		return true;
 	}
-
+	
+	/**
+	 * Register session handlers
+	 *
+	 * @return  void
+	 */
+	public function reregister()
+	{
+		$this->store->register();
+	}
+	
 	/**
 	 * Restart an expired or locked session.
 	 *


### PR DESCRIPTION
## Summary

Enable registration of session handlers for use with USP SSO authentication plugin. A single function is added, called reregister().

## Motivation

This change is needed for the plugin development described in this card: https://sdx-sdsc.atlassian.net/browse/USP-54

## Testing

This code was used on a development instance where the plugin was written. Both proof of concept and acceptance testing were performed on the instance: HUBzero developers and USP staff verified that the USP SSO plugin functions properly.

## Hotfix

This hotfix should be included on the USP production instance in order to make rollout of SSO possible there. See https://sdx-sdsc.atlassian.net/browse/USP-69

## PR checklist

[x] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
[x] Include a brief summary of the issue in your own words
[x] Include a brief summary of the fix/changed code
[x] Include a brief summary of your testing. What did you specifically do to investigate that this change has the correct results?
[x] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
[] Double check someone is assigned to review the ticket