### PR TITLE
PHP 8.2 backwards compatible fixes

### DIFF
--- a/core/bootstrap/Administrator/Providers/UserServiceProvider.php
+++ b/core/bootstrap/Administrator/Providers/UserServiceProvider.php
@@ -55,14 +55,15 @@ class UserServiceProvider extends ServiceProvider
 
 			User::$pictureResolvers[] = new File($config);
 
-			$resolver = $params->get('picture', '');
-
-			// Build the class name
-			$cls = 'Hubzero\\User\\Picture\\' . ucfirst($resolver);
-
-			if (class_exists($cls))
+			if ($resolver = $params->get('picture', ''))
 			{
-				User::$pictureResolvers[] = new $cls($config);
+				// Build the class name
+				$cls = '\\Hubzero\\User\\Picture\\' . ucfirst($resolver);
+
+				if (class_exists($cls))
+				{
+					User::$pictureResolvers[] = new $cls($config);
+				}
 			}
 		}
 	}

--- a/core/bootstrap/Api/Providers/UserServiceProvider.php
+++ b/core/bootstrap/Api/Providers/UserServiceProvider.php
@@ -55,14 +55,15 @@ class UserServiceProvider extends ServiceProvider
 
 			User::$pictureResolvers[] = new File($config);
 
-			$resolver = $params->get('picture');
-
-			// Build the class name
-			$cls = 'Hubzero\\User\\Picture\\' . ucfirst($resolver);
-
-			if (class_exists($cls))
+			if ($resolver = $params->get('picture', ''))
 			{
-				User::$pictureResolvers[] = new $cls($config);
+				// Build the class name
+				$cls = 'Hubzero\\User\\Picture\\' . ucfirst($resolver);
+
+				if (class_exists($cls))
+				{
+					User::$pictureResolvers[] = new $cls($config);
+				}
 			}
 		}
 	}

--- a/core/bootstrap/Cli/Providers/UserServiceProvider.php
+++ b/core/bootstrap/Cli/Providers/UserServiceProvider.php
@@ -62,14 +62,15 @@ class UserServiceProvider extends ServiceProvider
 
 			User::$pictureResolvers[] = new File($config);
 
-			$resolver = $params->get('picture');
-
-			// Build the class name
-			$cls = 'Hubzero\\User\\Picture\\' . ucfirst($resolver);
-
-			if (class_exists($cls))
+			if ($resolver = $params->get('picture', ''))
 			{
-				User::$pictureResolvers[] = new $cls($config);
+				// Build the class name
+				$cls = 'Hubzero\\User\\Picture\\' . ucfirst($resolver);
+
+				if (class_exists($cls))
+				{
+					User::$pictureResolvers[] = new $cls($config);
+				}
 			}
 		}
 	}

--- a/core/bootstrap/Site/Providers/UserServiceProvider.php
+++ b/core/bootstrap/Site/Providers/UserServiceProvider.php
@@ -61,7 +61,7 @@ class UserServiceProvider extends ServiceProvider
 			User::$pictureResolvers[] = new Namedfile($config);
 
 			// Specified resolver
-			if ($resolver = $params->get('picture'))
+			if ($resolver = $params->get('picture', ''))
 			{
 				$cls = 'Hubzero\\User\\Picture\\' . ucfirst($resolver);
 

--- a/core/components/com_answers/site/views/questions/tmpl/question.php
+++ b/core/components/com_answers/site/views/questions/tmpl/question.php
@@ -256,6 +256,10 @@ if ($this->question->isDeleted() or !$this->question->get('id'))
 						if (!is_object($tag))
 						{
 							$tag = new \Components\Tags\Models\Tag($tag);
+							if (!$tag->get('id'))
+							{
+								continue;
+							}
 						}
 						if (preg_match('/^tool:/i', $tag->get('raw_tag')))
 						{

--- a/core/components/com_citations/helpers/format.php
+++ b/core/components/com_citations/helpers/format.php
@@ -351,6 +351,8 @@ class Format
 					}
 
 					//prepare url
+					$url = $url ?: '';
+
 					if (strstr($url, "\r\n"))
 					{
 						$url = array_filter(array_values(explode("\r\n", $url)));

--- a/core/components/com_citations/models/citation.php
+++ b/core/components/com_citations/models/citation.php
@@ -853,7 +853,7 @@ class Citation extends Relational implements \Hubzero\Search\Searchable
 							$coins_data[] = $this->_coins_keys[$k] . '=' . $jt;
 							break;
 						default:
-							$coins_data[] = $this->_coins_keys[$k] . '=' . $this->$k;
+							$coins_data[] = isset($this->$k) ? $this->_coins_keys[$k] . '=' . $this->$k : '';
 					}
 				}
 
