### PR TITLE
Correct spelling of HTTP_REFERER variable

### DIFF
--- a/core/components/com_courses/models/asset.php
+++ b/core/components/com_courses/models/asset.php
@@ -310,7 +310,7 @@ class Asset extends Base
 		$view->viewed_by         = $member->get('id');
 		$view->ip                = (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '');
 		$view->url               = (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '');
-		$view->referrer          = (isset($_SERVER['HTTP_REFERRER']) ? $_SERVER['HTTP_REFERRER'] : '');
+		$view->referrer          = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '');
 		$view->user_agent_string = (isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '');
 		$view->session_id        = App::get('session')->getId();
 		if (!$view->store())


### PR DESCRIPTION
## Summary 

No value has been populated in jos_courses_asset_views.referrer column since 2013, presumably because no variable named HTTP_REFERRER is set (whereas HTTP_REFERER may be).

This small fix corrects the spelling of the variable so that this information can be populated in the Hub database. (It's extra amusing since the variable name itself is famously misspelled!)

## Motivation

See JIRA NCN-467 (https://sdx-sdsc.atlassian.net/browse/NCN-467). Nanohub is working to gather information about student use of courses. Goals are to collect and present metrics on course usage; market courses to appropriate markets; and recommend potential next courses to users. The 'referrer' column in jos_courses_asset_views is needed to provide input data for the recommender system. 

While HTTP_REFERER may be empty for various reasons, (see https://stackoverflow.com/questions/6880659/in-what-cases-will-http-referer-be-empty) it will certainly be empty if misspelled.

## Testing

Admittedly no testing has been done. The variable name has been changed in place on Nanohub, since this is a very safe fix. It is self-contained--the code checks for the var (with correct spelling) being set, and if so, uses its value to set the database column contents.

Live patching Nanohub with this fix would be appreciated as we would like this change to 'stick' for testing/verification.
