### PR TITLE
Issue: Series Resource incorrectly displaying 'workshop' button

### DIFF
--- a/core/components/com_resources/helpers/html.php
+++ b/core/components/com_resources/helpers/html.php
@@ -818,23 +818,27 @@ class Html
 					$pop   = '<p class="warning">' . Lang::txt('COM_RESOURCES_TOOL_VERSION_UNPUBLISHED') . '</p>';
 					$html .= self::primaryButton('link_disabled', '', Lang::txt('COM_RESOURCES_LAUNCH_TOOL'), '', '', '', 1, $pop);
 				}
-			break;
+				break;
 
 			case 4:
 				// write primary button and downloads for a Learning Module
 				$html .= self::primaryButton('', Route::url($resource->link() . '&task=play'), 'Start learning module');
-			break;
+				break;
 
 			case 6:
 				$mesg  = Lang::txt('COM_RESOURCES_VIEW') . ' Course Lectures';
 				$html .= self::primaryButton('download', Route::url($resource->link()) . '#courselecture', $mesg, '', $mesg, '');
+				break;
+
 			case 31:
 				$mesg  = Lang::txt('COM_RESOURCES_VIEW') . ' Series';
 				$html .= self::primaryButton('download', Route::url($resource->link()) . '#series', $mesg, '', $mesg, '');
+				break;
+
 			case 2:
 				$mesg  = Lang::txt('COM_RESOURCES_VIEW') . ' Workshop ';
 				$html .= self::primaryButton('download', Route::url($resource->link()) . '#workshop', $mesg, '', $mesg, '');
-			break;
+				break;
 
 			default:
 				$firstChild->title = str_replace('"', '&quot;', $firstChild->title);


### PR DESCRIPTION
# Resources
- https://sdx-sdsc.atlassian.net/browse/NCN-283
- https://nanohub.org/support/ticket/429421

# Issue Summary
On a resource page for a series, the workshop button is showing up. 

# Fix Summary
In the creation of the primary buttons, there was a switch statement that was written improperly. Each case didn't have a break. Fix was adding a break to each case. 

# Testing
- Currently fixed on dev.nanohub, was showing up - https://dev.nanohub.org/resources/20233

# Rollout
- Push this to stage for client testing, then production

# Review
- @nkissebe and @dbenham 