@@ -871,8 +871,12 @@ class Citation extends Relational implements \Hubzero\Search\Searchable
 				{
 					$a = array();
 
-					$auth = html_entity_decode($this->$k);
-					$auth = (!preg_match('!\S!u', $auth)) ? utf8_encode($auth) : $auth;
+					$auth = '';
+					if (isset($this->$k) && $this->$k)
+					{
+						$auth = html_entity_decode($this->$k);
+						$auth = (!preg_match('!\S!u', $auth)) ? utf8_encode($auth) : $auth;
+					}
 
 					// prefer the use of the relational table
 					$authors = $this->relatedAuthors()

--- a/core/components/com_courses/models/iterator.php
+++ b/core/components/com_courses/models/iterator.php
@@ -132,7 +132,7 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Is the current position the first one?
 	 *
-	 * @return     boolean
+	 * @return     bool
 	 */
 	public function isFirst()
 	{
@@ -142,7 +142,7 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Is the current position the last one?
 	 *
-	 * @return     boolean
+	 * @return     bool
 	 */
 	public function isLast()
 	{
@@ -169,7 +169,7 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Return the array count
 	 *
-	 * @return     integer
+	 * @return int
 	 */
 	public function total()
 	{
@@ -179,7 +179,7 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Return the array count
 	 *
-	 * @return     integer
+	 * @return int
 	 */
 
 	#[\ReturnTypeWillChange]
@@ -191,8 +191,10 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Return the first array value
 	 *
-	 * @return     mixed
+	 * @return void
 	 */
+
+	#[\ReturnTypeWillChange]
 	public function first()
 	{
 		$this->rewind();
@@ -201,8 +203,9 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Return the last array value
 	 *
-	 * @return     mixed
+	 * @return  void
 	 */
+	#[\ReturnTypeWillChange]
 	public function last()
 	{
 		$this->_pos = ($this->_total - 1);
@@ -232,8 +235,10 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Set cursor position to previous position and return array value
 	 *
-	 * @return     mixed
+	 * @return void
 	 */
+
+	#[\ReturnTypeWillChange]
 	public function prev()
 	{
 		--$this->_pos;
@@ -242,7 +247,7 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Set cursor position to next position and return array value
 	 *
-	 * @return     mixed
+	 * @return void
 	 */
 
 	#[\ReturnTypeWillChange]
@@ -254,7 +259,7 @@ class Iterator implements \Countable, \Iterator
 	/**
 	 * Check if the current cursor position is valid
 	 *
-	 * @return     mixed
+	 * @return bool
 	 */
 
 	#[\ReturnTypeWillChange]

--- a/core/components/com_events/site/controllers/events.php
+++ b/core/components/com_events/site/controllers/events.php
@@ -58,7 +58,7 @@ class Events extends SiteController
 			Request::setVar('task', $this->config->getCfg('startview', 'month'));
 		}
 
-		$this->_task = Request::getString('task');
+		$this->_task = strtolower(Request::getCmd('task', Request::getWord('layout', '')));
 
 		$this->registerTask('__default', $this->_task);
 		$this->registerTask('register', 'eventregister');
@@ -347,18 +347,20 @@ class Events extends SiteController
 
 		// Output HMTL
 		$this->view->setLayout('year')->setName('browse');
-		$this->view->option = $this->_option;
-		$this->view->title = $this->_title;
-		$this->view->task = $this->_task;
-		$this->view->year = $year;
-		$this->view->month = $month;
-		$this->view->day = $day;
-		$this->view->rows = $rows;
-		$this->view->authorized = $authorized;
-		$this->view->fields = $this->config->getCfg('fields');
-		$this->view->category = $this->category;
-		$this->view->categories = $categories;
-		$this->view->offset = $offset;
+		$this->view->setProperties(array(
+			'option' => $this->_option,
+			'title' => $this->_title,
+			'task' => $this->_task,
+			'year' => $year,
+			'month' => $month,
+			'day' => $day,
+			'rows' => $rows,
+			'authorized' => $authorized,
+			'fields' => $this->config->getCfg('fields'),
+			'category' => $this->category,
+			'categories' => $categories,
+			'offset' => $offset,
+		));
 
 		foreach ($this->getErrors() as $error)
 		{
@@ -423,18 +425,20 @@ class Events extends SiteController
 
 		// Output HTML
 		$this->view->setLayout('month')->setName('browse');
-		$this->view->option = $this->_option;
-		$this->view->title = $this->_title;
-		$this->view->task = $this->_task;
-		$this->view->year = $year;
-		$this->view->month = $month;
-		$this->view->day = $day;
-		$this->view->rows = $rows;
-		$this->view->authorized = $authorized;
-		$this->view->fields = $this->config->getCfg('fields');
-		$this->view->category = $this->category;
-		$this->view->categories = $categories;
-		$this->view->offset = $offset;
+		$this->view->setProperties(array(
+			'option' => $this->_option,
+			'title' => $this->_title,
+			'task' => $this->_task,
+			'year' => $year,
+			'month' => $month,
+			'day' => $day,
+			'rows' => $rows,
+			'authorized' => $authorized,
+			'fields' => $this->config->getCfg('fields'),
+			'category' => $this->category,
+			'categories' => $categories,
+			'offset' => $offset,
+		));
 
 		foreach ($this->getErrors() as $error)
 		{
@@ -467,7 +471,7 @@ class Events extends SiteController
 		$week_start = mktime(0, 0, 0, $month, ($day - $numday), $year);
 
 		$this_date = new EventsDate();
-		$this_date->setDate(strftime("%Y", $week_start), strftime("%m", $week_start), strftime("%d", $week_start));
+		$this_date->setDate(date("Y", $week_start), date("m", $week_start), date("d", $week_start));
 		$this_enddate = clone($this_date);
 		$this_enddate->addDays(+6);
 
@@ -529,21 +533,23 @@ class Events extends SiteController
 
 		// Output HTML;
 		$this->view->setLayout('week')->setName('browse');
-		$this->view->option = $this->_option;
-		$this->view->title = $this->_title;
-		$this->view->task = $this->_task;
-		$this->view->year = $year;
-		$this->view->month = $month;
-		$this->view->day = $day;
-		$this->view->rows = $rows;
-		$this->view->authorized = $authorized;
-		$this->view->fields = $this->config->getCfg('fields');
-		$this->view->category = $this->category;
-		$this->view->categories = $categories;
-		$this->view->offset = $offset;
-		$this->view->startdate = $sdt;
-		$this->view->enddate = $edt;
-		$this->view->week = $week;
+		$this->view->setProperties(array(
+			'option' => $this->_option,
+			'title' => $this->_title,
+			'task' => $this->_task,
+			'year' => $year,
+			'month' => $month,
+			'day' => $day,
+			'rows' => $rows,
+			'authorized' => $authorized,
+			'fields' => $this->config->getCfg('fields'),
+			'category' => $this->category,
+			'categories' => $categories,
+			'offset' => $offset,
+			'startdate' => $sdt,
+			'enddate' => $edt,
+			'week' => $week,
+		));
 
 		foreach ($this->getErrors() as $error)
 		{
@@ -620,18 +626,20 @@ class Events extends SiteController
 
 		// Output HTML
 		$this->view->setLayout('day')->setName('browse');
-		$this->view->option = $this->_option;
-		$this->view->title = $this->_title;
-		$this->view->task = $this->_task;
-		$this->view->year = $year;
-		$this->view->month = $month;
-		$this->view->day = $day;
-		$this->view->rows = $events;
-		$this->view->authorized = $authorized;
-		$this->view->fields = $this->config->getCfg('fields');
-		$this->view->category = $this->category;
-		$this->view->categories = $categories;
-		$this->view->offset = $offset;
+		$this->view->setProperties(array(
+			'option' => $this->_option,
+			'title' => $this->_title,
+			'task' => $this->_task,
+			'year' => $year,
+			'month' => $month,
+			'day' => $day,
+			'rows' => $events,
+			'authorized' => $authorized,
+			'fields' => $this->config->getCfg('fields'),
+			'category' => $this->category,
+			'categories' => $categories,
+			'offset' => $offset,
+		));
 
 		foreach ($this->getErrors() as $error)
 		{
@@ -824,22 +832,24 @@ class Events extends SiteController
 		{
 			$this->view->setLayout('modal');
 		}
-		$this->view->option = $this->_option;
-		$this->view->title = Lang::txt(strtoupper($this->_name)) . ': ' . Lang::txt(strtoupper($this->_name) . '_' . strtoupper($this->_task));
-		$this->view->task = $this->_task;
-		$this->view->year = $eyear;
-		$this->view->month = $emonth;
-		$this->view->day = $eday;
-		$this->view->row = $row;
-		$this->view->authorized = $authorized;
-		$this->view->fields = $fields;
-		$this->view->config = $this->config;
-		$this->view->categories = $categories;
-		$this->view->offset = $offset;
-		$this->view->tags = $tags;
-		$this->view->auth = $auth;
-		$this->view->page = $page;
-		$this->view->pages = $pages;
+		$this->view->setProperties(array(
+			'option' => $this->_option,
+			'title' => Lang::txt(strtoupper($this->_name)) . ': ' . Lang::txt(strtoupper($this->_name) . '_' . strtoupper($this->_task)),
+			'task' => $this->_task,
+			'year' => $eyear,
+			'month' => $emonth,
+			'day' => $eday,
+			'row' => $row,
+			'authorized' => $authorized,
+			'fields' => $fields,
+			'config' => $config,
+			'categories' => $categories,
+			'offset' => $offset,
+			'tags' => $tags,
+			'auth' => $auth,
+			'page' => $page,
+			'pages' => $pages,
+		));
 
 		foreach ($this->getErrors() as $error)
 		{
@@ -986,45 +996,48 @@ class Events extends SiteController
 				{
 					// Instantiate a view
 					$this->view->setLayout('default');
-					$this->view->state = 'open';
+					$this->view->set('state', 'open');
 				}
 				else
 				{
 					// Instantiate a view
 					$this->view->setLayout('restricted');
-					$this->view->state = 'restricted';
+					$this->view->set('state', 'restricted');
 				}
 			}
 			else
 			{
 				// Instantiate a view
 				$this->view->setLayout('default');
-				$this->view->state = 'open';
+				$this->view->set('state', 'open');
 			}
 		}
 		else
 		{
 			// Instantiate a view
 			$this->view->setLayout('closed');
-			$this->view->state = 'closed';
+			$this->view->set('state', 'closed');
 		}
 
 		// Output HTML
 		$this->view->setName('register');
-		$this->view->option = $this->_option;
-		$this->view->title = Lang::txt(strtoupper($this->_name)) . ': ' . Lang::txt('EVENTS_REGISTER');
-		$this->view->task = $this->_task;
-		$this->view->year = $year;
-		$this->view->month = $month;
-		$this->view->day = $day;
-		$this->view->offset = $offset;
-		$this->view->event = $event;
-		$this->view->authorized = $auth;
-		$this->view->page = $page;
-		$this->view->pages = $pages;
-		$this->view->register = $register;
-		$this->view->arrival = null;
-		$this->view->departure = null;
+		$this->view->setProperties(array(
+			'option' => $this->_option,
+			'title' => Lang::txt(strtoupper($this->_name)) . ': ' . Lang::txt('EVENTS_REGISTER'),
+			'task' => $this->_task,
+			'year' => $year,
+			'month' => $month,
+			'day' => $day,
+			'offset' => $offset,
+			'event' => $event,
+			'authorized' => $auth,
+			'page' => $page,
+			'pages' => $pages,
+			'register' => $register,
+			'arrival' => null,
+			'departure' => null,
+		));
+
 
 		foreach ($this->getErrors() as $error)
 		{
@@ -1227,21 +1240,23 @@ class Events extends SiteController
 			$this->view->setLayout('default');
 		}
 		$this->view->setName('register');
-		$this->view->state = 'open';
-		$this->view->option = $this->_option;
-		$this->view->title = Lang::txt(strtoupper($this->_name)) . ': ' . Lang::txt('EVENTS_REGISTER');
-		$this->view->task = $this->_task;
-		$this->view->year = $year;
-		$this->view->month = $month;
-		$this->view->day = $day;
-		$this->view->offset = $offset;
-		$this->view->event = $event;
-		$this->view->authorized = $auth;
-		$this->view->page = $page;
-		$this->view->pages = $pages;
-		$this->view->register = $register;
-		$this->view->arrival = $arrival;
-		$this->view->departure = $departure;
+		$this->view->setProperties(array(
+			'state' => 'open',
+			'option' => $this->_option,
+			'title' => Lang::txt(strtoupper($this->_name)) . ': ' . Lang::txt('EVENTS_REGISTER'),
+			'task' => $this->_task,
+			'year' => $year,
+			'month' => $month,
+			'day' => $day,
+			'offset' => $offset,
+			'event' => $event,
+			'authorized' => $auth,
+			'page' => $page,
+			'pages' => $pages,
+			'register' => $register,
+			'arrival' => $arrival,
+			'departure' => $departure,
+		));
 		if ($this->getError())
 		{
 			$this->view->setError($this->getError());
@@ -1479,9 +1494,9 @@ class Events extends SiteController
 				{
 					$offset = $this->offset;
 
-					$start_publish = strftime("%Y-%m-%d", time()+($offset*60*60)); //date("Y-m-d");
-					$stop_publish = strftime("%Y-%m-%d", time()+($offset*60*60));  //date("Y-m-d");
-					$registerby_date = strftime("%Y-%m-%d", time()+($offset*60*60));  //date("Y-m-d");
+					$start_publish = date("Y-m-d", time()+($offset*60*60)); //date("Y-m-d");
+					$stop_publish = date("Y-m-d", time()+($offset*60*60));  //date("Y-m-d");
+					$registerby_date = date("Y-m-d", time()+($offset*60*60));  //date("Y-m-d");
 				}
 
 				$start_time = "08:00";
@@ -1803,7 +1818,7 @@ class Events extends SiteController
 			$state = 'edit';
 
 			// Existing - update modified info
-			$row->modified = strftime("%Y-%m-%d %H:%M:%S", time()+($offset*60*60));
+			$row->modified = date("Y-m-d h:i:s", time()+($offset*60*60));
 			if (User::get('id'))
 			{
 				$row->modified_by = User::get('id');
@@ -1814,7 +1829,7 @@ class Events extends SiteController
 			$state = 'add';
 
 			// New - set created info
-			$row->created = strftime("%Y-%m-%d %H:%M:%S", time()+($offset*60*60));
+			$row->created = date("Y-m-d h:i:s", time()+($offset*60*60));
 			if (User::get('id'))
 			{
 				$row->created_by = User::get('id');

--- a/core/components/com_events/site/views/browse/tmpl/week.php
+++ b/core/components/com_events/site/views/browse/tmpl/week.php
@@ -39,9 +39,9 @@ $this->css();
 		<?php
 			foreach ($this->rows as $rows)
 			{
-				if ($rows['week']['month'] == strftime( "%m", time()+($this->offset*60*60) )
-				 && $rows['week']['year'] == strftime( "%Y", time()+($this->offset*60*60) )
-				 && $rows['week']['day'] == strftime( "%d", time()+($this->offset*60*60) )) {
+				if ($rows['week']['month'] == date("m", time()+($this->offset*60*60) )
+				 && $rows['week']['year'] == date("Y", time()+($this->offset*60*60) )
+				 && $rows['week']['day'] == date("d", time()+($this->offset*60*60) )) {
 					$cls = ' class="today"';
 				} else {
 					$cls = '';

--- a/core/components/com_forum/models/post.php
+++ b/core/components/com_forum/models/post.php
@@ -123,7 +123,7 @@ class Post extends Relational
 					->whereEquals('created_by', $data['created_by'])
 					->whereEquals('comment', $data['comment'])
 					->whereEquals('state', self::STATE_PUBLISHED)
-					//->where('created', '>', Date::of('now')->subtract('1 hour')->toSql())
+					//->where('created', '>', Date::of('now')->modify('-1 hour')->toSql())
 					//->whereEquals('category_id', $data['category_id'])
 					->whereEquals('scope', $data['scope'])
 					->whereEquals('scope_id', $data['scope_id'])

--- a/core/components/com_groups/helpers/pages.php
+++ b/core/components/com_groups/helpers/pages.php
@@ -650,13 +650,13 @@ class Pages
 		$version->set('content', trim($content));
 
 		// set vars to view
-		$view->user       = User::getInstance();
-		$view->group      = $group;
-		$view->page       = $page;
-		$view->version    = $version;
-		$view->authorized = $authorized;
-		$view->config     = Component::params('com_groups');
-		$view->option     = 'com_groups';
+		$view->set('user', User::getInstance());
+		$view->set('group', $group);
+		$view->set('page', $page);
+		$view->set('version', $version);
+		$view->set('authorized', $authorized);
+		$view->set('config', Component::params('com_groups'));
+		$view->set('option ', 'com_groups');
 
 		// return rendered template
 		return $view->loadTemplate();

--- a/core/components/com_groups/models/page.php
+++ b/core/components/com_groups/models/page.php
@@ -325,7 +325,7 @@ class Page extends Model
 		// if we have segments append them
 		if (count($segments) > 0)
 		{
-			$pageLink .= DS . implode($segments, DS);
+			$pageLink .= DS . implode(DS, $segments);
 		}
 
 		// return routed link

--- a/core/components/com_kb/site/views/articles/tmpl/article.php
+++ b/core/components/com_kb/site/views/articles/tmpl/article.php
@@ -248,7 +248,7 @@ Document::setTitle(Lang::txt('COM_KB') . ': ' . $this->category->get('title') . 
 
 					<input type="hidden" name="comment[id]" value="0" />
 					<input type="hidden" name="comment[entry_id]" value="<?php echo $this->escape($this->article->get('id')); ?>" />
-					<input type="hidden" name="comment[parent]" value="<?php echo $this->escape($replyto->get('id')); ?>" />
+					<input type="hidden" name="comment[parent]" value="<?php echo ($replyto->get('id') ? $this->escape($replyto->get('id')) : ''); ?>" />
 					<input type="hidden" name="comment[created]" value="" />
 					<input type="hidden" name="comment[created_by]" value="<?php echo $this->escape(User::get('id')); ?>" />
 					<input type="hidden" name="comment[state]" value="1" />

--- a/core/components/com_projects/models/file.php
+++ b/core/components/com_projects/models/file.php
@@ -33,7 +33,7 @@ class File extends Obj
 	 * @param   string  $repoPath
 	 * @return  void
 	 */
-	public function __construct($localPath = null, $repoPath = null)
+	public function __construct($localPath = '', $repoPath = '')
 	{
 		$this->set('localPath', $localPath); // Path to item within repo
 

--- a/core/components/com_projects/models/project.php
+++ b/core/components/com_projects/models/project.php
@@ -97,10 +97,15 @@ class Project extends Model
 		$this->params = $paramsRegistry;
 	}
 
+	/**
+	 * Get params as an array
+	 *
+	 * @return array
+	 */
 	protected function _getParsedParams()
 	{
 		$parsedParams = [];
-		$splitParams = explode("\n", $this->_tbl->get('params',''));
+		$splitParams = explode("\n", $this->_tbl->get('params', ''));
 
 		foreach ($splitParams as $param)
 		{

--- a/core/components/com_projects/site/controllers/projects.php
+++ b/core/components/com_projects/site/controllers/projects.php
@@ -185,28 +185,29 @@ class Projects extends Base
 		}
 
 		// Filters
-		$this->view->filters = array();
-		$this->view->filters['mine']    = 1;
-		$this->view->filters['updates'] = 1;
-		$this->view->filters['sortby']  = 'myprojects';
+		$filters = array();
+		$filters['mine']    = 1;
+		$filters['updates'] = 1;
+		$filters['sortby']  = 'myprojects';
+		$this->view->set('filters', $filters);
 
 		// Set the pathway
 		$this->_buildPathway();
 
 		// Set the page title
 		$this->_buildTitle();
-		$this->view->title = $this->title;
+		$this->view->set('title', $this->title);
 
 		// Log activity
 		$this->_logActivity();
 
 		// Output HTML
-		$this->view->option     = $this->_option;
-		$this->view->model      = $this->model;
-		$this->view->publishing = $this->_publishing;
-		$this->view->msg        = isset($this->_msg) && $this->_msg
+		$this->view->set('option', $this->_option);
+		$this->view->set('model', $this->model);
+		$this->view->set('publishing', $this->_publishing);
+		$this->view->set('msg', isset($this->_msg) && $this->_msg
 								? $this->_msg
-								: $this->_getNotifications('success');
+								: $this->_getNotifications('success'));
 
 		if ($this->getError())
 		{
@@ -229,15 +230,15 @@ class Projects extends Base
 
 		// Set the page title
 		$this->_buildTitle();
-		$this->view->title = $this->title;
+		$this->view->set('title', $this->title);
 
 		// Log activity
 		$this->_logActivity();
 
 		// Output HTML
-		$this->view->option     = $this->_option;
-		$this->view->config     = $this->config;
-		$this->view->publishing = $this->_publishing;
+		$this->view->set('option', $this->_option);
+		$this->view->set('config', $this->config);
+		$this->view->set('publishing', $this->_publishing);
 
 		if ($this->getError())
 		{
@@ -283,49 +284,50 @@ class Projects extends Base
 		}
 
 		// Incoming
-		$this->view->filters = array();
-		$this->view->filters['limit'] = Request::getInt(
+		$filters = array();
+		$filters['limit'] = Request::getInt(
 			'limit',
 			intval(\Config::get('list_limit', 25)),
 			'request'
 		);
-		$this->view->filters['start']    = Request::getInt('limitstart', 0, 'get');
-		$this->view->filters['sortby']   = strtolower(Request::getWord('sortby', 'title'));
-		$this->view->filters['search']   = Request::getString('search', '');
-		$this->view->filters['sortdir']  = strtoupper(Request::getWord('sortdir', 'ASC'));
-		$this->view->filters['reviewer'] = $reviewer;
-		$this->view->filters['filterby'] = Request::getWord('filterby', 'all');
+		$filters['start']    = Request::getInt('limitstart', 0, 'get');
+		$filters['sortby']   = strtolower(Request::getWord('sortby', 'title'));
+		$filters['search']   = Request::getString('search', '');
+		$filters['sortdir']  = strtoupper(Request::getWord('sortdir', 'ASC'));
+		$filters['reviewer'] = $reviewer;
+		$filters['filterby'] = Request::getWord('filterby', 'all');
 
 		if (User::isGuest() || (!User::authorise('core.manage', $this->_option) && !$this->model->reviewerAccess($reviewer)))
 		{
-			$this->view->filters['active'] = true;
+			$filters['active'] = true;
 		}
 
-		if (!in_array($this->view->filters['sortby'], array('title', 'id', 'myprojects', 'owner', 'created', 'type', 'role', 'privacy', 'status', 'grant_status')))
+		if (!in_array($filters['sortby'], array('title', 'id', 'myprojects', 'owner', 'created', 'type', 'role', 'privacy', 'status', 'grant_status')))
 		{
-			$this->view->filters['sortby'] = 'title';
+			$filters['sortby'] = 'title';
 		}
 
-		if (!in_array($this->view->filters['sortdir'], array('DESC', 'ASC')))
+		if (!in_array($filters['sortdir'], array('DESC', 'ASC')))
 		{
-			$this->view->filters['sortdir'] = 'ASC';
+			$filters['sortdir'] = 'ASC';
 		}
 
-		if (!in_array($this->view->filters['filterby'], array('all', 'open', 'public', 'archived', 'pending')))
+		if (!in_array($filters['filterby'], array('all', 'open', 'public', 'archived', 'pending')))
 		{
-			$this->view->filters['filterby'] = 'all';
+			$filters['filterby'] = 'all';
 		}
 		// We're filtering by a specific state
 		// Do NOT include all projects the user may have access to as some of them may not be of this state
-		//if (in_array($this->view->filters['filterby'], array('open', 'public')))
+		//if (in_array($filters['filterby'], array('open', 'public')))
 		//{
-		//	$this->view->filters['uid'] = 0;
+		//	$filters['uid'] = 0;
 		//}
 
 		/*if ($reviewer == 'sensitive' || $reviewer == 'sponsored')
 		{
-			$this->view->filters['filterby'] = Request::getWord('filterby', 'pending');
+			$filters['filterby'] = Request::getWord('filterby', 'pending');
 		}*/
+		$this->view->set('filters', $filters);
 
 		// Login for private projects
 		if (User::isGuest() && $action == 'login')
@@ -339,12 +341,12 @@ class Projects extends Base
 		$this->_logActivity(0, 'general', 'browse');
 
 		// Output HTML
-		$this->view->model    = $this->model;
-		$this->view->option   = $this->_option;
-		$this->view->config   = $this->config;
-		$this->view->title    = $this->title;
-		$this->view->reviewer = $reviewer;
-		$this->view->msg      = $this->_getNotifications('success');
+		$this->view->set('model', $this->model);
+		$this->view->set('option', $this->_option);
+		$this->view->set('config', $this->config);
+		$this->view->set('title', $this->title);
+		$this->view->set('reviewer', $reviewer);
+		$this->view->set('msg', $this->_getNotifications('success'));
 		if ($this->getError())
 		{
 			$this->view->setError($this->getError());
@@ -681,24 +683,24 @@ class Projects extends Base
 		$this->_buildTitle();
 
 		// Output HTML
-		$this->view->params   = $this->model->params;
-		$this->view->model    = $this->model;
-		$this->view->reviewer = $reviewer;
-		$this->view->title    = $this->title;
-		$this->view->active   = $this->active;
-		$this->view->task     = $this->_task;
-		$this->view->option   = $this->_option;
-		$this->view->config   = $this->config;
-		$this->view->msg      = $this->_getNotifications('success');
+		$this->view->set('params', $this->model->params);
+		$this->view->set('model', $this->model);
+		$this->view->set('reviewer', $reviewer);
+		$this->view->set('title', $this->title);
+		$this->view->set('active', $this->active);
+		$this->view->set('task', $this->_task);
+		$this->view->set('option', $this->_option);
+		$this->view->set('config', $this->config);
+		$this->view->set('msg', $this->_getNotifications('success'));
 
 		/// Info block moved to info plugin
-		$this->view->info = array();
+		$this->view->set('info', array());
 
 
 		if ($layout == 'invited')
 		{
-			$this->view->confirmcode = $confirmcode;
-			$this->view->email       = $email;
+			$this->view->set('confirmcode', $confirmcode);
+			$this->view->set('email', $email);
 		}
 
 		$error = $this->getError() ? $this->getError() : $this->_getNotifications('error');
@@ -791,21 +793,21 @@ class Projects extends Base
 		if (!$confirm || $this->getError())
 		{
 			$this->view->setLayout('provisioned');
-			$this->view->model = $this->model;
+			$this->view->set('model', $this->model);
 
-			$this->view->team  = $this->model->_tblOwner->getOwnerNames($this->model->get('alias'));
+			$this->view->set('team', $this->model->_tblOwner->getOwnerNames($this->model->get('alias')));
 
 			// Output HTML
-			$this->view->pub        = isset($pub) ? $pub : '';
-			$this->view->suggested  = $name;
-			$this->view->verified   = $verified;
-			$this->view->suggested  = $verified ? $this->view->suggested : '';
-			$this->view->title      = $this->title;
-			$this->view->active     = $this->active;
-			$this->view->task       = $this->_task;
-			$this->view->authorized = 1;
-			$this->view->option     = $this->_option;
-			$this->view->msg        = $this->_getNotifications('success');
+			$this->view->set('pub', isset($pub) ? $pub : '');
+			$this->view->set('suggested', $name);
+			$this->view->set('verified', $verified);
+			$this->view->set('suggested', $verified ? $this->view->suggested : '');
+			$this->view->set('title', $this->title);
+			$this->view->set('active', $this->active);
+			$this->view->set('task', $this->_task);
+			$this->view->set('authorized', 1);
+			$this->view->set('option', $this->_option);
+			$this->view->set('msg', $this->_getNotifications('success'));
 
 			if ($this->getError())
 			{
@@ -1289,18 +1291,18 @@ class Projects extends Base
 			$this->view->setLayout('review');
 
 			// Output HTML
-			$this->view->reviewer = $reviewer;
-			$this->view->ajax     = Request::getInt('ajax', 0);
-			$this->view->title    = $this->title;
-			$this->view->option   = $this->_option;
-			$this->view->model    = $this->model;
-			$this->view->params   = $params;
-			$this->view->config   = $this->config;
-			$this->view->database = $this->database;
-			$this->view->action   = $action;
-			$this->view->filterby = $filterby;
-			$this->view->uid      = User::get('id');
-			$this->view->msg      = $this->_getNotifications('success');
+			$this->view->set('reviewer', $reviewer);
+			$this->view->set('ajax', Request::getInt('ajax', 0));
+			$this->view->set('title', $this->title);
+			$this->view->set('option', $this->_option);
+			$this->view->set('model', $this->model);
+			$this->view->set('params', $params);
+			$this->view->set('config', $this->config);
+			$this->view->set('database', $this->database);
+			$this->view->set('action', $action);
+			$this->view->set('filterby', $filterby);
+			$this->view->set('uid', User::get('id'));
+			$this->view->set('msg', $this->_getNotifications('success'));
 			if ($this->getError())
 			{
 				$this->view->setError($this->getError());

--- a/core/components/com_publications/helpers/html.php
+++ b/core/components/com_publications/helpers/html.php
@@ -857,16 +857,16 @@ class Html
 			'name'      => 'view',
 			'layout'    => '_primary'
 		));
-		$view->option   = 'com_publications';
-		$view->disabled = $disabled;
-		$view->class    = $class;
-		$view->href     = $href;
-		$view->title    = $title;
-		$view->action   = $action;
-		$view->xtra     = $xtra;
-		$view->pop      = $pop;
-		$view->msg      = $msg;
-		$view->options  = $options;
+		$view->set('option', 'com_publications');
+		$view->set('disabled', $disabled);
+		$view->set('class', $class);
+		$view->set('href', $href);
+		$view->set('title', $title);
+		$view->set('action', $action);
+		$view->set('xtra', $xtra);
+		$view->set('pop', $pop);
+		$view->set('msg', $msg);
+		$view->set('options', $options);
 
 		return $view->loadTemplate();
 	}
@@ -890,21 +890,21 @@ class Html
 				'layout'  =>'statusbar'
 			)
 		);
-		$view->row           = $item->row;
-		$view->version       = $item->version;
-		$view->panels        = $item->panels;
-		$view->active        = isset($item->active) ? $item->active : null;
-		$view->move          = isset($item->move) ? $item->move : 0;
-		$view->step          = $step;
-		$view->lastpane      = $item->lastpane;
-		$view->option        = $item->option;
-		$view->project       = $item->project;
-		$view->current_idx   = $item->current_idx;
-		$view->last_idx      = $item->last_idx;
-		$view->checked       = $item->checked;
-		$view->url           = $item->url;
-		$view->review        = $review;
-		$view->show_substeps = $showSubSteps;
+		$view->set('row', $item->row);
+		$view->set('version', $item->version);
+		$view->set('panels', $item->panels);
+		$view->set('active', isset($item->active) ? $item->active : null);
+		$view->set('move', isset($item->move) ? $item->move : 0);
+		$view->set('step', $step);
+		$view->set('lastpane', $item->lastpane);
+		$view->set('option', $item->option);
+		$view->set('project', $item->project);
+		$view->set('current_idx', $item->current_idx);
+		$view->set('last_idx', $item->last_idx);
+		$view->set('checked', $item->checked);
+		$view->set('url', $item->url);
+		$view->set('review', $review);
+		$view->set('show_substeps', $showSubSteps);
 		$view->display();
 	}
 

--- a/core/components/com_publications/models/bundle.php
+++ b/core/components/com_publications/models/bundle.php
@@ -19,6 +19,27 @@ use Hubzero\Utility\Arr;
 class Bundle
 {
 	/**
+	 * Publication
+	 *
+	 * @var object
+	 */
+	protected $publication;
+
+	/**
+	 * Publication ID
+	 *
+	 * @var int
+	 */
+	protected $publication_id;
+
+	/**
+	 * Publication version ID
+	 *
+	 * @var int
+	 */
+	protected $publication_version_id;
+
+	/**
 	 * Contents of archive
 	 *
 	 * @var  array

--- a/core/components/com_publications/site/controllers/publications.php
+++ b/core/components/com_publications/site/controllers/publications.php
@@ -669,17 +669,17 @@ class Publications extends SiteController
 				'name'   => 'about',
 				'layout' => 'default'
 			));
-			$view->option      = $this->_option;
-			$view->controller  = $this->_controller;
-			$view->task        = $this->_task;
-			$view->config      = $this->config;
-			$view->database    = $this->database;
-			$view->publication = $this->model;
-			$view->authorized  = $authorized;
-			$view->restricted  = $restricted;
-			$view->version     = $publicationVersionId;
-			$view->bundle      = $bundle;
-			$view->sections    = $sections;
+			$view->set('option', $this->_option);
+			$view->set('controller', $this->_controller);
+			$view->set('task', $this->_task);
+			$view->set('config', $this->config);
+			$view->set('database', $this->database);
+			$view->set('publication', $this->model);
+			$view->set('authorized', $authorized);
+			$view->set('restricted', $restricted);
+			$view->set('version', $publicationVersionId);
+			$view->set('bundle', $bundle);
+			$view->set('sections', $sections);
 			$body              = $view->loadTemplate();
 
 			// Log page view (public pubs only)
@@ -712,19 +712,19 @@ class Publications extends SiteController
 		// Set the pathway
 		$this->_buildPathway();
 
-		$this->view->version        = $this->model->versionAlias;
-		$this->view->config         = $this->config;
-		$this->view->option         = $this->_option;
-		$this->view->publication    = $this->model;
-		$this->view->authorized     = $authorized;
-		$this->view->restricted     = $restricted;
-		$this->view->cats           = $cats;
-		$this->view->tab            = $tab;
-		$this->view->sections       = $sections;
-		$this->view->database       = $this->database;
-		$this->view->filters        = $filters;
-		$this->view->lastPubRelease = $lastPubRelease;
-		$this->view->contributable  = $this->_contributable;
+		$this->view->set('version', $this->model->versionAlias);
+		$this->view->set('config', $this->config);
+		$this->view->set('option', $this->_option);
+		$this->view->set('publication', $this->model);
+		$this->view->set('authorized', $authorized);
+		$this->view->set('restricted', $restricted);
+		$this->view->set('cats', $cats);
+		$this->view->set('tab', $tab);
+		$this->view->set('sections', $sections);
+		$this->view->set('database', $this->database);
+		$this->view->set('filters', $filters);
+		$this->view->set('lastPubRelease', $lastPubRelease);
+		$this->view->set('contributable', $this->_contributable);
 
 		if ($this->getError())
 		{
@@ -812,8 +812,8 @@ class Publications extends SiteController
 					'name'   => 'view',
 					'layout' => '_contents'
 				]);
-				$view->model  = $this->model;
-				$view->option = $this->_option;
+				$view->set('model', $this->model);
+				$view->set('option', $this->_option);
 				$view->display();
 
 				return;
@@ -1229,8 +1229,8 @@ class Publications extends SiteController
 			'name'   => 'submit',
 			'layout' => 'default'
 		));
-		$this->view->option = $this->_option;
-		$this->view->config = $this->config;
+		$this->view->set('option', $this->_option);
+		$this->view->set('config', $this->config);
 
 		// Set page title
 		$this->_task_title = Lang::txt('COM_PUBLICATIONS_SUBMIT');
@@ -1294,9 +1294,9 @@ class Publications extends SiteController
 				'name'   => 'error',
 				'layout' => 'restricted'
 			));
-			$this->view->error  = Lang::txt('COM_PUBLICATIONS_ERROR_NOT_FROM_CREATOR_GROUP');
-			$this->view->title  = $this->title;
-			$this->view->option = $this->_option;
+			$this->view->set('error', Lang::txt('COM_PUBLICATIONS_ERROR_NOT_FROM_CREATOR_GROUP'));
+			$this->view->set('title', $this->title);
+			$this->view->set('option', $this->_option);
 			$this->view->display();
 			return;
 		}
@@ -1315,7 +1315,7 @@ class Publications extends SiteController
 		);
 
 		$content = Event::trigger('projects.onProject', $plugin_params);
-		$this->view->content = (is_array($content) && isset($content[0]['html'])) ? $content[0]['html'] : '';
+		$this->view->set('content', (is_array($content) && isset($content[0]['html'])) ? $content[0]['html'] : '');
 
 		if (isset($content[0]['msg']) && !empty($content[0]['msg']))
 		{
@@ -1346,12 +1346,12 @@ class Publications extends SiteController
 		}
 
 		// Output HTML
-		$this->view->project = $project;
-		$this->view->action  = $action;
-		$this->view->pid     = $pid;
-		$this->view->title   = $this->_title;
-		$this->view->msg     = $this->getNotifications('success');
-		$error               = $this->getError() ? $this->getError() : $this->getNotifications('error');
+		$this->view->set('project', $project);
+		$this->view->set('action', $action);
+		$this->view->set('pid', $pid);
+		$this->view->set('title', $this->_title);
+		$this->view->set('msg', $this->getNotifications('success'));
+		$error = $this->getError() ? $this->getError() : $this->getNotifications('error');
 		if ($error)
 		{
 			$this->view->setError($error);

--- a/core/components/com_publications/site/views/view/tmpl/_contributors.php
+++ b/core/components/com_publications/site/views/view/tmpl/_contributors.php
@@ -12,14 +12,14 @@ $database = \App::get('db');
 
 if ($this->contributors)
 {
-	$html 		= '';
-	$names 		= array();
-	$orgs 		= array();
-	$i 			= 1;
-	$k 			= 0;
-	$orgsln 	= '';
-	$names_s 	= array();
-	$orgsln_s 	= '';
+	$html     = '';
+	$names    = array();
+	$orgs     = array();
+	$i        = 1;
+	$k        = 0;
+	$orgsln   = '';
+	$names_s  = array();
+	$orgsln_s = '';
 
 	foreach ($this->contributors as $contributor)
 	{
@@ -49,7 +49,10 @@ if ($this->contributors)
 		{
 			$contributor->organization = $contributor->p_organization;
 		}
-		$contributor->organization = $this->escape(stripslashes(trim($contributor->organization)));
+		if ($contributor->organization)
+		{
+			$contributor->organization = $this->escape(stripslashes(trim($contributor->organization)));
+		}
 
 		$name = str_replace( '"', '&quot;', $name );
 		if ($contributor->user_id && $contributor->open)
@@ -63,17 +66,17 @@ if ($this->contributors)
 		}
 		$link .= ($contributor->role) ? ' ('.$contributor->role.')' : '';
 
-		if (trim($contributor->organization) != '' && !in_array(trim($contributor->organization), $orgs))
+		if ($contributor->organization && !in_array(trim($contributor->organization), $orgs))
 		{
-			$orgs[$i-1] = trim($contributor->organization);
-			$orgsln 	.= $i. '. ' . trim($contributor->organization) . ' ';
-			$orgsln_s 	.= trim($contributor->organization) . ' ';
+			$orgs[$i-1] = $contributor->organization;
+			$orgsln   .= $i . '. ' . $contributor->organization . ' ';
+			$orgsln_s .= $contributor->organization . ' ';
 			$k = $i;
 			$i++;
 		}
-		else if (trim($contributor->organization) != '')
+		else if ($contributor->organization)
 		{
-			$k = array_search(trim($contributor->organization), $orgs) + 1;
+			$k = array_search($contributor->organization, $orgs) + 1;
 		}
 		else
 		{
@@ -105,7 +108,6 @@ if ($this->contributors)
 	{
 		$html = count($names) > 1  ? implode( ', ', $names ) : implode( ', ', $names_s );
 	}
-
 }
 else
 {

--- a/core/components/com_publications/site/views/view/tmpl/_supportingdocs.php
+++ b/core/components/com_publications/site/views/view/tmpl/_supportingdocs.php
@@ -9,7 +9,7 @@
 defined('_HZEXEC_') or die();
 
 $publication = $this->publication;
-$children    = $publication->_attachments[2];
+$children    = $publication->_attachments ? $publication->_attachments[2] : false;
 $archive     = $publication->bundlePath();
 
 // Set counts

--- a/core/components/com_publications/tables/publication.php
+++ b/core/components/com_publications/tables/publication.php
@@ -105,7 +105,7 @@ class Publication extends Table
 
 		if (!isset($filters['all_versions']) || !$filters['all_versions'])
 		{
-			$groupby = ' GROUP BY C.id ';
+			$groupby = ' GROUP BY C.id, V.id ';
 		}
 
 		$project  = isset($filters['project']) && intval($filters['project']) ? $filters['project'] : "";

--- a/core/components/com_publications/tables/publication.php
+++ b/core/components/com_publications/tables/publication.php
@@ -531,7 +531,7 @@ class Publication extends Table
 		}
 
 		$now = Date::toSql();
-		$alias = str_replace(':', '-', $alias);
+		$alias = $alias ? str_replace(':', '-', $alias) : '';
 
 		$sql  = "SELECT V.*, C.id as id, C.category, C.master_type,
 				C.project_id, C.access as master_access, C.master_doi,

--- a/core/components/com_resources/helpers/html.php
+++ b/core/components/com_resources/helpers/html.php
@@ -1097,15 +1097,15 @@ class Html
 			'name'   => 'view',
 			'layout' => '_primary'
 		));
-		$view->option   = 'com_resources';
-		$view->disabled = $disabled;
-		$view->class    = $class;
-		$view->href     = $href;
-		$view->title    = $title;
-		$view->action   = $action;
-		$view->xtra     = $xtra;
-		$view->pop      = $pop;
-		$view->msg      = $msg;
+		$view->set('option', 'com_resources')
+			->set('disabled', $disabled)
+			->set('class', $class)
+			->set('href', $href)
+			->set('title', $title)
+			->set('action', $action)
+			->set('xtra', $xtra)
+			->set('pop', $pop)
+			->set('msg', $msg);
 
 		return $view->loadTemplate();
 	}

--- a/core/libraries/Hubzero/Access/Access.php
+++ b/core/libraries/Hubzero/Access/Access.php
@@ -79,7 +79,8 @@ class Access
 		$userId = (int) $userId;
 
 		$action = strtolower(preg_replace('#[\s\-]+#', '.', trim($action)));
-		$asset  = strtolower(preg_replace('#[\s\-]+#', '.', trim($asset)));
+		$asset  = $asset ? $asset : '';
+		$asset  = is_int($asset) ? $asset : strtolower(preg_replace('#[\s\-]+#', '.', trim($asset)));
 
 		// Default to the root asset node.
 		if (empty($asset))

--- a/core/libraries/Hubzero/Base/Client/Administrator.php
+++ b/core/libraries/Hubzero/Base/Client/Administrator.php
@@ -39,4 +39,11 @@ class Administrator implements ClientInterface
 	 * @var  string
 	 */
 	public $url = 'admin';
+
+	/**
+	 * Boostrap filesystem path
+	 *
+	 * @var  string
+	 */
+	public $path = '';
 }

--- a/core/libraries/Hubzero/Base/Client/Api.php
+++ b/core/libraries/Hubzero/Base/Client/Api.php
@@ -32,4 +32,11 @@ class Api implements ClientInterface
 	 * @var  string
 	 */
 	public $url = 'api';
+
+	/**
+	 * Boostrap filesystem path
+	 *
+	 * @var  string
+	 */
+	public $path = '';
 }

--- a/core/libraries/Hubzero/Base/Client/Cli.php
+++ b/core/libraries/Hubzero/Base/Client/Cli.php
@@ -44,6 +44,13 @@ class Cli implements ClientInterface
 	public $url = '';
 
 	/**
+	 * Boostrap filesystem path
+	 *
+	 * @var  string
+	 */
+	public $path = '';
+
+	/**
 	 * Method to call another console command
 	 *
 	 * @param   string  $class      The command to call

--- a/core/libraries/Hubzero/Base/Client/Site.php
+++ b/core/libraries/Hubzero/Base/Client/Site.php
@@ -39,4 +39,11 @@ class Site implements ClientInterface
 	 * @var  string
 	 */
 	public $url = '';
+
+	/**
+	 * Boostrap filesystem path
+	 *
+	 * @var  string
+	 */
+	public $path = '';
 }

--- a/core/libraries/Hubzero/Base/ItemList.php
+++ b/core/libraries/Hubzero/Base/ItemList.php
@@ -92,6 +92,8 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	 *
 	 * @return  void
 	 */
+
+	#[\ReturnTypeWillChange]
 	public function reset()
 	{
 		$this->_pos = 0;
@@ -121,17 +123,17 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	/**
 	 * Seek to an absolute position
 	 *
-	 * @param   integer               $index
-	 * @throws  OutOfBoundsException  When the seek position is invalid
+	 * @param   integer               $offset
+	 * @throws  \OutOfBoundsException  When the seek position is invalid
 	 * @return  void
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function seek($index)
+	public function seek($offset)
 	{
 		$this->rewind();
 
-		while ($this->_pos < $index && $this->valid())
+		while ($this->_pos < $offset && $this->valid())
 		{
 			$this->next();
 		}
@@ -162,7 +164,7 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	/**
 	 * Return the array count
 	 *
-	 * @return  integer
+	 * @return  int
 	 */
 	public function total()
 	{
@@ -172,7 +174,7 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	/**
 	 * Return the array count
 	 *
-	 * @return  integer
+	 * @return  int
 	 */
 
 	#[\ReturnTypeWillChange]
@@ -220,10 +222,11 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	 *
 	 * @return  mixed
 	 */
+
+	#[\ReturnTypeWillChange]
 	public function prev()
 	{
 		--$this->_pos;
-		return $this->current();
 	}
 
 	/**
@@ -236,13 +239,12 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	public function next()
 	{
 		++$this->_pos;
-		return $this->current();
 	}
 
 	/**
 	 * Check if the current cursor position is valid
 	 *
-	 * @return  mixed
+	 * @return  bool
 	 */
 
 	#[\ReturnTypeWillChange]
@@ -316,7 +318,7 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	/**
 	 * Run a map over each of the items
 	 *
-	 * @param   object  $callback  Closure
+	 * @param   Closure  $callback
 	 * @return  array
 	 */
 	public function map(Closure $callback)
@@ -327,8 +329,8 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	/**
 	 * Run a filter over each of the items
 	 *
-	 * @param   object  $callback  Closure
-	 * @return  array
+	 * @param   Closure  $callback
+	 * @return  ItemList
 	 */
 	public function filter(Closure $callback)
 	{
@@ -339,7 +341,7 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	 * Merge Item Lists
 	 *
 	 * @param   object  $data  ItemList
-	 * @return  object  ItemList
+	 * @return  ItemList
 	 */
 	public function merge()
 	{
@@ -357,7 +359,7 @@ class ItemList implements SeekableIterator, Countable, ArrayAccess
 	/**
 	 * Reverse data order.
 	 *
-	 * @return  object  ItemList
+	 * @return  ItemList
 	 */
 	public function reverse()
 	{

--- a/core/libraries/Hubzero/Cache/Storage/None.php
+++ b/core/libraries/Hubzero/Cache/Storage/None.php
@@ -41,7 +41,7 @@ class None implements StorageInterface
 		if (!isset($this->options['hash']))
 		{
 			$config = new \Hubzero\Config\Repository('site');
-			$this->options['hash'] = md5($config->get('secret'));
+			$this->options['hash'] = md5($config->get('secret', 'secret'));
 		}
 	}
 

--- a/core/libraries/Hubzero/Component/View.php
+++ b/core/libraries/Hubzero/Component/View.php
@@ -23,6 +23,34 @@ class View extends AbstractView
 	protected $_layout = 'display';
 
 	/**
+	 * Base URL
+	 *
+	 * @var string
+	 */
+	protected $baseurl;
+
+	/**
+	 * Current component
+	 *
+	 * @var string
+	 */
+	protected $option;
+
+	/**
+	 * Current controller
+	 *
+	 * @var string
+	 */
+	protected $controller;
+
+	/**
+	 * Current task
+	 *
+	 * @var string
+	 */
+	protected $task;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $config  A named configuration array for object construction.<br/>
@@ -50,7 +78,7 @@ class View extends AbstractView
 	 *
 	 * @param   string  $layout  View layout
 	 * @param   string  $name    View name
-	 * @return  object
+	 * @return  View
 	 */
 	public function view($layout, $name=null)
 	{

--- a/core/libraries/Hubzero/Config/Registry.php
+++ b/core/libraries/Hubzero/Config/Registry.php
@@ -89,7 +89,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * @return  object  This object represented as an ArrayIterator.
 	 * @see     IteratorAggregate::getIterator()
 	 */
-
 	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
@@ -101,7 +100,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  integer  The custom count as an integer.
 	 */
-
 	#[\ReturnTypeWillChange]
 	public function count()
 	{
@@ -112,9 +110,8 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 * Implementation for the JsonSerializable interface.
 	 * Allows us to pass Registry objects to json_encode.
 	 *
-	 * @return  object
+	 * @return  mixed
 	 */
-
 	#[\ReturnTypeWillChange]
 	public function jsonSerialize()
 	{
@@ -364,7 +361,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 
 		// If the source isn't already a Registry
 		// we'll turn it into one
-
 		if (!is_array($source))
 		{
 			if (!($source instanceof Registry) && !method_exists($source, 'toArray'))
@@ -568,53 +564,49 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	/**
 	 * Determine if the given configuration option exists.
 	 *
-	 * @param   string  $key
+	 * @param   mixed $offset
 	 * @return  bool
 	 */
-
 	#[\ReturnTypeWillChange]
-	public function offsetExists($key)
+	public function offsetExists($offset)
 	{
-		return $this->has($key);
+		return $this->has($offset);
 	}
 
 	/**
 	 * Get a configuration option.
 	 *
-	 * @param   string  $key
+	 * @param   mixed $offset
 	 * @return  mixed
 	 */
-
 	#[\ReturnTypeWillChange]
-	public function offsetGet($key)
+	public function offsetGet($offset)
 	{
-		return $this->get($key);
+		return $this->get($offset);
 	}
 
 	/**
 	 * Set a configuration option.
 	 *
-	 * @param   string  $key
+	 * @param   mixed   $offset
 	 * @param   mixed   $value
 	 * @return  void
 	 */
-
 	#[\ReturnTypeWillChange]
-	public function offsetSet($key, $value)
+	public function offsetSet($offset, $value)
 	{
-		$this->set($key, $value);
+		$this->set($offset, $value);
 	}
 
 	/**
 	 * Unset a configuration option.
 	 *
-	 * @param   string  $key
+	 * @param   mixed $offset
 	 * @return  void
 	 */
-
 	#[\ReturnTypeWillChange]
-	public function offsetUnset($key)
+	public function offsetUnset($offset)
 	{
-		$this->set($key, null);
+		$this->set($offset, null);
 	}
 }

--- a/core/libraries/Hubzero/Console/Command/Help.php
+++ b/core/libraries/Hubzero/Console/Command/Help.php
@@ -18,6 +18,13 @@ use Hubzero\Console\Arguments;
 class Help extends Base implements CommandInterface
 {
 	/**
+	 * List of commands
+	 *
+	 * @var array
+	 */
+	protected $_commands = array();
+
+	/**
 	 * Default (required) command
 	 *
 	 * Generates list of available commands and their respective tasks

--- a/core/libraries/Hubzero/Database/Rows.php
+++ b/core/libraries/Hubzero/Database/Rows.php
@@ -65,6 +65,7 @@ class Rows implements Iterator, Countable
 	/**
 	 * Calls the given array function on the rows object and attaches itself to the model
 	 *
+	 * @param   string $function
 	 * @return  mixed
 	 * @since   2.1.0
 	 **/
@@ -101,6 +102,7 @@ class Rows implements Iterator, Countable
 	/**
 	 * Removes model from the stack
 	 *
+	 * @param   int $key
 	 * @return  void
 	 * @since   2.0.0
 	 **/
@@ -123,7 +125,7 @@ class Rows implements Iterator, Countable
 	/**
 	 * Selects a number of randomly selected rows
 	 *
-	 * @param   integer  $n  The number of rows to randomly select
+	 * @param   int  $n  The number of rows to randomly select
 	 * @return  Rows
 	 * @since   2.1.13
 	 **/
@@ -220,7 +222,7 @@ class Rows implements Iterator, Countable
 	/**
 	 * Gets the current key
 	 *
-	 * @return  string
+	 * @return  mixed
 	 * @since   2.0.0
 	 **/
 
@@ -231,6 +233,7 @@ class Rows implements Iterator, Countable
 		{
 			return key($this->rows);
 		}
+		return null;
 	}
 
 	/**
@@ -287,7 +290,7 @@ class Rows implements Iterator, Countable
 	#[\ReturnTypeWillChange]
 	public function next()
 	{
-		return $this->callArrayFunc('next');
+		$this->callArrayFunc('next');
 	}
 
 	/**
@@ -309,7 +312,7 @@ class Rows implements Iterator, Countable
 	/**
 	 * Fast-forwards to the end of the iterable list
 	 *
-	 * @return  mixed
+	 * @return  void
 	 * @since   2.0.0
 	 **/
 	public function last()
@@ -388,17 +391,20 @@ class Rows implements Iterator, Countable
 	/**
 	 * Seeks to the given key
 	 *
+	 * @param   mixed  $offset
 	 * @return  mixed
 	 * @since   2.0.0
 	 **/
-	public function seek($key)
+	public function seek($offset)
 	{
-		return isset($this->rows[$key]) ? $this->rows[$key] : false;
+		return isset($this->rows[$offset]) ? $this->rows[$offset] : false;
 	}
 
 	/**
 	 * Search for the given key/value pair, returning false if not found
 	 *
+	 * @param   mixed $key
+	 * @param   mixed $value
 	 * @return  mixed
 	 * @since   2.0.0
 	 **/

--- a/core/libraries/Hubzero/Database/Table.php
+++ b/core/libraries/Hubzero/Database/Table.php
@@ -74,6 +74,13 @@ abstract class Table extends Obj
 	protected $_locked = false;
 
 	/**
+	 * Cached table field descriptions
+	 *
+	 * @var array
+	 */
+	private $fieldCache = null;
+
+	/**
 	 * Object constructor to set table and key fields.  In most cases this will
 	 * be overridden by child classes to explicitly set the table and key fields
 	 * for a particular database table.
@@ -124,9 +131,7 @@ abstract class Table extends Obj
 	 */
 	public function getFields()
 	{
-		static $cache = null;
-
-		if ($cache === null)
+		if ($this->fieldCache === null)
 		{
 			// Lookup the fields for this table only once.
 			$name = $this->_tbl;
@@ -138,10 +143,10 @@ abstract class Table extends Obj
 				$this->setError($e);
 				return false;
 			}
-			$cache = $fields;
+			$this->fieldCache = $fields;
 		}
 
-		return $cache;
+		return $this->fieldCache;
 	}
 
 	/**

--- a/core/libraries/Hubzero/Events/Dispatcher.php
+++ b/core/libraries/Hubzero/Events/Dispatcher.php
@@ -106,6 +106,10 @@ class Dispatcher implements DispatcherInterface
 
 		foreach ($listeners as $listener)
 		{
+			if (!$listener)
+			{
+				continue;
+			}
 			if (!$this->hasListener($listener))
 			{
 				$this->addListener($listener, $events);

--- a/core/libraries/Hubzero/Events/Event.php
+++ b/core/libraries/Hubzero/Events/Event.php
@@ -97,7 +97,7 @@ class Event implements ArrayAccess, Serializable, Countable
 	 *
 	 * @param   string  $name   The argument name.
 	 * @param   mixed   $value  The argument value.
-	 * @return  object  This method is chainable.
+	 * @return  self
 	 */
 	public function addArgument($name, $value)
 	{
@@ -115,7 +115,7 @@ class Event implements ArrayAccess, Serializable, Countable
 	 *
 	 * @param   string  $name   The argument name.
 	 * @param   mixed   $value  The argument value.
-	 * @return  object  This method is chainable.
+	 * @return  self
 	 */
 	public function setArgument($name, $value)
 	{
@@ -128,7 +128,7 @@ class Event implements ArrayAccess, Serializable, Countable
 	 * Remove an event argument.
 	 *
 	 * @param   string  $name  The argument name.
-	 * @return  object  This method is chainable.
+	 * @return  se;f
 	 */
 	public function removeArgument($name)
 	{
@@ -143,7 +143,7 @@ class Event implements ArrayAccess, Serializable, Countable
 	/**
 	 * Clear all event arguments.
 	 *
-	 * @return  array  The old arguments.
+	 * @return  self
 	 */
 	public function clearArguments()
 	{
@@ -196,7 +196,6 @@ class Event implements ArrayAccess, Serializable, Countable
 	 *
 	 * @return  integer  The number of arguments.
 	 */
-
 	#[\ReturnTypeWillChange]
 	public function count()
 	{
@@ -212,49 +211,48 @@ class Event implements ArrayAccess, Serializable, Countable
 	#[\ReturnTypeWillChange]
 	public function serialize()
 	{
-		return serialize(array($this->name, $this->arguments, $this->stopped));
+		return $this->__serialize();
 	}
 
 	/**
 	 * Serialize the event.
 	 *
-	 * @return  array  The serialized event.
+	 * @return  string  The serialized event.
 	 */
 	public function __serialize()
 	{
-		return array($this->name, $this->arguments, $this->stopped);
+		return serialize(array($this->name, $this->arguments, $this->stopped));
 	}
 
 	/**
 	 * Unserialize the event.
 	 *
-	 * @param   string  $serialized  The serialized event.
-	 * @return  void
+	 * @param   string  $data  The serialized event.
+	 * @return  mixed
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function unserialize($serialized)
+	public function unserialize($data)
 	{
-		list($this->name, $this->arguments, $this->stopped) = unserialize($serialized);
+		$this->__unserialize(unserialize($data));
 	}
 
 	/**
 	 * Unserialize the event.
 	 *
-	 * @param   array  $serialized  The serialized event.
+	 * @param   array  $data The serialized event.
 	 * @return  void
 	 */
-	public function __unserialize($serialized)
+	public function __unserialize($data)
 	{
-		list($this->name, $this->arguments, $this->stopped) = $serialized;
+		list($this->name, $this->arguments, $this->stopped) = $data;
 	}
 
 	/**
 	 * Add an error message.
 	 *
-	 * @param   string  $error  Error message.
-	 * @param   string  $key    Specific key to set the value to
-	 * @return  object  This method is chainable.
+	 * @param   string  $data
+	 * @return  self
 	 */
 	public function addResponse($data)
 	{
@@ -306,59 +304,59 @@ class Event implements ArrayAccess, Serializable, Countable
 	/**
 	 * Set the value of an event argument.
 	 *
-	 * @param   string  $name   The argument name.
+	 * @param   mixed   $offset The argument name.
 	 * @param   mixed   $value  The argument value.
 	 * @return  void
 	 * @throws  InvalidArgumentException  If the argument name is null.
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function offsetSet($name, $value)
+	public function offsetSet($offset, $value)
 	{
-		if (is_null($name))
+		if (is_null($offset))
 		{
 			throw new InvalidArgumentException('The argument name cannot be null.');
 		}
 
-		$this->setArgument($name, $value);
+		$this->setArgument($offset, $value);
 	}
 
 	/**
 	 * Remove an event argument.
 	 *
-	 * @param   string  $name  The argument name.
+	 * @param   mixed  $offset  The argument name.
 	 * @return  void
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function offsetUnset($name)
+	public function offsetUnset($offset)
 	{
-		$this->removeArgument($name);
+		$this->removeArgument($offset);
 	}
 
 	/**
 	 * Tell if the given event argument exists.
 	 *
-	 * @param   string  $name  The argument name.
+	 * @param   mixed  $offset  The argument name.
 	 * @return  boolean  True if it exists, false otherwise.
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function offsetExists($name)
+	public function offsetExists($offset)
 	{
-		return $this->hasArgument($name);
+		return $this->hasArgument($offset);
 	}
 
 	/**
 	 * Get an event argument value.
 	 *
-	 * @param   string  $name  The argument name.
+	 * @param   mixed  $offset  The argument name.
 	 * @return  mixed  The argument value or null if not existing.
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function offsetGet($name)
+	public function offsetGet($offset)
 	{
-		return $this->getArgument($name);
+		return $this->getArgument($offset);
 	}
 }

--- a/core/libraries/Hubzero/Facades/Date.php
+++ b/core/libraries/Hubzero/Facades/Date.php
@@ -41,6 +41,7 @@ class Date extends Facade
 	 */
 	public static function of($date = 'now', $tz = null)
 	{
+		$date = $date ?: 'now';
 		return new \Hubzero\Utility\Date($date, $tz);
 	}
 }

--- a/core/libraries/Hubzero/Form/Field.php
+++ b/core/libraries/Hubzero/Form/Field.php
@@ -151,6 +151,13 @@ abstract class Field
 	protected $value;
 
 	/**
+	 * The input placeholder
+	 *
+	 * @var  string
+	 */
+	protected $placeholder;
+
+	/**
 	 * The label's CSS class of the form field
 	 *
 	 * @var  mixed
@@ -170,13 +177,6 @@ abstract class Field
 	 * @var  integer
 	 */
 	protected static $generated_fieldname = '__field';
-
-	/**
-	 * Field placeholder
-	 *
-	 * @var  string
-	 */
-	public $placeholder = '';
 
 	/**
 	 * Method to instantiate the form field object.
@@ -374,7 +374,7 @@ abstract class Field
 		$this->value = $value;
 
 		// Set the field placeholder
-		$this->placeholder = (string) $element['placeholder'];
+		$this->placeholder = isset($element['placeholder']) ? (string) $element['placeholder'] : '';
 
 		// Set the CSS class of field label
 		$this->labelClass = (string) $element['labelclass'];

--- a/core/libraries/Hubzero/Form/Fields/Calendar.php
+++ b/core/libraries/Hubzero/Form/Fields/Calendar.php
@@ -71,7 +71,7 @@ class Calendar extends Field
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')
 		{
-			$this->value = strftime($format);
+			$this->value = date($format);
 		}
 
 		// If a known filter is given use it.

--- a/core/libraries/Hubzero/Html/Builder/Behavior.php
+++ b/core/libraries/Hubzero/Html/Builder/Behavior.php
@@ -891,7 +891,7 @@ class Behavior
 			elseif (!is_array($v) && !is_object($v))
 			{
 				$object .= ' ' . $k . ': ';
-				$object .= (is_numeric($v) || strpos($v, '\\') === 0) ? (is_numeric($v)) ? $v : substr($v, 1) : "'" . $v . "'";
+				$object .= (is_numeric($v) || strpos($v, '\\') === 0) ? (is_numeric($v) ? $v : substr($v, 1)) : "'" . $v . "'";
 				$object .= ',';
 			}
 			else

--- a/core/libraries/Hubzero/Language/Translator.php
+++ b/core/libraries/Hubzero/Language/Translator.php
@@ -224,6 +224,11 @@ class Translator extends Obj
 
 			foreach ($this->callbacks as $callback => $value)
 			{
+				if (!$callback)
+				{
+					continue;
+				}
+
 				$method = 'get' . ucfirst($callback);
 
 				if (method_exists($class, $method))

--- a/core/libraries/Hubzero/Menu/Type/Base.php
+++ b/core/libraries/Hubzero/Menu/Type/Base.php
@@ -39,6 +39,34 @@ class Base extends Obj
 	protected $_active = 0;
 
 	/**
+	 * Filter by set language
+	 *
+	 * @var string
+	 */
+	protected $language_filter;
+
+	/**
+	 * Default language
+	 *
+	 * @var string
+	 */
+	protected $language;
+
+	/**
+	 * Access level
+	 *
+	 * @var int
+	 */
+	protected $access = 1;
+
+	/**
+	 * Database connection
+	 *
+	 * @var object
+	 */
+	protected $db = null;
+
+	/**
 	 * Menu instances container.
 	 *
 	 * @var  array

--- a/core/libraries/Hubzero/Module/Loader.php
+++ b/core/libraries/Hubzero/Module/Loader.php
@@ -131,7 +131,7 @@ class Loader
 		{
 			if ($modules[$i]->position == $position)
 			{
-				$result[] =& $modules[$i];
+				$result[] = $modules[$i];
 			}
 		}
 

--- a/core/libraries/Hubzero/Oauth/Server.php
+++ b/core/libraries/Hubzero/Oauth/Server.php
@@ -29,6 +29,13 @@ class Server
 	private $server = null;
 
 	/**
+	 * Config values
+	 *
+	 * @var array
+	 */
+	private $config = array();
+
+	/**
 	 * Constructor to setup setup server
 	 *
 	 * @param   object  $storage

--- a/core/libraries/Hubzero/Pathway/Trail.php
+++ b/core/libraries/Hubzero/Pathway/Trail.php
@@ -148,7 +148,7 @@ class Trail implements \Iterator, \ArrayAccess, \Countable
 	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
-		return reset($this->items);
+		reset($this->items);
 	}
 
 	/**
@@ -184,13 +184,13 @@ class Trail implements \Iterator, \ArrayAccess, \Countable
 	#[\ReturnTypeWillChange]
 	public function next()
 	{
-		return next($this->items);
+		next($this->items);
 	}
 
 	/**
 	 * Is current position valid?
 	 *
-	 * @return  voolean
+	 * @return  boolean
 	 */
 
 	#[\ReturnTypeWillChange]

--- a/core/libraries/Hubzero/Plugin/Loader.php
+++ b/core/libraries/Hubzero/Plugin/Loader.php
@@ -230,7 +230,7 @@ class Loader implements LoaderInterface
 	 * @param   object   $plugin  The plugin data.
 	 * @return  boolean  True on success.
 	 */
-	protected function init(&$plugin, $autocreate = true, $dispatcher = null)
+	protected function init($plugin, $autocreate = true, $dispatcher = null)
 	{
 		$plugin->type = preg_replace('/[^A-Z0-9_\.-]/i', '', $plugin->type);
 		$plugin->name = preg_replace('/[^A-Z0-9_\.-]/i', '', $plugin->name);

--- a/core/libraries/Hubzero/Plugin/Plugin.php
+++ b/core/libraries/Hubzero/Plugin/Plugin.php
@@ -63,6 +63,13 @@ class Plugin extends Obj
 	protected $_autoloadLanguage = false;
 
 	/**
+	 * The triggered event
+	 *
+	 * @var object
+	 */
+	public $event;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   object  $subject  Event dispatcher

--- a/core/libraries/Hubzero/Session/Storage/Apc.php
+++ b/core/libraries/Hubzero/Session/Storage/Apc.php
@@ -49,24 +49,26 @@ class Apc extends Store
 	 * Read the data for a particular session identifier from the
 	 * SessionHandler backend.
 	 *
-	 * @param   string  $session_id  The session identifier.
+	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
-		return (string) apc_fetch($this->key($session_id));
+		return (string) apc_fetch($this->key($id));
 	}
 
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		return apc_store($this->key($session_id), $session_data, ini_get("session.gc_maxlifetime"));
+		return apc_store($this->key($id), $data, ini_get("session.gc_maxlifetime"));
 	}
 
 	/**
@@ -75,9 +77,10 @@ class Apc extends Store
 	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		return apc_delete($this->key($session_id));
+		return apc_delete($this->key($id));
 	}
 
 	/**

--- a/core/libraries/Hubzero/Session/Storage/Database.php
+++ b/core/libraries/Hubzero/Session/Storage/Database.php
@@ -72,7 +72,8 @@ class Database extends Store
 	 * @param   string  $id  The session identifier.
 	 * @return  mixed   The session data on success, False on failure.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
 		// Get the database connection object and verify its connected.
 		if (!$this->connection->connected())
@@ -86,7 +87,7 @@ class Database extends Store
 			$query = $this->connection->getQuery()
 				->select('data')
 				->from('#__session')
-				->whereEquals('session_id', $session_id);
+				->whereEquals('session_id', $id);
 
 			$this->connection->setQuery($query->toString());
 
@@ -101,11 +102,12 @@ class Database extends Store
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
 		// Skip session write on API and command line calls
 		if ($this->skipWrites)
@@ -125,11 +127,11 @@ class Database extends Store
 				$query = $this->connection->getQuery()
 					->update('#__session')
 					->set(array(
-						'data' => $session_data,
+						'data' => $data,
 						'time' => (int) time(),
 						'ip'   => $_SERVER['REMOTE_ADDR']
 					))
-					->whereEquals('session_id', $session_id);
+					->whereEquals('session_id', $id);
 
 				// Try to update the session data in the database table.
 				$this->connection->setQuery($query->toString());
@@ -165,7 +167,8 @@ class Database extends Store
 	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
 		// Get the database connection object and verify its connected.
 		if (!$this->connection->connected())
@@ -177,7 +180,7 @@ class Database extends Store
 		{
 			$query = $this->connection->getQuery()
 				->delete('#__session')
-				->whereEquals('session_id', $session_id);
+				->whereEquals('session_id', $id);
 
 			// Remove a session from the database.
 			$this->connection->setQuery($query->toString());
@@ -193,10 +196,11 @@ class Database extends Store
 	/**
 	 * Garbage collect stale sessions from the SessionHandler backend.
 	 *
-	 * @param   integer  $lifetime  The maximum age of a session.
+	 * @param   int  $maxlifetime  The maximum age of a session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function gc($lifetime = 1440)
+	#[\ReturnTypeWillChange]
+	public function gc($maxlifetime = null)
 	{
 		// Get the database connection object and verify its connected.
 		if (!$this->connection->connected())
@@ -205,7 +209,7 @@ class Database extends Store
 		}
 
 		// Determine the timestamp threshold with which to purge old sessions.
-		$past = time() - $lifetime;
+		$past = time() - $maxlifetime;
 
 		try
 		{
@@ -227,10 +231,10 @@ class Database extends Store
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
+	 * @param   int  $id  Session Id
 	 * @return  object
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
 		$query = $this->connection->getQuery()
 			->select('*')

--- a/core/libraries/Hubzero/Session/Storage/Eaccelerator.php
+++ b/core/libraries/Hubzero/Session/Storage/Eaccelerator.php
@@ -48,24 +48,26 @@ class Eaccelerator extends Store
 	/**
 	 * Read the data for a particular session identifier from the SessionHandler backend.
 	 *
-	 * @param   string  $session_id  The session identifier.
+	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
-		return (string) eaccelerator_get($this->key($session_id));
+		return (string) eaccelerator_get($this->key($id));
 	}
 
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		return eaccelerator_put($this->key($session_id), $session_data, ini_get("session.gc_maxlifetime"));
+		return eaccelerator_put($this->key($id), $data, ini_get("session.gc_maxlifetime"));
 	}
 
 	/**
@@ -74,17 +76,19 @@ class Eaccelerator extends Store
 	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		return eaccelerator_rm($this->key($session_id));
+		return eaccelerator_rm($this->key($id));
 	}
 
 	/**
 	 * Garbage collect stale sessions from the SessionHandler backend.
 	 *
-	 * @param   integer  $maxlifetime  The maximum age of a session.
+	 * @param   int  $maxlifetime  The maximum age of a session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime = null)
 	{
 		eaccelerator_gc();
@@ -94,14 +98,14 @@ class Eaccelerator extends Store
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
+	 * @param   int  $id  Session Id
 	 * @return  object
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
 		$session = new Object;
-		$session->session_id = $session_id;
-		$session->data       = $this->read($session_id);
+		$session->session_id = $id;
+		$session->data       = $this->read($id);
 
 		return $session;
 	}

--- a/core/libraries/Hubzero/Session/Storage/File.php
+++ b/core/libraries/Hubzero/Session/Storage/File.php
@@ -68,9 +68,10 @@ class File extends Store
 	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
-		if ($this->files->exists($path = $this->path . DS . $session_id))
+		if ($this->files->exists($path = $this->path . DS . $id))
 		{
 			return $this->files->get($path);
 		}
@@ -81,13 +82,14 @@ class File extends Store
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		$this->files->put($this->path . DS . $session_id, $session_data, true);
+		$this->files->put($this->path . DS . $id, $data, true);
 	}
 
 	/**
@@ -97,17 +99,19 @@ class File extends Store
 	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		$this->files->delete($this->path . DS . $session_id);
+		$this->files->delete($this->path . DS . $id);
 	}
 
 	/**
 	 * Garbage collect stale sessions from the SessionHandler backend.
 	 *
-	 * @param   integer  $maxlifetime  The maximum age of a session.
+	 * @param   int  $maxlifetime  The maximum age of a session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime = null)
 	{
 		$files = $this->files->files($this->path);
@@ -131,14 +135,14 @@ class File extends Store
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
+	 * @param   int  $id  Session Id
 	 * @return  object
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
 		$session = new Object;
-		$session->session_id = $session_id;
-		$session->data       = $this->read($session_id);
+		$session->session_id = $id;
+		$session->data       = $this->read($id);
 
 		return $session;
 	}

--- a/core/libraries/Hubzero/Session/Storage/Memcache.php
+++ b/core/libraries/Hubzero/Session/Storage/Memcache.php
@@ -8,6 +8,7 @@
 namespace Hubzero\Session\Storage;
 
 use Hubzero\Session\Store;
+use Hubzero\Base\Obj;
 
 /**
  * Memcache session storage handler
@@ -33,7 +34,7 @@ class Memcache extends Store
 	/**
 	 * Use compression?
 	 *
-	 * @var  integer
+	 * @var  int
 	 */
 	private $compress = false;
 
@@ -92,6 +93,7 @@ class Memcache extends Store
 	 * @param   string   $name       The name of the session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $name)
 	{
 		$this->engine = new \Memcache;
@@ -114,6 +116,7 @@ class Memcache extends Store
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		return $this->engine->close();
@@ -125,9 +128,10 @@ class Memcache extends Store
 	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
-		$key = $this->key($session_id);
+		$key = $this->key($id);
 
 		$this->expiration($key);
 
@@ -137,13 +141,14 @@ class Memcache extends Store
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		$key = $this->key($session_id);
+		$key = $this->key($id);
 
 		if ($this->engine->get($key . '_expire'))
 		{
@@ -155,11 +160,11 @@ class Memcache extends Store
 		}
 		if ($this->engine->get($key))
 		{
-			$this->engine->replace($key, $session_data, $this->compress);
+			$this->engine->replace($key, $data, $this->compress);
 		}
 		else
 		{
-			$this->engine->set($key, $session_data, $this->compress);
+			$this->engine->set($key, $data, $this->compress);
 		}
 
 		return;
@@ -168,12 +173,13 @@ class Memcache extends Store
 	/**
 	 * Destroy the data for a particular session identifier in the SessionHandler backend.
 	 *
-	 * @param   string   $session_id  The session identifier.
+	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		$key = $this->key($session_id);
+		$key = $this->key($id);
 
 		$this->engine->delete($key . '_expire');
 
@@ -183,14 +189,14 @@ class Memcache extends Store
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
-	 * @return  object
+	 * @param   int  $id  Session Id
+	 * @return  Obj
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
-		$session = new Object;
-		$session->session_id = $session_id;
-		$session->data       = $this->read($session_id);
+		$session = new Obj;
+		$session->session_id = $id;
+		$session->data       = $this->read($id);
 
 		return $session;
 	}
@@ -213,7 +219,7 @@ class Memcache extends Store
 		{
 			if (strpos($value->name, $this->prefix) === 0)
 			{
-				$session = new Object;
+				$session = new Obj;
 				$session->session_id = $value->name;
 				$session->data       = $value;
 

--- a/core/libraries/Hubzero/Session/Storage/Memcached.php
+++ b/core/libraries/Hubzero/Session/Storage/Memcached.php
@@ -33,7 +33,7 @@ class Memcached extends Store
 	/**
 	 * Use compression?
 	 *
-	 * @var  integer
+	 * @var  int
 	 */
 	private $compress = false;
 
@@ -92,6 +92,7 @@ class Memcached extends Store
 	 * @param   string   $name       The name of the session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $name)
 	{
 		$this->engine = new \Memcached;
@@ -114,6 +115,7 @@ class Memcached extends Store
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		// $this->engine->close();
@@ -123,12 +125,13 @@ class Memcached extends Store
 	/**
 	 * Read the data for a particular session identifier from the SessionHandler backend.
 	 *
-	 * @param   string  $session_id  The session identifier.
+	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
-		$key = $this->key($session_id);
+		$key = $this->key($id);
 
 		$this->expiration($key);
 
@@ -138,13 +141,14 @@ class Memcached extends Store
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		$key = $this->key($session_id);
+		$key = $this->key($id);
 
 		if ($this->engine->get($key . '_expire'))
 		{
@@ -156,11 +160,11 @@ class Memcached extends Store
 		}
 		if ($this->engine->get($key))
 		{
-			$this->engine->replace($key, $session_data);
+			$this->engine->replace($key, $data);
 		}
 		else
 		{
-			$this->engine->set($key, $session_data);
+			$this->engine->set($key, $data);
 		}
 
 		return;
@@ -169,12 +173,13 @@ class Memcached extends Store
 	/**
 	 * Destroy the data for a particular session identifier in the SessionHandler backend.
 	 *
-	 * @param   string   $session_id  The session identifier.
+	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		$key = $this->key($session_id);
+		$key = $this->key($id);
 
 		$this->engine->delete($key . '_expire');
 
@@ -186,9 +191,10 @@ class Memcached extends Store
 	 *
 	 * -- Not Applicable in memcached --
 	 *
-	 * @param   integer  $maxlifetime  The maximum age of a session.
+	 * @param   int  $maxlifetime  The maximum age of a session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime = null)
 	{
 		return true;
@@ -197,14 +203,14 @@ class Memcached extends Store
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
+	 * @param   int  $id  Session Id
 	 * @return  object
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
 		$session = new Object;
-		$session->session_id = $session_id;
-		$session->data       = $this->read($session_id);
+		$session->session_id = $id;
+		$session->data       = $this->read($id);
 
 		return $session;
 	}

--- a/core/libraries/Hubzero/Session/Storage/Redis.php
+++ b/core/libraries/Hubzero/Session/Storage/Redis.php
@@ -65,6 +65,7 @@ class Redis extends Store
 	 * @param   string   $name       The name of the session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $name)
 	{
 		$this->database = RedisDatabase::connect('default');
@@ -76,6 +77,7 @@ class Redis extends Store
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		$this->database->disconnect();
@@ -84,13 +86,14 @@ class Redis extends Store
 	/**
 	 * Read session hash for Id
 	 *
-	 * @param   string  $session_id  Session Id
+	 * @param   string  $id  Session Id
 	 * @return  mixed   Session Data
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
 		// get session hash
-		$session = $this->database->hgetall($this->key($session_id));
+		$session = $this->database->hgetall($this->key($id));
 
 		// return session data
 		return (isset($session['data'])) ? $session['data'] : null;
@@ -103,21 +106,22 @@ class Redis extends Store
 	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
 		$data = array(
-			'session_id' => $session_id,
+			'session_id' => $id,
 			'client_id'  => \App::get('client')->id,
 			'guest'      => \User::isGuest(),
 			'time'       => time(),
-			'data'       => $session_data,
+			'data'       => $data,
 			'userid'     => \User::get('id'),
 			'username'   => \User::get('username'),
 			'usertype'   => null,
 			'ip'         => $_SERVER['REMOTE_ADDR']
 		);
 
-		$saved = $this->database->hmset($this->key($session_id), $data);
+		$saved = $this->database->hmset($this->key($id), $data);
 
 		return $saved;
 	}
@@ -125,12 +129,13 @@ class Redis extends Store
 	/**
 	 * Delete session hash
 	 *
-	 * @param  string  $session_id  Session Id
+	 * @param  string  $id  Session Id
 	 * @return boolean              Destroyed or not
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		if (!$this->database->del($this->key($session_id)))
+		if (!$this->database->del($this->key($id)))
 		{
 			return false;
 		}
@@ -140,9 +145,10 @@ class Redis extends Store
 	/**
 	 * Garbage collect stale sessions from the SessionHandler backend.
 	 *
-	 * @param   integer  $maxlifetime  The maximum age of a session.
+	 * @param   int  $maxlifetime  The maximum age of a session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime = null)
 	{
 		//'redis gc';
@@ -151,12 +157,12 @@ class Redis extends Store
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
+	 * @param   int  $id  Session Id
 	 * @return  object
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
-		return (object) $this->database->hgetall($session_id);
+		return (object) $this->database->hgetall($id);
 	}
 
 	/**

--- a/core/libraries/Hubzero/Session/Storage/WinCache.php
+++ b/core/libraries/Hubzero/Session/Storage/WinCache.php
@@ -48,35 +48,38 @@ class WinCache extends Store
 	/**
 	 * Read the data for a particular session identifier from the SessionHandler backend.
 	 *
-	 * @param   string  $session_id  The session identifier.
+	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
-		return (string) wincache_ucache_get($this->key($session_id));
+		return (string) wincache_ucache_get($this->key($id));
 	}
 
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		return wincache_ucache_set($this->key($session_id), $session_data, ini_get("session.gc_maxlifetime"));
+		return wincache_ucache_set($this->key($id), $data, ini_get("session.gc_maxlifetime"));
 	}
 
 	/**
 	 * Destroy the data for a particular session identifier in the SessionHandler backend.
 	 *
-	 * @param   string   $session_id  The session identifier.
+	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		return wincache_ucache_delete($this->key($session_id));
+		return wincache_ucache_delete($this->key($id));
 	}
 
 	/**

--- a/core/libraries/Hubzero/Session/Storage/Xcache.php
+++ b/core/libraries/Hubzero/Session/Storage/Xcache.php
@@ -48,46 +48,49 @@ class Xcache extends Store
 	/**
 	 * Read the data for a particular session identifier from the SessionHandler backend.
 	 *
-	 * @param   string  $session_id  The session identifier.
+	 * @param   string  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read($id)
 	{
 		// Check if id exists
-		if (!xcache_isset($this->key($session_id)))
+		if (!xcache_isset($this->key($id)))
 		{
 			return;
 		}
 
-		return (string) xcache_get($this->key($session_id));
+		return (string) xcache_get($this->key($id));
 	}
 
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $data  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function write($session_id, $session_data)
+	#[\ReturnTypeWillChange]
+	public function write($id, $data)
 	{
-		return xcache_set($this->key($session_id), $session_data, ini_get("session.gc_maxlifetime"));
+		return xcache_set($this->key($id), $data, ini_get("session.gc_maxlifetime"));
 	}
 
 	/**
 	 * Destroy the data for a particular session identifier in the SessionHandler backend.
 	 *
-	 * @param   string   $session_id  The session identifier.
+	 * @param   string   $id  The session identifier.
 	 * @return  boolean  True on success, false otherwise.
 	 */
-	public function destroy($session_id)
+	#[\ReturnTypeWillChange]
+	public function destroy($id)
 	{
-		if (!xcache_isset($this->key($session_id)))
+		if (!xcache_isset($this->key($id)))
 		{
 			return true;
 		}
 
-		return xcache_unset($this->key($session_id));
+		return xcache_unset($this->key($id));
 	}
 
 	/**

--- a/core/libraries/Hubzero/Session/Store.php
+++ b/core/libraries/Hubzero/Session/Store.php
@@ -84,13 +84,13 @@ abstract class Store extends Obj implements SessionHandlerInterface
 	/**
 	 * Open the SessionHandler backend.
 	 *
-	 * @param   string   $save_path  The path to the session object.
+	 * @param   string   $path  The path to the session object.
 	 * @param   string   $name       The name of the session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function open($save_path, $name)
+	public function open($path, $name)
 	{
 		return true;
 	}
@@ -111,26 +111,26 @@ abstract class Store extends Obj implements SessionHandlerInterface
 	 * Read the data for a particular session identifier from the
 	 * SessionHandler backend.
 	 *
-	 * @param   string  $id  The session identifier.
+	 * @param   string|false  $id  The session identifier.
 	 * @return  string  The session data.
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function read($session_id)
+	public function read($id)
 	{
-		return;
+		return false;
 	}
 
 	/**
 	 * Write session data to the SessionHandler backend.
 	 *
-	 * @param   string   $session_id    The session identifier.
-	 * @param   string   $session_data  The session data.
+	 * @param   string   $id    The session identifier.
+	 * @param   string   $ata  The session data.
 	 * @return  boolean  True on success, false otherwise.
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function write($session_id, $session_data)
+	public function write($d, $data)
 	{
 		return true;
 	}
@@ -144,7 +144,7 @@ abstract class Store extends Obj implements SessionHandlerInterface
 	 */
 
 	#[\ReturnTypeWillChange]
-	public function destroy($session_id)
+	public function destroy($id)
 	{
 		return true;
 	}
@@ -152,7 +152,7 @@ abstract class Store extends Obj implements SessionHandlerInterface
 	/**
 	 * Garbage collect stale sessions from the SessionHandler backend.
 	 *
-	 * @param   integer  $maxlifetime  The maximum age of a session.
+	 * @param   int  $maxlifetime  The maximum age of a session.
 	 * @return  boolean  True on success, false otherwise.
 	 */
 
@@ -165,13 +165,13 @@ abstract class Store extends Obj implements SessionHandlerInterface
 	/**
 	 * Get single session data as an object
 	 *
-	 * @param   integer  $session_id  Session Id
+	 * @param   int  $id  Session Id
 	 * @return  object
 	 */
-	public function session($session_id)
+	public function session($id)
 	{
-		$session = new Object;
-		$session->id = $session_id;
+		$session = new Obj;
+		$session->id = $id;
 
 		return $session;
 	}

--- a/core/libraries/Hubzero/User/User.php
+++ b/core/libraries/Hubzero/User/User.php
@@ -133,9 +133,7 @@ class User extends \Hubzero\Database\Relational
 	 */
 	public function serialize()
 	{
-		$attr = $this->getAttributes();
-
-		$attr['guest'] = $this->guest;
+		$attr = $this->__serialize();
 
 		return serialize($attr);
 	}
@@ -163,17 +161,8 @@ class User extends \Hubzero\Database\Relational
 	 */
 	public function unserialize($data)
 	{
-		$this->__construct();
-
 		$data = unserialize($data);
-
-		if (isset($data['guest']))
-		{
-			$this->guest = $data['guest'];
-			unset($data['guest']);
-		}
-
-		$this->set($data);
+		$this->__unserialize($data);
 	}
 
 	/**

--- a/core/libraries/Hubzero/Utility/Arr.php
+++ b/core/libraries/Hubzero/Utility/Arr.php
@@ -403,7 +403,10 @@ class Arr
 		self::$sortKey       = (array) $k;
 		self::$sortLocale    = $locale;
 
-		usort($a, array(__CLASS__, '_sortObjects'));
+		usort($a, function($a, $b)
+		{
+			return static::_sortObjects($a, $b);
+		});
 
 		self::$sortCase      = null;
 		self::$sortDirection = null;

--- a/core/libraries/Hubzero/Utility/Date.php
+++ b/core/libraries/Hubzero/Utility/Date.php
@@ -74,14 +74,14 @@ class Date extends DateTime
 	/**
 	 * Constructor.
 	 *
-	 * @param   string  $date  String in a format accepted by strtotime(), defaults to "now".
-	 * @param   mixed   $tz    Time zone to be used for the date.
+	 * @param   string  $datetime  String in a format accepted by strtotime(), defaults to "now".
+	 * @param   mixed   $timezone  Time zone to be used for the date.
+	 * @param   bool    $ignoreDst
 	 * @return  void
 	 * @throws  Exception
 	 */
-
 	#[\ReturnTypeWillChange]
-	public function __construct($date = 'now', $tz = null, $ignoreDst = false)
+	public function __construct($datetime = 'now', $timezone = null, $ignoreDst = false)
 	{
 		// Create the base GMT and server time zone objects.
 		if (empty(self::$gmt) || empty(self::$stz))
@@ -90,21 +90,20 @@ class Date extends DateTime
 			self::$stz = new DateTimeZone(@date_default_timezone_get());
 		}
 
-		$tz = self::getTimeZoneObject($tz, $ignoreDst);
-
+		$timezone = self::getTimeZoneObject($timezone, $ignoreDst);
 
 		// If the date is numeric assume a unix timestamp and convert it.
 		date_default_timezone_set('UTC');
-		$date = is_numeric($date) ? date('c', $date) : $date;
+		$datetime = is_numeric($datetime) ? date('c', $datetime) : $datetime;
 
 		// Call the DateTime constructor.
-		parent::__construct($date, $tz);
+		parent::__construct($datetime, $timezone);
 
 		// reset the timezone for 3rd party libraries/extension that does not use Date
 		date_default_timezone_set(self::$stz->getName());
 
 		// Set the timezone object for access later.
-		$this->_tz = $tz;
+		$this->_tz = $timezone;
 	}
 
 	/**
@@ -355,7 +354,6 @@ class Date extends DateTime
 	 * @param   object  $tz  The new DateTimeZone object.
 	 * @return  object  The old DateTimeZone object.
 	 */
-
 	#[\ReturnTypeWillChange]
 	public function setTimezone($tz)
 	{
@@ -374,6 +372,7 @@ class Date extends DateTime
 	 *
 	 * @param   string  $modifier
 	 * @return  object
+	 * @deprecated
 	 */
 
 	#[\ReturnTypeWillChange]
@@ -387,6 +386,7 @@ class Date extends DateTime
 	 *
 	 * @param   string  $modifier
 	 * @return  object
+	 * @deprecated
 	 */
 
 	#[\ReturnTypeWillChange]

--- a/core/libraries/Hubzero/Utility/Str.php
+++ b/core/libraries/Hubzero/Utility/Str.php
@@ -704,12 +704,12 @@ class Str
 		return false;
 	}
 
-		/**
-   * Replaces &amp; with & for XHTML compliance
-   *
-   * @param   string  $text  Text to process
-   * @return  string  Processed string.
-   */
+	/**
+	 * Replaces &amp; with & for XHTML compliance
+	 *
+	 * @param   string  $text  Text to process
+	 * @return  string  Processed string.
+	 */
 	public static function ampReplace($text)
 	{
 		$text = str_replace('&&', '*--*', $text ? $text : '');

--- a/core/modules/mod_adminmenu/node.php
+++ b/core/modules/mod_adminmenu/node.php
@@ -84,7 +84,7 @@ class Node extends Obj
 		{
 			$link = \Route::url($link);
 		}
-		$this->link   = \Hubzero\Utility\Str::ampReplace($link);
+		$this->link   = $link ? \Hubzero\Utility\Str::ampReplace($link) : '';
 		$this->class  = $class;
 		$this->active = $active;
 

--- a/core/modules/mod_featuredresource/helper.php
+++ b/core/modules/mod_featuredresource/helper.php
@@ -39,10 +39,10 @@ class Helper extends Module
 		$filters = array(
 			'limit'      => 1,
 			'start'      => 0,
-			'type'       => trim($this->params->get('type','')),
+			'type'       => $this->params->get('type', ''),
 			'sortby'     => 'random',
-			'minranking' => trim($this->params->get('minranking','')),
-			'tag'        => trim($this->params->get('tag','')),
+			'minranking' => trim((string)$this->params->get('minranking', '6.0')),
+			'tag'        => trim((string)$this->params->get('tag', '')),
 			'access'     => 'public',
 			'published'  => 1,
 			'standalone' => 1,
@@ -55,12 +55,12 @@ class Helper extends Module
 			->rows()
 			->fieldsByKey('id');
 
-                if (!empty($rows))
-                {
-		    $id = array_rand($rows);
+		if (!empty($rows))
+		{
+			$id = array_rand($rows);
 
-		    $row = Entry::oneOrNew((isset($rows[$id]) ? $rows[$id] : 0));
-                }
+			$row = Entry::oneOrNew((isset($rows[$id]) ? $rows[$id] : 0));
+		}
 
 		$this->cls = trim($this->params->get('moduleclass_sfx',''));
 		$this->txt_length = trim($this->params->get('txt_length',''));
@@ -98,19 +98,22 @@ class Helper extends Module
 				$thumb = DS . trim($config->get('defaultpic',''));
 			}
 
-			$row->typetitle = trim(stripslashes($row->typetitle));
-			if (substr($row->typetitle, -1, 1) == 's' && substr($row->typetitle, -3, 3) != 'ies')
+			if ($row->typetitle)
 			{
-				$row->typetitle = substr($row->typetitle, 0, strlen($row->typetitle) - 1);
+				$row->typetitle = trim($row->typetitle);
+				if (substr($row->typetitle, -1, 1) == 's' && substr($row->typetitle, -3, 3) != 'ies')
+				{
+					$row->typetitle = substr($row->typetitle, 0, strlen($row->typetitle) - 1);
+				}
 			}
 
 			$this->id    = $id;
 			$this->thumb = $thumb;
 		}
-                else
-                {
-                    $row = '';
-                }
+		else
+		{
+			$row = '';
+		}
 
 		$this->row = $row;
 

--- a/core/modules/mod_groups/helper.php
+++ b/core/modules/mod_groups/helper.php
@@ -66,7 +66,7 @@ class Helper extends Module
 		}
 
 		// Last 24 hours
-		$lastDay = with(new Date('now'))->subtract('1 Day')->toSql();
+		$lastDay = with(new Date('now'))->modify('-1 Day')->toSql();
 
 		$database->setQuery("SELECT count(*) FROM `#__xgroups` WHERE created >= '$lastDay' AND type='$type'");
 		$this->pastDay = $database->loadResult();

--- a/core/modules/mod_mytools/helper.php
+++ b/core/modules/mod_mytools/helper.php
@@ -52,7 +52,7 @@ class Helper extends Module
 				if (strstr($item, '_r'))
 				{
 					$bits = explode('_r', $item);
-					$rev  = (is_array($bits) && count($bits > 1)) ? array_pop($bits) : '';
+					$rev  = (is_array($bits) && count($bits) > 1) ? array_pop($bits) : '';
 					$item = trim(implode('_r', $bits));
 				}
 

--- a/core/plugins/cron/activity/activity.php
+++ b/core/plugins/cron/activity/activity.php
@@ -98,7 +98,7 @@ class plgCronActivity extends \Hubzero\Plugin\Plugin
 
 			// Find all users that want weekly digests and the last time the digest
 			// was sent was NEVER or older than 1 month ago.
-			$previous = Date::of('now')->subtract('1 ' . $interval)->toSql();
+			$previous = Date::of('now')->modify('-1 ' . $interval)->toSql();
 
 			// Set up the query
 			$query = "SELECT DISTINCT(scope_id)

--- a/core/plugins/cron/publications/publications.php
+++ b/core/plugins/cron/publications/publications.php
@@ -474,7 +474,7 @@ class plgCronPublications extends \Hubzero\Plugin\Plugin
 		include_once Component::path('com_publications') . '/models/publication.php';
 
 		$params = $job->params;
-		$yesterday = !empty($job->params['startdate']) ? $job->params['startdate'] : Date::of()->subtract('1 day')->format('Y-m-d 00:00:00');
+		$yesterday = !empty($job->params['startdate']) ? $job->params['startdate'] : Date::of()->modify('-1 day')->format('Y-m-d 00:00:00');
 		$today = Date::of()->format('Y-m-d 00:00:00');
 
 		$versions = \Components\Publications\Models\Orm\Version::all()

--- a/core/plugins/cron/resources/resources.php
+++ b/core/plugins/cron/resources/resources.php
@@ -370,7 +370,7 @@ class plgCronResources extends \Hubzero\Plugin\Plugin
 		$interval = strtoupper($params->get('digest_frequency', '1 month'));
 
 		$now      = Date::of('now')->toSql();
-		$previous = Date::of('now')->subtract($interval)->toSql();
+		$previous = Date::of('now')->modify('-' . $interval)->toSql();
 
 		// Get records that haven't been processed
 		$db = App::get('db');

--- a/core/plugins/groups/calendar/calendar.php
+++ b/core/plugins/groups/calendar/calendar.php
@@ -486,7 +486,7 @@ class plgGroupsCalendar extends \Hubzero\Plugin\Plugin
 				// Kevin: Don't change this value. Everyone else is wrong.
 				// Seriously this is the correct way to do all-day events.
 				// Previous entries may need to be corrected, but future events will be correct.
-				$endDay = Date::of($event->end)->subtract('24 hours');
+				$endDay = Date::of($event->end)->modify('-24 hours');
 				if ($endDay < $up)
 				{
 					$event->end = Date::of($event->start)->add('24 hours')->format($timeFormat);
@@ -578,7 +578,7 @@ class plgGroupsCalendar extends \Hubzero\Plugin\Plugin
 				$endDate = $view->event->get('publish_down');
 				if ($allDay == '1' && !empty($endDate))
 				{
-					$newEndDate = Date::of($endDate)->subtract('24 hours')->toSql();
+					$newEndDate = Date::of($endDate)->modify('-24 hours')->toSql();
 					$view->event->set('publish_down', $newEndDate);
 				}
 			}

--- a/core/plugins/groups/calendar/views/calendar/tmpl/details.php
+++ b/core/plugins/groups/calendar/views/calendar/tmpl/details.php
@@ -97,7 +97,7 @@ $ignoreDst = $params->get('ignore_dst', 0) == 1 ? true : false;
 					<?php
 						// check to see if its a single date all day event
 						$d1 = Date::of($publish_up);
-						$d2 = Date::of($publish_down)->subtract('24 hours');
+						$d2 = Date::of($publish_down)->modify('-24 hours');
 						if ($d1 == $d2 || !$publish_down || $publish_down == '0000-00-00 00:00:00')
 						{
 							echo $d1->format('l, F d, Y', true);

--- a/core/plugins/members/blog/views/browse/tmpl/default.php
+++ b/core/plugins/members/blog/views/browse/tmpl/default.php
@@ -72,7 +72,7 @@ $this->css()
 					<fieldset class="entry-search">
 						<legend><?php echo Lang::txt('PLG_MEMBERS_BLOG_SEARCH_LEGEND'); ?></legend>
 						<label for="entry-search-field"><?php echo Lang::txt('PLG_MEMBERS_BLOG_SEARCH_LABEL'); ?></label>
-						<input type="text" name="search" id="entry-search-field" value="<?php echo $this->escape(utf8_encode(stripslashes($this->filters['search']))); ?>" placeholder="<?php echo Lang::txt('PLG_MEMBERS_BLOG_SEARCH_PLACEHOLDER'); ?>" />
+						<input type="text" name="search" id="entry-search-field" value="<?php echo ($this->filters['search'] ? $this->escape(utf8_encode(stripslashes($this->filters['search']))) : ''); ?>" placeholder="<?php echo Lang::txt('PLG_MEMBERS_BLOG_SEARCH_PLACEHOLDER'); ?>" />
 					</fieldset>
 				</div><!-- / .container -->
 

--- a/core/plugins/members/citations/citations.php
+++ b/core/plugins/members/citations/citations.php
@@ -333,10 +333,7 @@ class plgMembersCitations extends \Hubzero\Plugin\Plugin
 		$view->types = $ct;
 
 		// OpenURL
-		$openURL = $this->_handleOpenURL();
-		$view->openurl['link'] = $openURL['link'];
-		$view->openurl['text'] = $openURL['text'];
-		$view->openurl['icon'] = $openURL['icon'];
+		$view->openurl = $this->_handleOpenURL();
 
 		// Output HTML
 		foreach ($this->getErrors() as $error)
@@ -1525,7 +1522,7 @@ class plgMembersCitations extends \Hubzero\Plugin\Plugin
 	/**
 	 * Uses URL to determine OpenURL server
 	 *
-	 * @return  mixed
+	 * @return  array<string,string>
 	 */
 	private function _handleOpenURL()
 	{
@@ -1585,13 +1582,11 @@ class plgMembersCitations extends \Hubzero\Plugin\Plugin
 		// if we have resolver set vars for creating open urls
 		if ($resolver != null)
 		{
-			$openURL['link'] = $resolver->baseURL;
-			$openURL['text'] = $resolver->linkText;
-			$openURL['icon'] = $resolver->linkIcon;
-
-			return $openURL;
+			$openurl['link'] = $resolver->baseURL;
+			$openurl['text'] = $resolver->linkText;
+			$openurl['icon'] = $resolver->linkIcon;
 		}
 
-		return false;
+		return $openurl;
 	}
 }

--- a/core/plugins/members/contributions/views/display/tmpl/default.php
+++ b/core/plugins/members/contributions/views/display/tmpl/default.php
@@ -214,11 +214,12 @@ foreach ($this->results as $category)
 		$html .= '<ol class="search results">' . "\n";
 		foreach ($category as $row)
 		{
+			$row->href = $row->href ? $row->href : '';
 			$row->href = str_replace('&amp;', '&', $row->href);
 			$row->href = str_replace('&', '&amp;', $row->href);
 
 			// Does this category have a unique output display?
-			$func = 'plgMembers' . ucfirst($row->section) . 'Out';
+			$func = 'plgMembers' . ($row->section ? ucfirst($row->section) : '') . 'Out';
 			// Check if a method exist (using old Plugin style)
 			$obj = 'plgMembers' . ucfirst($this->cats[$k]['category']);
 

--- a/core/plugins/publications/dublincore/dublincore.php
+++ b/core/plugins/publications/dublincore/dublincore.php
@@ -71,7 +71,7 @@ class plgPublicationsDublincore extends \Hubzero\Plugin\Plugin
 
 		foreach ($publication->_authors as $contributor)
 		{
-			if (strtolower($contributor->role) == 'submitter')
+			if ($contributor->role && strtolower($contributor->role) == 'submitter')
 			{
 				continue;
 			}

--- a/core/plugins/publications/googlescholar/googlescholar.php
+++ b/core/plugins/publications/googlescholar/googlescholar.php
@@ -69,7 +69,7 @@ class plgPublicationsGooglescholar extends \Hubzero\Plugin\Plugin
 
 		foreach ($publication->_authors as $contributor)
 		{
-			if (strtolower($contributor->role) == 'submitter')
+			if ($contributor->role && strtolower($contributor->role) == 'submitter')
 			{
 				continue;
 			}

--- a/core/plugins/publications/jsonld/jsonld.php
+++ b/core/plugins/publications/jsonld/jsonld.php
@@ -96,7 +96,7 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 
 		foreach ($publication->_authors as $contributor)
 		{
-			if (strtolower($contributor->role) == 'submitter')
+			if ($contributor->role && strtolower($contributor->role) == 'submitter')
 			{
 				continue;
 			}

--- a/core/plugins/publications/usage/helpers/publicationUsageHelper.php
+++ b/core/plugins/publications/usage/helpers/publicationUsageHelper.php
@@ -10,8 +10,40 @@ defined('_HZEXEC_') or die();
 
 class PublicationUsageHelper
 {
+	/**
+	 * Database connection
+	 *
+	 * @var object
+	 */
+	protected $_db;
 
+	/**
+	 * Publication
+	 *
+	 * @var object
+	 */
+	protected $_publication;
+
+	/**
+	 * Log table
+	 *
+	 * @var string
+	 */
 	protected $_logsTable = '#__publication_logs';
+
+	/**
+	 * Version ID
+	 *
+	 * @var int
+	 */
+	protected $_versionId;
+
+	/**
+	 * Publication ID
+	 *
+	 * @var int
+	 */
+	protected $_publicationId;
 
 	/**
 	 * Instantiates PublicationUsageHelper
@@ -112,5 +144,4 @@ class PublicationUsageHelper
 
 		return $this->_versionId;
 	}
-
 }

--- a/core/plugins/publications/wishlist/wishlist.php
+++ b/core/plugins/publications/wishlist/wishlist.php
@@ -331,7 +331,7 @@ class plgPublicationsWishlist extends \Hubzero\Plugin\Plugin
 					->rows();
 
 				$title = ($admin) ?  Lang::txt('COM_WISHLIST_TITLE_PRIORITIZED') : Lang::txt('COM_WISHLIST_TITLE_RECENT_WISHES');
-				if (count($wishlist->items) > 0 && $items > $filters['limit'])
+				if ($wishlist->items && count($wishlist->items) > 0 && $items > $filters['limit'])
 				{
 					$title.= ' (<a href="' . Route::url('index.php?option=' . $option . '&task=wishlist&category=' . $wishlist->category . '&rid=' . $wishlist->referenceid) . '">' . Lang::txt('view all') . ' ' . $items . '</a>)';
 				}

--- a/core/plugins/resources/dublincore/dublincore.php
+++ b/core/plugins/resources/dublincore/dublincore.php
@@ -82,7 +82,10 @@ class plgResourcesDublincore extends \Hubzero\Plugin\Plugin
 			{
 				$contributor->org = $contributor->xorg;
 			}
-			$contributor->org = stripslashes(trim($contributor->org));
+			if ($contributor->org)
+			{
+				$contributor->org = stripslashes(trim($contributor->org));
+			}
 
 			Document::setMetaData('dcterms.creator', $view->escape($name . ($contributor->org ? ', ' . $contributor->org : '')));
 		}

--- a/core/plugins/resources/findthistext/views/index/tmpl/default.php
+++ b/core/plugins/resources/findthistext/views/index/tmpl/default.php
@@ -87,7 +87,7 @@ if (count($matches) > 0)
 					{
 						$query .= $resourceFields['doi'];
 					}
-					elseif ($this->model->resource->title)
+					elseif ($this->model->resource && $this->model->resource->title)
 					{
 						$query .= $this->model->title;
 					}

--- a/core/plugins/resources/googlescholar/googlescholar.php
+++ b/core/plugins/resources/googlescholar/googlescholar.php
@@ -91,7 +91,10 @@ class plgResourcesGooglescholar extends \Hubzero\Plugin\Plugin
 			{
 				$contributor->org = $contributor->xorg;
 			}
-			$contributor->org = stripslashes(trim($contributor->org));
+			if ($contributor->org)
+			{
+				$contributor->org = stripslashes(trim($contributor->org));
+			}
 
 			Document::setMetaData('citation_author', $view->escape($name));
 			if ($contributor->org)

--- a/core/plugins/system/incomplete/incomplete.php
+++ b/core/plugins/system/incomplete/incomplete.php
@@ -39,9 +39,9 @@ class plgSystemIncomplete extends \Hubzero\Plugin\Plugin
 				'/legal/terms'
 			];
 
-			if ($allowed = trim($this->params->get('exceptions','')))
+			if ($allowed = $this->params->get('exceptions', ''))
 			{
-				$allowed = str_replace("\r", '', $allowed);
+				$allowed = str_replace("\r", '', trim($allowed));
 				$allowed = str_replace('\n', "\n", $allowed);
 				$allowed = explode("\n", $allowed);
 				$allowed = array_map('trim', $allowed);

--- a/core/plugins/system/sef/sef.php
+++ b/core/plugins/system/sef/sef.php
@@ -108,7 +108,7 @@ class plgSystemSef extends \Hubzero\Plugin\Plugin
 	 * @param   array   $matches  An array of matches (see preg_match_all)
 	 * @return  string
 	 */
-	protected static function route(&$matches)
+	protected static function route($matches)
 	{
 		$url = $matches[1];
 		$url = str_replace('&amp;', '&', $url);

--- a/core/plugins/wiki/parserdefault/parser.php
+++ b/core/plugins/wiki/parserdefault/parser.php
@@ -117,6 +117,34 @@ class WikiParser
 	);
 
 	/**
+	 * List of macros
+	 *
+	 * @var array
+	 */
+	private $macros = array();
+
+	/**
+	 * Flag for list element open/closed state
+	 *
+	 * @var bool
+	 */
+	private $mDTopen;
+
+	/**
+	 * Flag for PRE element open/closed state
+	 *
+	 * @var bool
+	 */
+	private $mInPre;
+
+	/**
+	 * Flag for last section state
+	 *
+	 * @var bool
+	 */
+	private $mLastSection;
+
+	/**
 	 * Constructor
 	 *
 	 * @param      array $config Configuration options


### PR DESCRIPTION
This includes a number of backwards compatible fixes for PHP 8.1+, a fix for MySQL 8+/MariaDB10+, and a handful of general bug fixes. This is by no means comprehensive. Some fixes, such as method signatures, were originally PHP8.2+ only but changed to be backwards compatible.
