### PR TITLE
Admin page for Groups throws error

### DIFF
--- a/core/components/com_groups/admin/controllers/manage.php
+++ b/core/components/com_groups/admin/controllers/manage.php
@@ -292,7 +292,7 @@ class Manage extends AdminController
 		// Check for any missing info
 		if (!$g['cn'])
 		{
-			$this->setError(Lang::txt('COM_GROUPS_ERROR_MISSING_INFORMATION') . ': ' . Lang::txt('COM_GROUPS_ID'));
+			$this->setError(Lang::txt('COM_GROUPS_ERROR_MISSING_INFORMATION') . ': ' . Lang::txt('COM_GROUPS_CN'));
 		}
 		if (!$g['description'])
 		{

--- a/core/components/com_groups/admin/controllers/manage.php
+++ b/core/components/com_groups/admin/controllers/manage.php
@@ -313,7 +313,7 @@ class Manage extends AdminController
 				->setLayout('edit')
 				->set('group', $group)
 				->set('customFields', $customFields)
-				->set('customAnswers', $customFieldForms)
+				->set('customAnswers', $customFieldForm)
 				->display();
 			return;
 		}


### PR DESCRIPTION
## Summary

Error was encountered while generating test data. There is no ticket or Jira card.

A clear misspelling of a variable name (`$customFieldForms` instead of `$customFieldForm`) was resulting in an error being thrown, "Undefined variable: customFieldForms". This error occurred on creating a group on the admin interface, in the specific case when the Group's Alias was left blank.

After the variable name was corrected, it became clear that the UI's error message about the missing Alias could be improved. The message originally referred to a missing "Group ID". The message has been amended to refer to the Alias.

## Testing

Testing this small change was performed on a VirtualBox VM on the developer's workstation. Specificially, the admin page for creating groups was loaded and a new Group created with the Alias left blank. With the fix in place, the appropriate error message was seen, prompting the user for an Alias; before the fix, the page threw an unrecoverable error.

