### PR TITLE
Honor admin settings in user profile Fullname and Email fields

### DIFF
--- a/core/plugins/members/profile/views/index/tmpl/default.php
+++ b/core/plugins/members/profile/views/index/tmpl/default.php
@@ -52,6 +52,9 @@ require_once Component::path('com_members') . '/models/incremental/awards.php';
 require_once Component::path('com_members') . '/models/incremental/groups.php';
 require_once Component::path('com_members') . '/models/incremental/options.php';
 
+use Components\Members\Models\Profile\Field;
+
+
 $uid = (int)$this->profile->get('id');
 $incrOpts = new Components\Members\Models\Incremental\Options;
 $isIncrementalEnabled = $incrOpts->isEnabled($uid);
@@ -281,7 +284,7 @@ $legacy = array(
 	<?php endif; ?>
 
 	<ul id="profile">
-		<?php if ($isUser) : ?>
+		<?php if ($isUser && (Field::state('registrationFullname', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_HIDDEN)) : ?>
 			<li class="profile-name section hidden">
 				<div class="section-content">
 					<div class="key"><?php echo Lang::txt('PLG_MEMBERS_PROFILE_NAME'); ?></div>
@@ -292,10 +295,12 @@ $legacy = array(
 						$name .= '<label class="side-by-side three">' . Lang::txt('PLG_MEMBERS_PROFILE_MIDDLE_NAME') . ' <input type="text" name="name[middle]" id="middle-name" class="input-text" value="'.$this->escape($this->profile->get('middleName')).'" /></label>';
 						$name .= '<label class="side-by-side three no-padding-right">' . Lang::txt('PLG_MEMBERS_PROFILE_LAST_NAME') . ' <input type="text" name="name[last]" id="last-name" class="input-text" value="'.$this->escape($this->profile->get('surname')).'" /></label>';
 
+						if (Field::state('registrationFullname', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_READONLY)
 						$this->view('default', 'edit')
 						     ->set('registration_field', 'name')
 						     ->set('profile_field', 'name')
 						     ->set('registration', $this->profile->get('name'))
+						     ->set('field_state', Field::state('registrationFullname', 'RRRR', 'edit'))
 						     ->set('title', Lang::txt('PLG_MEMBERS_PROFILE_NAME'))
 						     ->set('profile', $this->profile)
 						     ->set('isUser', $isUser)
@@ -304,15 +309,17 @@ $legacy = array(
 						     ->display();
 					?>
 				</div>
+				<?php if ($isUser && Field::state('registrationFullname', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_READONLY): ?>
 				<div class="section-edit">
 					<a class="edit-profile-section" href="#">
 						<?php echo Lang::txt('PLG_MEMBERS_PROFILE_EDIT'); ?>
 					</a>
 				</div>
+				<?php endif; ?>
 			</li>
 		<?php endif; ?>
 
-		<?php if ($isUser) : ?>
+		<?php if ($isUser && (Field::state('registrationUsername', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_HIDDEN)) : ?>
 			<li class="profile-name section hidden">
 				<div class="section-content">
 					<div class="key"><?php echo Lang::txt('PLG_MEMBERS_PROFILE_USERNAME'); ?></div>
@@ -322,7 +329,7 @@ $legacy = array(
 			</li>
 		<?php endif; ?>
 
-		<?php if ($isUser) : ?>
+		<?php if ($isUser && (Field::state('registrationPassword', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_HIDDEN)) : ?>
 			<?php
 			// Determine what type of password change the user needs
 			$hzup = \Hubzero\User\Password::getInstance($this->profile->get('id'));
@@ -367,7 +374,7 @@ $legacy = array(
 						<br class="clear" />
 						<div class="section-edit-container">
 							<div class="section-edit-content">
-								<form action="<?php echo Route::url('index.php?option=com_members'); ?>" method="post" data-section-registration="password" data-section-profile="password">
+								<form action="<?php echo Route::url('index.php?option=com_members'); ?>" method="post" data-section-registation="password" data-section-profile="password">
 									<span class="section-edit-errors"></span>
 									<?php if ($passtype == 'changelocal' || $passtype == 'changehub'): ?>
 										<div class="input-wrap">
@@ -434,7 +441,7 @@ $legacy = array(
 			<?php endif; ?>
 		<?php endif; ?>
 
-		<?php if ($this->profile->get('email')) : ?>
+		<?php if ($this->profile->get('email') && (Field::state('registrationEmail', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_HIDDEN)) : ?>
 			<?php if ($this->params->get('access_email', 2) == 0
 					|| ($this->params->get('access_email', 2) == 1 && $loggedin)
 					|| ($this->params->get('access_email', 2) == 2 && $isUser)
@@ -468,7 +475,7 @@ $legacy = array(
 								<?php echo \Components\Members\Helpers\Html::obfuscate($this->profile->get('email')); ?>
 							</a>
 						</div>
-						<?php if ($isUser) : ?>
+						<?php if ($isUser && Field::state('registrationEmail', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_READONLY): ?>
 							<br class="clear" />
 							<input type="hidden" class="input-text" name="email" id="email" value="<?php echo $this->escape($this->profile->get('email')); ?>" />
 							<?php
@@ -487,6 +494,7 @@ $legacy = array(
 								     ->set('registration_field', 'email')
 								     ->set('profile_field', 'email')
 								     ->set('registration', 1)
+								     ->set('field_state', Field::state('registrationEmail', 'RRRR', 'edit'))
 								     ->set('title', Lang::txt('PLG_MEMBERS_PROFILE_EMAIL'))
 								     ->set('profile', $this->profile)
 								     ->set('isUser', $isUser)
@@ -498,7 +506,7 @@ $legacy = array(
 							?>
 						<?php endif; ?>
 					</div>
-					<?php if ($isUser) : ?>
+					<?php if ($isUser && Field::state('registrationEmail', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_READONLY): ?>
 						<div class="section-edit">
 							<a class="edit-profile-section" href="#">
 								<?php echo Lang::txt('PLG_MEMBERS_PROFILE_EDIT'); ?>
@@ -890,6 +898,7 @@ $legacy = array(
 				}
 				$select .= '</select>' . "\n";
 			?>
+			<?php if ($isUser && (Field::state('registrationOptIn', 'RRRR', 'edit') != Components\Members\Models\Profile\Field::STATE_HIDDEN)) : ?>
 			<li class="profile-optin section <?php echo $cls; ?>">
 				<div class="section-content">
 					<div class="key"><?php echo Lang::txt('PLG_MEMBERS_PROFILE_EMAILUPDATES'); ?></div>
@@ -920,7 +929,7 @@ $legacy = array(
 							{
 								$access  = '<label>' . Lang::txt('PLG_MEMBERS_PROFILE_PRIVACY')  . '</label>';
 								$access .= Lang::txt('PLG_MEMBERS_PROFILE_ACCESS_MUST_BE_PUBLIC');
-								$access .= '<input type="hidden" name="access[sendEmail]" value="' . $this->params->get('access_optin') . '" />';
+								$access .= '<input type="hidden" name="sendEmail" value="' . $this->params->get('access_optin') . '" />';
 							}
 							else
 							{
@@ -948,6 +957,7 @@ $legacy = array(
 					</div>
 				<?php endif; ?>
 			</li>
+			<?php endif; ?>
 		<?php endif; ?>
 	</ul>
 </div><!-- /#profile-page-content -->


### PR DESCRIPTION
## Issue summary

Though admin settings are available for controlling end-user access to their profile fields for editing, some of these settings do not work as advertised. (see hub.org/administrator -> Members -> Registration)

Edit access to several end user profile fields can be controlled, at several times. 

Times: 
- account creation
- proxy account creation
- user update on next login
- profile editing

Control settings:
- Required
- Optional
- Hidden
- Read-only

In theory, the admin could disable editing of the user Email by setting it to Required/Required/Readonly/Readonly. However, in the user profile edit interface, a working Edit link was still displayed (and usable). This fix addresses this problem for the Email and Fullname fields.

## This fix

Attempts to set the end-user Email address and Fullname fields as Read Only were unsuccessful. This fix enables:
- administrator can disable editability of Email and Fullname fields in user profile
- Edit link in the UI is hidden if editing is disabled

## Testing

In testing, Admin user can set/unset required/readonly/hidden for these fields and the end user's profile editor enables editing, disables editing, hides field accordingly.

It is likely that some of these other profile fields do not behave ideally. This fix and testing of this fix have been focused on Email and Fullname fields.

Testing was performed on the USP AWS dev instance.

See the very general Jira ticket, USP-57.

This fix by @nkissebe and @jsperhac 

