### PR TITLE
DOI metadats mods

### DIFF
--- a/core/components/com_publications/admin/controllers/items.php
+++ b/core/components/com_publications/admin/controllers/items.php
@@ -821,6 +821,7 @@ class Items extends AdminController
 			// Update DOI if locally issued
 			if (preg_match("/" . $doiService->_configs->shoulder . "/", $this->model->version->doi))
 			{
+				$doiService->set('authors', $authors);
 				$doiService->update($this->model->version->doi, true);
 
 				if ($doiService->getError())
@@ -874,6 +875,7 @@ class Items extends AdminController
 						if ($this->model->version->doi
 							&& preg_match("/" . $doiService->_configs->shoulder . "/", $this->model->version->doi))
 						{
+							$doiService->set('authors', $authors);
 							$doiService->update($this->model->version->doi, true);
 
 							if ($doiService->getError())
@@ -1009,6 +1011,7 @@ class Items extends AdminController
 						if ($this->model->version->doi
 							&& preg_match("/" . $doiService->_configs->shoulder . "/", $this->model->version->doi))
 						{
+							$doiService->set('authors', $authors);
 							$doiService->update($this->model->version->doi, true);
 							
 							$resURL = $doiService->_configs->livesite . DS . 'index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&task=tombstone' . '&id=' . $id . '&v=' . $this->model->version->version_number;

--- a/core/components/com_publications/helpers/tags.php
+++ b/core/components/com_publications/helpers/tags.php
@@ -135,15 +135,29 @@ class Tags extends \Hubzero\Base\Obj
 		}
 		if ($tagger_id != 0)
 		{
-			$where[] = "rt.taggerid=" . $tagger_id;
+			$where[] = "rt.taggerid=" . $this->_db->quote($tagger_id);
 		}
 		if ($strength)
 		{
-			$where[] = "rt.strength=" . $strength;
+			$where[] = "rt.strength=" . $this->_db->quote($strength);
 		}
 
 		$sql .= implode(" AND ", $where) . " ORDER BY t.raw_tag";
 
+		$this->_db->setQuery($sql);
+		return $this->_db->loadObjectList();
+	}
+	
+	/**
+	 * Get all tags of a publication
+	 *
+	 * @param      integer 		$vid		Publication version ID
+	 *
+	 * @return     array for false
+	 */
+	public function getAllTags($vid)
+	{
+		$sql = "SELECT DISTINCT jt.* FROM $this->_tag_tbl AS jt LEFT JOIN $this->_obj_tbl AS jto ON jt.id = jto.tagid WHERE jto.objectid = $this->_db->quote($vid)";
 		$this->_db->setQuery($sql);
 		return $this->_db->loadObjectList();
 	}
@@ -187,7 +201,7 @@ class Tags extends \Hubzero\Base\Obj
 				AND (V.publish_down IS NULL OR V.publish_down = '0000-00-00 00:00:00' OR V.publish_down >= '$now') ";
 		if ($category)
 		{
-			$sql .= "AND r.category=" . $category . " ";
+			$sql .= "AND r.category=" . $this->_db->quote($category) . " ";
 		}
 
 		if (!User::isGuest())
@@ -351,7 +365,8 @@ class Tags extends \Hubzero\Base\Obj
 	public function get_tag_cloud($showsizes=0, $admin=0, $objectid=null)
 	{
 		$cloud = new Cloud($objectid, $this->_tbl);
-		return $cloud->render('html', array('admin' => $admin));
+		return $cloud->render(); //TODO: Check with author as to why admin is aasumed not needed
+		//return $cloud->render('html', array('admin' => $admin));
 	}
 
 	/**
@@ -617,7 +632,7 @@ class Tags extends \Hubzero\Base\Obj
 	public function countTags($id)
 	{
 		$sql = "SELECT COUNT(*) FROM $this->_tag_tbl AS t,
-			$this->_obj_tbl AS rt WHERE rt.objectid=$id
+			$this->_obj_tbl AS rt WHERE rt.objectid=$this->_db->quote($id)
 			AND rt.tbl='$this->_tbl' AND rt.tagid=t.id";
 		$this->_db->setQuery( $sql );
 		return $this->_db->loadResult();
@@ -651,6 +666,40 @@ class Tags extends \Hubzero\Base\Obj
 		$sql .= " ORDER BY t.raw_tag";
 		$this->_db->setQuery( $sql );
 		return $this->_db->loadObjectList();
+	}
+	
+	/**
+	 * Get FOS (Field of Science and Technology) tag according Subject tag id
+	 *
+	 * @param      int $tagid
+	 *
+	 * @return     object array or false
+	 */
+	public function getFOSTag($tagid)
+	{
+		$sql = "SELECT jto.tagid FROM $this->_tag_tbl AS jt LEFT JOIN $this->_obj_tbl AS jto ON jto.objectid = jt.id WHERE jto.tbl =" . '"tags" AND jto.label = "parent" AND jt.id=' . $this->_db->quote($tagid);
+		$this->_db->setQuery($sql);
+		$ids = $this->_db->loadColumn();
+		
+		if ($ids)
+		{
+			$fosTagObjects = [];
+			foreach ($ids as $id)
+			{
+				$sql = "SELECT jt.* FROM $this->_tag_tbl AS jt WHERE jt.id = " . $this->_db->quote($id);
+				$this->_db->setQuery($sql);
+				$fosTagObj = $this->_db->loadObject();
+				
+				if ($fosTagObj)
+				{
+					$fosTagObjects[] = $fosTagObj;
+				}
+			}
+			
+			return !empty($fosTagObjects) ? $fosTagObjects : false;
+		}
+		
+		return false;
 	}
 
 	/**
@@ -694,9 +743,9 @@ class Tags extends \Hubzero\Base\Obj
 		$sql .= "FROM $this->_tag_tbl AS t ";
 		$sql .= "JOIN $this->_obj_tbl AS tj ON t.id=tj.tagid ";
 		$sql .= "WHERE ";
-		$sql .= $picked ? " t.id NOT IN (".$picked.")" : "1=1";
+		$sql .= $picked ? " t.id NOT IN (".$this->_db->quote($picked).")" : "1=1";
 		$sql .= " GROUP BY tagid ";
-		$sql .= " HAVING tcount > ".$tcount;
+		$sql .= " HAVING tcount > ".$this->_db->quote($tcount);
 
 		if (!empty($keywords))
 		{
@@ -704,7 +753,7 @@ class Tags extends \Hubzero\Base\Obj
 			$w = 1;
 			foreach ($keywords as $key)
 			{
-				$sql .= 't.raw_tag LIKE "%'.$key.'%"';
+				$sql .= 't.raw_tag LIKE "%'.$this->_db->escape($key).'%"';
 				$sql .= $w == count($keywords) ? '' : ' OR ';
 				$w++;
 			}

--- a/core/components/com_publications/models/publication.php
+++ b/core/components/com_publications/models/publication.php
@@ -1003,6 +1003,29 @@ class Publication extends Obj
 
 		return $this->_attachments;
 	}
+	
+	/**
+	 * Get publication attachments count
+	 *
+	 * @return  int
+	 */
+	public function attachmentsCount()
+	{
+		if (!$this->exists())
+		{
+			return array();
+		}
+		if (!isset($this->_tblContent))
+		{
+			$this->_tblContent = new Tables\Attachment($this->_db);
+		}
+		if (!isset($this->_attachmentsCount))
+		{
+			$this->_attachmentsCount = $this->_tblContent->getAttachmentsCount ($this->version->id);
+		}
+
+		return $this->_attachmentsCount;
+	}
 
 	/**
 	 * Get publication license
@@ -2380,5 +2403,47 @@ class Publication extends Obj
 		$series = $this->_tblAttachment->getSeries($this->version->id);
 
 		return $series;
+	}
+	
+	/**
+	 * Get tags that belongs to the publication
+	 *
+	 * @return  array or false
+	 */
+	public function getTagsOfPublication()
+	{
+		// Check whether the version exists
+		if (!$this->exists())
+		{
+			return false;
+		}
+
+		include_once dirname(__DIR__)  . DS . 'helpers' . DS . 'tags.php';
+		
+		$tagsObj = new Helpers\Tags($this->_db);
+		
+		return $tagsObj->getAllTags($this->version->id);
+	}
+	
+	/**
+	 * Get FOS (Field of Science and Technology) tag according the Subject tag id
+	 *
+	 * @param   int  $tagid
+	 *
+	 * @return  object array or false
+	 */
+	public function getFOSTag($tagid)
+	{
+		// Check whether the version exists
+		if (!$this->exists())
+		{
+			return false;
+		}
+
+		include_once dirname(__DIR__)  . DS . 'helpers' . DS . 'tags.php';
+		
+		$tagsObj = new Helpers\Tags($this->_db);
+		
+		return $tagsObj->getFOSTag($tagid);
 	}
 }

