### PR TITLE
[CDMHUB-49] Update Twitter Share URL

### DIFF
--- a/core/components/com_resources/site/assets/js/hubpresenter.js
+++ b/core/components/com_resources/site/assets/js/hubpresenter.js
@@ -847,7 +847,7 @@ HUB.Presenter = {
 							<div id=\"link\"> \
 								<span>Share:</span><input type=\"text\" id=\"replay-link\" value=" + window.location + " /> \
 								<a target='_blank' href=\"http://www.facebook.com/share.php?u=" + window.location + "\" id=\"facebook\" title=\"Share on Facebook\">Facebook</a> \
-								<a target='_blank' href=\"http://twitter.com/home?status=Currently Watching: " + window.location +"\" id=\"twitter\" title=\"Share on Twitter\">Twitter</a> \
+								<a target='_blank' href=\"http://twitter.com/intent/tweet?text=Currently Watching: " + window.location +"\" id=\"twitter\" title=\"Share on Twitter\">Twitter</a> \
 							</div> \
 						</div> \
 						<a class=\"btn icon-close\" id=\"replay-back\" href=\"#\">Close Presentation</a> \

--- a/core/components/com_resources/site/assets/js/video.js
+++ b/core/components/com_resources/site/assets/js/video.js
@@ -654,7 +654,7 @@ HUB.Video = {
 							<div id=\"link\"> \
 								<span>Share:</span><input type=\"text\" id=\"replay-link\" value=" + window.location + " /> \
 								<a target='_blank' href=\"http://www.facebook.com/share.php?u=" + window.location + "\" id=\"facebook\" title=\"Share on Facebook\">Facebook</a> \
-								<a target='_blank' href=\"http://twitter.com/home?status=Currently Watching: " + window.location +"\" id=\"twitter\" title=\"Share on Twitter\">Twitter</a> \
+								<a target='_blank' href=\"http://twitter.com/intent/tweet?text=Currently Watching: " + window.location +"\" id=\"twitter\" title=\"Share on Twitter\">Twitter</a> \
 							</div> \
 						</div> \
 						<a id=\"replay-back\" href=\"#\">&laquo; Close Video</a> \

--- a/core/plugins/handlers/hubpresenter/assets/js/hubpresenter.js
+++ b/core/plugins/handlers/hubpresenter/assets/js/hubpresenter.js
@@ -952,7 +952,7 @@ HUB.Presenter = {
 							<div id=\"link\"> \
 								<span>Share:</span><input type=\"text\" id=\"replay-link\" value=" + window.location + " /> \
 								<a rel="noopener noreferrer" target='_blank' href=\"http://www.facebook.com/share.php?u=" + window.location + "\" id=\"facebook\" title=\"Share on Facebook\">Facebook</a> \
-								<a rel="noopener noreferrer" target='_blank' href=\"http://twitter.com/home?status=Currently Watching: " + window.location +"\" id=\"twitter\" title=\"Share on Twitter\">Twitter</a> \
+								<a rel="noopener noreferrer" target='_blank' href=\"http://twitter.com/intent/tweet?text=Currently Watching: " + window.location +"\" id=\"twitter\" title=\"Share on Twitter\">Twitter</a> \
 							</div> \
 						</div> \
 						<a class=\"btn icon-close\" id=\"replay-back\" href=\"#\">Close Presentation</a> \

--- a/core/plugins/publications/share/share.php
+++ b/core/plugins/publications/share/share.php
@@ -141,7 +141,7 @@ class plgPublicationsShare extends \Hubzero\Plugin\Plugin
 				break;
 
 			case 'twitter':
-				$link = 'http://twitter.com/home?status=' . urlencode(Lang::txt('PLG_PUBLICATION_SHARE_VIEWING', Config::get('sitename'), stripslashes($publication->title) . ' ' . $url));
+				$link = 'http://twitter.com/intent/tweet?text=' . urlencode(Lang::txt('PLG_PUBLICATION_SHARE_VIEWING', Config::get('sitename'), stripslashes($publication->title) . ' ' . $url));
 				break;
 
 			case 'google':

--- a/core/plugins/resources/share/share.php
+++ b/core/plugins/resources/share/share.php
@@ -151,7 +151,7 @@ class plgResourcesShare extends \Hubzero\Plugin\Plugin
 				break;
 
 			case 'twitter':
-				$link = 'http://twitter.com/home?status=' . urlencode(Lang::txt('PLG_RESOURCES_SHARE_VIEWING', Config::get('sitename'), stripslashes($resource->title)) . ' ' . $url);
+				$link = 'http://twitter.com/intent/tweet?text=' . urlencode(Lang::txt('PLG_RESOURCES_SHARE_VIEWING', Config::get('sitename'), stripslashes($resource->title)) . ' ' . $url);
 				break;
 
 			case 'google':


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- https://sdx-sdsc.atlassian.net/browse/CDMHUB-49
- https://cdmhub.org/support/ticket/2226?show=419&search=&limit=20&start=0

**Brief summary of the issue**
Hitting the Twitter button on a resource page, nothing is pulled over to the tweet pop up window. 

**Brief summary of the fix**
Need to update the Twitter sharing URL, more info located here: [Stack Overflow Link](https://stackoverflow.com/questions/15665027/twitter-status-update-url-not-working-on-ios)

**Brief summary of your testing**
- Go to a resource detail page with the plugin resource-sharing turned on
- Select the Twitter button and click on it to reach a pop up window
- Pop up window should show the resource verbiage to share with everyone or a few on Twitter. 

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
No

**Double check someone is assigned to review the ticket**
Yes - Nick and David