### PR TITLE
[HZ-548] Fix Article "Saving to Copy" Functionality

### DIFF
--- a/core/components/com_content/admin/controllers/articles.php
+++ b/core/components/com_content/admin/controllers/articles.php
@@ -440,9 +440,11 @@ class Articles extends AdminController
 		// Upon "saving to copy" or "save to new", blank out alias, update created and published up date to now
         if (in_array($this->_task, $newTasks)) {
             $article->set('created', Date::of('now')->toSql());
+			$article->set('created_by', User::getInstance()->get('id'));
             $article->set('publish_up', Date::of('now')->toSql());
 			$article->set('publish_down', null);
 			$article->set('alias', null);
+			$article->save();
         }
 
 		$this->view

--- a/core/components/com_content/admin/controllers/articles.php
+++ b/core/components/com_content/admin/controllers/articles.php
@@ -438,14 +438,14 @@ class Articles extends AdminController
 		$task = in_array($this->_task, $newTasks) ? 'add' : $this->_task;
 
 		// Upon "saving to copy" or "save to new", blank out alias, update created and published up date to now
-        if (in_array($this->_task, $newTasks)) {
-            $article->set('created', Date::of('now')->toSql());
-            $article->set('created_by', User::getInstance()->get('id'));
-            $article->set('publish_up', Date::of('now')->toSql());
-            $article->set('publish_down', null);
-            $article->set('alias', null);
-            $article->save();
-        }
+		if (in_array($this->_task, $newTasks)) {
+			$article->set('created', Date::of('now')->toSql());
+			$article->set('created_by', User::getInstance()->get('id'));
+			$article->set('publish_up', Date::of('now')->toSql());
+			$article->set('publish_down', null);
+			$article->set('alias', null);
+			$article->save();
+		}
 
 		$this->view
 			->set('task', $task)

--- a/core/components/com_content/admin/controllers/articles.php
+++ b/core/components/com_content/admin/controllers/articles.php
@@ -440,11 +440,11 @@ class Articles extends AdminController
 		// Upon "saving to copy" or "save to new", blank out alias, update created and published up date to now
         if (in_array($this->_task, $newTasks)) {
             $article->set('created', Date::of('now')->toSql());
-			$article->set('created_by', User::getInstance()->get('id'));
+            $article->set('created_by', User::getInstance()->get('id'));
             $article->set('publish_up', Date::of('now')->toSql());
-			$article->set('publish_down', null);
-			$article->set('alias', null);
-			$article->save();
+            $article->set('publish_down', null);
+            $article->set('alias', null);
+            $article->save();
         }
 
 		$this->view


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- https://sdx-sdsc.atlassian.net/browse/HZ-548 (Bug Fix)
- https://sdx-sdsc.atlassian.net/browse/HZ-534 (Original Content Test Ticket)
- https://github.com/hubzero/hubzero-cms/pull/1617 (Original PR)

**Brief summary of the issue**
Upon copying an existing article, the 'created date' and 'created by' individual doesn't change. The original PR did fix up the start publishing and finish publishing date, which the date remains what was selected. 

**Brief summary of the fix**
- Upon the copy of the original article, the article needs to be SAVED with current date of creation and created by with the current logged in individual. 

**Brief summary of your testing**
- Log in and go to articles library
- Select an article, get to the "edit article" page
- Hit the "Save to Copy" button next to the star button on the right
- The new article should have a new id, created by is set to admin logged in, article alias is null, updated created date, modified date and start publishing date set to now. 
- Update the publishing date and hit the "Save" button, it should be the date selected and doesn't jump around due to time difference in time zone. 

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
Yes, it needs to be released with 2.2.26 version

**Double check someone is assigned to review the ticket**
Yes - Nick and David