### PR TITLE
Mismatch of author in citation between Citation View and Software Download Citation Tab

### DIFF
--- a/core/components/com_citations/models/citation.php
+++ b/core/components/com_citations/models/citation.php
@@ -549,13 +549,23 @@ class Citation extends Relational implements \Hubzero\Search\Searchable
 	}
 
 	/**
-	 * Defines a one to many relationship with authors
+	 * Defines a one to many relationship with authors for search results
 	 *
 	 * @return  object
 	 */
 	public function relatedAuthors()
 	{
 		return $this->oneToMany('Author', 'cid');
+	}
+
+	/**
+	 * Defines a one to many relationship with authors for resource citations tab
+	 *
+	 * @return  object
+	 */
+	public function relatedAuthorsByCitation()
+	{
+		return $this->oneToMany('Author', 'cid', 'cid');
 	}
 
 	/**
@@ -871,11 +881,14 @@ class Citation extends Relational implements \Hubzero\Search\Searchable
 				{
 					$a = array();
 
+					// This is a string of authors from the cite object
 					$auth = html_entity_decode($this->$k);
 					$auth = (!preg_match('!\S!u', $auth)) ? utf8_encode($auth) : $auth;
 
 					// prefer the use of the relational table
-					$authors = $this->relatedAuthors()
+					// Fix for the citation tab of a resource. 
+					// There were mismatch of author names to a citation, reason being it was using the id to match it with cid in table. 
+					$authors = $this->relatedAuthorsByCitation()
 						->order('ordering', 'asc')
 						->order('id', 'asc')
 						->rows();


### PR DESCRIPTION
# Reference
* https://geodynamics.org/support/ticket/232
* https://sdx-sdsc.atlassian.net/browse/GEOD-83

# Summary of the Issue
* Client GeoDynamics found that different authors were showing in the citation tabs for a resource where the search results of citations of that same scientific journal article showed the right authors. 

# Summary of the Development
* Looking at the SQL statement, with the inner joins of tables 'jos_citations_assoc' and 'jos_citations', the right key should have been given to 'jos_citations_authors' should have been CID - the citation id, and not the table id. With table id of 1445 given, it picked up the related author and used that. But using CID of 1393, it returns nothing for related authors, and will use the string of authors from the citation array object. 
* All was done in production environment on GeoDynamics because the need for real data. 
* Looked at logs, SQL tables and CMS code. 

# Testing Strategy
Manually tested working on production GeoDynamics