### PR TITLE
Fix de id order

### DIFF
--- a/core/components/com_members/admin/controllers/members.php
+++ b/core/components/com_members/admin/controllers/members.php
@@ -1038,9 +1038,6 @@ class Members extends AdminController
 			$anonUserNameSpace = "AnonFirst Middle Last" . $id;
 
 			// Can't rely on any order the plugins run in. Setting the deletion profile key in controller before calling the plugins 
-			$delete_UserProfile_Query = "DELETE from `#__user_profiles` where user_id =" . $db->quote($id) . " AND 'profile_key' !='edulevel' AND profile_key !='gender' AND profile_key !='hispanic' AND profile_key !='organization' AND profile_key !='orgtype' AND profile_key !='race' AND profile_key !='reason'";
-			$this->runUpdateOrDeleteQuery($delete_UserProfile_Query);
-
 			$insert_UserProfileWithStatus_Query = "INSERT INTO `#__user_profiles` (`user_id`, `profile_key`, `profile_value`) values (?, 'deletion', 'marked')";
 			$this->runInsertQuery($insert_UserProfileWithStatus_Query, array($id));
 
@@ -1049,10 +1046,8 @@ class Members extends AdminController
 
 			if ($result) {
 				// ----------- UPDATES TO THE PROFILES AND USERS TABLE, and User Profiles Table  ----------
-				// Unset the keys and updates the final user records until after all plugins run
-				$update_XProfilesById_Query = "UPDATE `#__xprofiles` set name=" . $db->quote($anonUserNameSpace) . ", username=" . $db->quote($anonUserName) . ", userPassword=" . $db->quote($anonPassword) . ", url='', phone='', regHost='', regIP='', givenName=" . $db->quote($anonUserName) . ", middleName='', surname='anonSurName', picture='', public=0, params='', note='', orcid='', homeDirectory='/home/anonymous', email=" . $db->quote($anonUserName . "@example.com") . " where uidNumber =" . $db->quote($userId);
-				$this->runUpdateOrDeleteQuery($update_XProfilesById_Query);
-
+				// Unset the keys and updates the final user records until after all plugins run. 
+				// If anything fail, jos_users still exist which is enough to re-run deidentification. 
 				$update_UsersById_Query = "UPDATE `#__users` set name=" . $db->quote($anonUserNameSpace) . ", givenName=" . $db->quote($anonUserName) .", middleName='', surname='anonSurName', username=" . $db->quote($anonUserName) . ", password=" .  $db->quote($anonPassword) . ", block='1', registerIP='', params='', homeDirectory='', email=" .  $db->quote($anonUserName . "@example.com") . " where id =" . $db->quote($userId);
 				$this->runUpdateOrDeleteQuery($update_UsersById_Query);
 				

--- a/core/plugins/user/hubzero/hubzero.php
+++ b/core/plugins/user/hubzero/hubzero.php
@@ -511,7 +511,7 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
         }
 
         // ======= Sanitation Queries // deletes, updates, inserts =======
-        // NOTE: moved the deletion profile key SQL statement to controller. 
+        // NOTE: moved the deletion (pre deletes) and updated (post deletes) profile key SQL statement to controller com_members/admin/controllers/members.php
 
         $update_SupportTicketsByEmail_Query = "UPDATE `#__support_tickets` set login='',ip='', email='', hostname='', name='' where email=" . $db->quote($userEmail);
         $this->runUpdateOrDeleteQuery($update_SupportTicketsByEmail_Query);
@@ -643,6 +643,6 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
             system($cmd2, $retval);
         }
 
-		// NOTE: moved the update profile key and user SQL statements to controller.        
+		return true;
     }
 }

--- a/core/plugins/user/hubzero/hubzero.php
+++ b/core/plugins/user/hubzero/hubzero.php
@@ -511,11 +511,7 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
         }
 
         // ======= Sanitation Queries // deletes, updates, inserts =======
-        $delete_UserProfile_Query = "DELETE from `#__user_profiles` where user_id =" . $db->quote($userId) . " AND 'profile_key' !='edulevel' AND profile_key !='gender' AND profile_key !='hispanic' AND profile_key !='organization' AND profile_key !='orgtype' AND profile_key !='race' AND profile_key !='reason'";
-        $this->runUpdateOrDeleteQuery($delete_UserProfile_Query);
-
-        $insert_UserProfileWithStatus_Query = "INSERT INTO `#__user_profiles` (`user_id`, `profile_key`, `profile_value`) values (?, 'deletion', 'marked')";
-        $this->runInsertQuery($insert_UserProfileWithStatus_Query, array($user_id));
+        // NOTE: moved the deletion profile key SQL statement to controller. 
 
         $update_SupportTicketsByEmail_Query = "UPDATE `#__support_tickets` set login='',ip='', email='', hostname='', name='' where email=" . $db->quote($userEmail);
         $this->runUpdateOrDeleteQuery($update_SupportTicketsByEmail_Query);
