### PR TITLE
Featured groups don't have a div container

### DIFF
--- a/core/components/com_groups/site/views/groups/tmpl/display.php
+++ b/core/components/com_groups/site/views/groups/tmpl/display.php
@@ -171,14 +171,13 @@ $this->css('introduction.css', 'system')
 					<p><?php echo Lang::txt('COM_GROUPS_BROWSE_NO_GROUPS'); ?></p>
 				</div>
 			<?php else : ?>
-				<?php
-				foreach ($this->featuredgroups as $group)
-				{
+				<div class="groups-container">
+				<?php foreach ($this->featuredgroups as $group) {
 					$this->view('_group')
 						->set('group', $group)
 						->display();
-				}
-				?>
+				} ?>
+				</div>
 			<?php endif; ?>
 		</section><!-- / .featuredgroups -->
 	<?php endif; ?>


### PR DESCRIPTION
# Reference
- https://sdx-sdsc.atlassian.net/browse/HZ-189
- https://theghub.org/support/ticket/2615

# Summary of the Issue
Need to have feature groups wrapped in a div with class 'groups-container'

# Summary of the Development
Added in outside div container with class named 'groups-container' in 'com_groups > site > views > groups > tmpl > display.php'

