### PR TITLE
fix progress check in author step of creating resource

### DIFF
--- a/core/components/com_resources/site/controllers/create.php
+++ b/core/components/com_resources/site/controllers/create.php
@@ -1720,7 +1720,7 @@ class Create extends SiteController
 		if ($id)
 		{
 			$resource = Entry::oneOrNew($id);
-			$total = $resource->authors()->total();
+			$contributors = $resource->authors()->total();
 		}
 
 		return $contributors;


### PR DESCRIPTION

- **JIRA Task**: VHUB-24
- **Support Ticket:** theghub.org #2738
- **Summary of issue**:   Author step in creating a new resource is not being set to completed after saving.
- **Summary of fix**: Changed $total to $contributors (which is what is being returned) in step_authors_check() of core/components/com_resources/site/controllers/create.php.
- **Summary of testing**: Tested on personal dev machine by creating new resource
- **Hotfix needed?**  Can wait for 2.2.26 rollout