@@ -647,14 +643,6 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
             system($cmd2, $retval);
         }
 
-        // ----------- UPDATES TO THE PROFILES AND USERS TABLE, and User Profiles Table  ----------
-        $update_XProfilesById_Query = "UPDATE `#__xprofiles` set name=" . $db->quote($anonUserNameSpace) . ", username=" . $db->quote($anonUserName) . ", userPassword=" . $db->quote($anonPassword) . ", url='', phone='', regHost='', regIP='', givenName=" . $db->quote($anonUserName) . ", middleName='', surname='anonSurName', picture='', public=0, params='', note='', orcid='', homeDirectory='/home/anonymous', email=" . $db->quote($anonUserName . "@example.com") . " where uidNumber =" . $db->quote($userId);
-        $this->runUpdateOrDeleteQuery($update_XProfilesById_Query);
-
-        $update_UsersById_Query = "UPDATE `#__users` set name=" . $db->quote($anonUserNameSpace) . ", givenName=" . $db->quote($anonUserName) .", middleName='', surname='anonSurName', username=" . $db->quote($anonUserName) . ", password=" .  $db->quote($anonPassword) . ", block='1', registerIP='', params='', homeDirectory='', email=" .  $db->quote($anonUserName . "@example.com") . " where id =" . $db->quote($userId);
-        $this->runUpdateOrDeleteQuery($update_UsersById_Query);
-
-        $update_UserProfiles_Query = "UPDATE `#__user_profiles` SET profile_value='sanitized' WHERE user_id=" . $db->quote($userId) . " AND profile_key='deletion'";
-        $this->runUpdateOrDeleteQuery($update_UserProfiles_Query);
+		// NOTE: moved the update profile key and user SQL statements to controller.        
     }
 }

--- a/core/plugins/user/hubzero/hubzero.php
+++ b/core/plugins/user/hubzero/hubzero.php
@@ -511,7 +511,9 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
         }
 
         // ======= Sanitation Queries // deletes, updates, inserts =======
-        // NOTE: moved the deletion (pre deletes) and updated (post deletes) profile key SQL statement to controller com_members/admin/controllers/members.php
+        // NOTE: moved the insert (pre deletes) and updated (post deletes) profile key SQL statement to controller com_members/admin/controllers/members.php
+		$delete_UserProfile_Query = "DELETE from `#__user_profiles` where user_id =" . $db->quote($userId) . " AND 'profile_key' !='edulevel' AND profile_key !='gender' AND profile_key !='hispanic' AND profile_key !='organization' AND profile_key !='orgtype' AND profile_key !='race' AND profile_key !='reason'";
+		$this->runUpdateOrDeleteQuery($delete_UserProfile_Query);
 
         $update_SupportTicketsByEmail_Query = "UPDATE `#__support_tickets` set login='',ip='', email='', hostname='', name='' where email=" . $db->quote($userEmail);
         $this->runUpdateOrDeleteQuery($update_SupportTicketsByEmail_Query);
@@ -642,6 +644,9 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
             $cmd2 = "/bin/rm -rf /webdav/home/" . escapeshellarg($userName) . "/.*";
             system($cmd2, $retval);
         }
+
+		$update_XProfilesById_Query = "UPDATE `#__xprofiles` set name=" . $db->quote($anonUserNameSpace) . ", username=" . $db->quote($anonUserName) . ", userPassword=" . $db->quote($anonPassword) . ", url='', phone='', regHost='', regIP='', givenName=" . $db->quote($anonUserName) . ", middleName='', surname='anonSurName', picture='', public=0, params='', note='', orcid='', homeDirectory='/home/anonymous', email=" . $db->quote($anonUserName . "@example.com") . " where uidNumber =" . $db->quote($userId);
+		$this->runUpdateOrDeleteQuery($update_XProfilesById_Query);
 
 		return true;
     }


### PR DESCRIPTION
Can't rely on the order the plugin runs in, so should set the deletion profile key in the controller before calling the plugins, and unset the key after the plugin is ran. Should move the last database updates where we update the field user records until after all plugins run. Should also check plugin returns, shouldn't run the final deletion if any of the plugins fail. 