### PR TITLE
[PURR-82] added __isset() to Relational class

### DIFF
--- a/core/libraries/Hubzero/Database/Relational.php
+++ b/core/libraries/Hubzero/Database/Relational.php
@@ -431,6 +431,17 @@ class Relational implements \IteratorAggregate, \ArrayAccess, \Serializable
 	}
 
 	/**
+	 * Chevk ig attributes (i.e. field) on the model is set
+	 *
+	 * @param   array|string  $key    The key to check if set
+	 * @return  boolean 
+	 */
+	public function __isset($name)
+	{
+		return isset($this->attributes[$name]);
+	}
+
+	/**
 	 * Sets attributes (i.e. fields) on the model
 	 *
 	 * @param   array|string  $key    The key to set, or array of key/value pairs

--- a/core/libraries/Hubzero/Database/Relational.php
+++ b/core/libraries/Hubzero/Database/Relational.php
@@ -431,14 +431,14 @@ class Relational implements \IteratorAggregate, \ArrayAccess, \Serializable
 	}
 
 	/**
-	 * Chevk ig attributes (i.e. field) on the model is set
+	 * Check if attributes (i.e. field) on the model is set
 	 *
-	 * @param   array|string  $key    The key to check if set
+	 * @param   string  $name    The attribute to check if set
 	 * @return  boolean 
 	 */
 	public function __isset($name)
 	{
-		return isset($this->attributes[$name]);
+		return $this->hasAttribute($name);
 	}
 
 	/**


### PR DESCRIPTION
### This is an alternate solution to [PR 1661](https://github.com/hubzero/hubzero-cms/pull/1661)

- **JIRA issue**: https://sdx-sdsc.atlassian.net/browse/PURR-82
- **Support ticket**: https://purr.purdue.edu/support/ticket/2439?show=324&search=&limit=20&start=0
- **Summary of issue**: In the publication curation workflow the title of the citation does not appear. In fact the citation is essentially blank.
- **Summary of fix**:  The test for the presence of a citation key (such as title) was incorrectly returning false even though it was set. Added a magic __isset() to core/libraries/Hubzero/Database/Relational.php that checks whether the attribute is set.
- **Summary of testing**:  The issue was replicated on my dev machine and now works with this fix.
- **Hotfix needed?**  Possibly on PURR.
