### PR TITLE
Fix up Issue Adding Specific Team Members in Group Projects

### DIFF
--- a/core/components/com_projects/site/controllers/setup.php
+++ b/core/components/com_projects/site/controllers/setup.php
@@ -275,7 +275,14 @@ class Setup extends Base
 			if ($this->model->exists())
 			{
 				$objO = $this->model->table('Owner');
-				$objO->reconcileGroups($this->model->get('id'), $this->model->get('owned_by_group'), $this->model->get('sync_group'));
+
+				// Based on the sync group radio button. 
+				// If user select specific members radio, the save should pick up the request.
+				$syncGroupFromDb = $this->model->get('sync_group');
+				$syncGroupPostForm = Request::getInt('sync_group', 0, 'post');				
+				$syncGroup = (isset($syncGroupPostForm)) ? $syncGroupPostForm : $syncGroupFromDb;
+
+				$objO->reconcileGroups($this->model->get('id'), $this->model->get('owned_by_group'), $syncGroup);
 			}
 			else
 			{

--- a/core/plugins/projects/team/assets/js/team.js
+++ b/core/plugins/projects/team/assets/js/team.js
@@ -308,6 +308,26 @@ HUB.ProjectTeam = {
 	}
 }
 
+// Sync Groups Radio Buttons. Toggling the sync/custom button between the 2 radio button. 
+$(document).ready(function () {
+	const membershipSyncRadio = $('#membership_sync');
+	const membershipCustomRadio = $('#membership_custom');
+	const syncRoleSelector = $('#sync-role-selector')
+
+	membershipSyncRadio.click(function() {
+		membershipSyncRadio.closest('div[class^="input-wrap"]').addClass('active');
+		membershipCustomRadio.closest('div[class^="input-wrap"]').removeClass('active');
+		syncRoleSelector.show()
+	});
+
+	membershipCustomRadio.click(function() {
+		membershipCustomRadio.closest('div[class^="input-wrap"]').addClass('active');
+		membershipSyncRadio.closest('div[class^="input-wrap"]').removeClass('active');
+		syncRoleSelector.hide()
+	});
+});
+
+
 jQuery(document).ready(function($){
 	HUB.ProjectTeam.initialize();
 


### PR DESCRIPTION
# Reference
- https://sdx-sdsc.atlassian.net/browse/NCN-319
- https://nanohub.org/support/ticket/431712

# Summary of the Issue
- Upon a NanoHub user creating a project within a group, after selecting 'specific membership' radio button in the 'group members' box, adding one individual user will actually bring in ALL group members into the project. This is an issue of not considering the request sync_group value upon submission of form, but uses whatever sync_group value is in the database which by default is 1. 
 
# Summary of the Development
- Talking to Amy, got more insight into the issue
- The javascript in toggling between the two radio options of 'sync membership' vs 'specific membership' was broken, it didn't toggle at all. 
- Had to find where the logic saved to the database with the sync_group. Saw that with a database sync_group value of 1, there was an insert of all members, ignoring what the user selected as the option they want. 

# Testing Strategy
- Utilized dev.nanohub.org to do testing. 
- Using one project, utilized SQL resets to continue working with that one project. 

Sql statements used to reset the project:
 - select * from jos_projects where created >= '2023-07-01';
 - select * from jos_projects where id = 429;
 - select * from jos_project_owners where projectid = 429;
 - update jos_projects set sync_group = 1 where id = 429;
 - update jos_project_owners set status = 2 where userid != 261949 and projectid = 429;
 - delete from jos_project_owners where projectid = 429 and status = 2;

# How to Rollout
- Already pushed out to dev, should push to stage for testing and then production. Will need help from @dbenham 

# Assigned?
@dbenham @nkissebe 
