### PR TITLE
Broken Previous Button for Tool Description

### DIFF
--- a/core/components/com_tools/site/assets/js/resource.js
+++ b/core/components/com_tools/site/assets/js/resource.js
@@ -21,11 +21,13 @@ HUB.ToolsResource = {
 	initialize: function() {
 		var $ = this.jQuery;
 
+		// Previous Button on the Tool Edit Description Wizard
 		$('.returntoedit').each(function(i, item) {
 			$(item).on('click', function(e) {
 				e.preventDefault();
 
 				var editform = document.getElementById("hubForm");
+				editform.controller.value = "resources";
 				editform.step.value = editform.step.value-2;
 				editform.task.value = "start";
 				editform.submit();

--- a/core/components/com_tools/site/views/resources/tmpl/preview.php
+++ b/core/components/com_tools/site/views/resources/tmpl/preview.php
@@ -62,7 +62,7 @@ $this->css('resource.css')
 		<input type="hidden" name="toolname" value="<?php echo $this->resource->alias; ?>" />
 
 		<div class="steps-nav">
-			<span class="step-prev"><input type="button" value="&lt; <?php echo ucfirst(Lang::txt('COM_TOOLS_PREVIOUS')); ?>" class="returntoedit" /></span>
+			<span class="step-prev"><input type="button" value="&lt; <?php echo ucfirst(Lang::txt('COM_TOOLS_PREVIOUS')); ?>" class="btn returntoedit" /></span>
 			<span class="step-next"><input type="submit" value="<?php echo ucfirst(Lang::txt('COM_TOOLS_CONTRIBTOOL_STEP_FINALIZE')); ?> &gt;" /></span>
 		</div>
 		<div class="clear"></div>


### PR DESCRIPTION
# Reference
- https://sdx-sdsc.atlassian.net/browse/NCN-290
- https://nanohub.org/support/ticket/429594

# Summary of the Issue
Editing the Tools description, on the "Finalize" tab, the "< previous" button is broken and doesn't match the style. It should go to "Tags" tab, but it currently goes to the pipeline page. It is not just happening on Nanohub, but on all CMS. 

# Summary of the Development
The controller should have been pointed to the 'resources' controller upon submission, but it was defaulting to the preview.php controller of 'pipeline'. The 'pipeline' controller doesn't have a way to respond to the "< previous" button. 

# Testing
The fix can be tested on https://dev.nanohub.org/tools/pipeline.