--- a/core/components/com_publications/tables/attachment.php
+++ b/core/components/com_publications/tables/attachment.php
@@ -398,6 +398,25 @@ class Attachment extends Table
 		$this->_db->setQuery($query);
 		return $count ? $this->_db->loadResult() : $this->_db->loadObjectList();
 	}
+	
+	/**
+	 * Get attachments count
+	 *
+	 * @param   integer  $versionid  pub version id
+	 * @return  int
+	 */
+	public function getAttachmentsCount($versionid)
+	{
+		if ($versionid === null)
+		{
+			$versionid = $this->publication_version_id;
+		}
+		
+		$query = "SELECT COUNT(*) FROM $this->_tbl AS a where a.publication_version_id = " . $this->_db->quote($versionid);
+		$this->_db->setQuery($query);
+		
+		return $this->_db->loadResult();
+	}
 
 	/**
 	 * Delete element attachment

--- a/core/components/com_publications/tables/author.php
+++ b/core/components/com_publications/tables/author.php
@@ -114,7 +114,7 @@ class Author extends Table
 		{
 			return false;
 		}
-		$uids = "'" . implode("','", $uids) . "'";
+		$uids = "'" . implode( "','", $uids) . "'";
 		$query  = "SELECT id FROM $this->_tbl WHERE publication_version_id=" . $this->_db->quote($vid) . " AND id IN (" . $uids . ")";
 		$query .= " AND (role != 'submitter')";
 		$query .= " ORDER BY ordering";
@@ -311,6 +311,12 @@ class Author extends Table
 					$res->middleName = $user->get('middleName');
 					$res->surname = $user->get('surname');
 					$res->orcid = $user->get('orcid');
+				}
+				
+				if ($res->user_id)
+				{
+					$res->organization = $user->get('organization');
+					$res->orgid = $user->get('orgid');
 				}
 			}
 		}


### PR DESCRIPTION
- **JIRA task**: https://sdx-sdsc.atlassian.net/browse/PURR-117
- **PURR core addition**: 0 - DOI metadata mods
- **Summary of Issue**: When reviewing the metadata set that currently PURR datasets have, we find that more elements are necessary to be added to the metadata set, which is going to improve the interoperability of PURR metadata with other infrastructure, scripts, and tools that evaluate level of FAIRness of metadata that PURR provides.
- **Summary of Fix/Changes**: This change provides new data to Datacite from hubzero, data that we already have, but it's data they are providing datacite in a large XML metadata blob.
- **Summary of Testing**:  Testing done by PURR staff on their dev environment.  This will be tested again on PURR production hub by PURR staff.
- **Hotfix needed?** This will be pulled to PURR prod as part of testing and targeted for next CMS release (2.2.27)
