### PR TITLE
[USP-76] New SSO user account should not be prompted for email address

### DIFF
--- a/core/components/com_members/site/controllers/register.php
+++ b/core/components/com_members/site/controllers/register.php
@@ -367,6 +367,19 @@ class Register extends SiteController
 					unset($profile[$key . '_other']);
 				}
 			}
+
+			$emailState = Field::state('registrationEmail', 'RRRR', $this->_task);
+
+			if ($emailState == \Components\Members\Models\Profile\Field::STATE_HIDDEN)
+			{
+				$username = User::get('username');
+			
+				if ($username[0] == '-' && is_object($hzal))
+				{
+					$xregistration->set('email', $hzal->email);
+				}
+			}
+
 		}
 		else
 		{

--- a/core/components/com_members/site/views/register/tmpl/default.php
+++ b/core/components/com_members/site/views/register/tmpl/default.php
@@ -273,7 +273,7 @@ if (!$form_redirect && !in_array($current, array('/register/update', '/members/u
 			<div class="clear"></div>
 		<?php } ?>
 
-		<?php if ($this->registrationFullname != Field::STATE_HIDDEN) { ?>
+		<?php if ($this->registrationFullname != Field::STATE_HIDDEN || $this->registrationEmail != Field::STATE_HIDDEN) { ?>
 			<div class="explaination">
 				<?php if ($this->task == 'create') { ?>
 					<p><?php echo Lang::txt('COM_MEMBERS_REGISTER_ACTIVATION_EMAIL_HINT'); ?></p>

--- a/core/components/com_resources/helpers/html.php
+++ b/core/components/com_resources/helpers/html.php
@@ -919,7 +919,8 @@ class Html
 
 						if (substr($firstChild->path, 0, 16) == 'https://doi.org/')
 						{
-							$mesg  = substr($firstChild->path,16);
+							$mesg  = Lang::txt('COM_RESOURCES_VIEW_RESOURCE');
+							//$mesg  = substr($firstChild->path,16);
 						}
 						else if (substr($firstChild->path, 0, 7) == 'http://'
 						 || substr($firstChild->path, 0, 8) == 'https://'

--- a/core/components/com_resources/helpers/html.php
+++ b/core/components/com_resources/helpers/html.php
@@ -919,8 +919,7 @@ class Html
 
 						if (substr($firstChild->path, 0, 16) == 'https://doi.org/')
 						{
-							$mesg  = Lang::txt('COM_RESOURCES_VIEW_RESOURCE');
-							//$mesg  = substr($firstChild->path,16);
+							$mesg  = substr($firstChild->path,16);
 						}
 						else if (substr($firstChild->path, 0, 7) == 'http://'
 						 || substr($firstChild->path, 0, 8) == 'https://'


### PR DESCRIPTION
## Summary

Signing on to the USP test IdP runs properly and redirects user to the USP Hub.

However, if the user declined to link their SSO account to an existing local Hub account, they were prompted for a valid email address. We have “update on next” set 'read only', so no email address is displayed or editable. User is stuck at members/update and unable to complete registration.

Registration should accept the USP provided email address for the new account.

Fix performed by @nkissebe 

Please see Jira card here: https://sdx-sdsc.atlassian.net/browse/USP-76

## Testing

Parameters are:

- USP prod Hub (cmkc.usp.org)
- USP test IdP (identity provider), usp-logintest-sp

Three cases while signing in as a USP SSO user are now working as expected:

1.    as USP SSO user zzz:
    no, have never logged in before
    if username collision, must change username
    success, account is marked as approved.
    This works correctly.

1.    as USP SSO user yyy:
    yes, have logged in before
    decline to link accounts
    if username collision, must change username
    success, account is automatically approved.
    This works correctly.

1.    as USP SSO user xxx:
    yes, have logged in before
    attempt to link accounts
    prompted to sign in as existing Hub account, first
    on successful sign-in, SSO and local accounts are linked
    can view specifics in user's profile page, password detail