### PR TITLE
fix issue of citations not appearing in curation workflow

### DIFF
--- a/core/components/com_citations/helpers/format.php
+++ b/core/components/com_citations/helpers/format.php
@@ -862,7 +862,7 @@ class Format
 	 */
 	public static function keyExistsOrIsNotEmpty($key, $row)
 	{
-		if (isset($row->$key))
+		if (isset($row[$key]))
 		{
 			if ($row->$key != '' && $row->$key != '0' && $row->$key != '0000-00-00 00:00:00')
 			{


### PR DESCRIPTION
- **JIRA issue**: https://sdx-sdsc.atlassian.net/browse/PURR-82
- **Support ticket**: https://purr.purdue.edu/support/ticket/2439?show=324&search=&limit=20&start=0
- **Summary of issue**: In the publication curation workflow the title of the citation does not appear. In fact the citation is essentially blank.
- **Summary of fix**:  The test for the presence of a citation key (such as title) was incorrectly returning false even though it was set. I changed asset($row->$key) to asset($row[$key]), which returns true when set.  Apparently there was change in the way PHP handles this type class attribute reference.
- **Summary of testing**:  The issue was replicated on my dev machine and now works with this fix.
- **Hotfix needed?**  Possibly on PURR.