### PR TITLE
minor fixes to developer API docs browser

### DIFF
--- a/core/components/com_developer/site/controllers/applications.php
+++ b/core/components/com_developer/site/controllers/applications.php
@@ -166,7 +166,7 @@ class Applications extends SiteController
 		// must be logged in
 		if (User::isGuest())
 		{
-			$return = Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&task=edit&id=' . $id, false, true);
+			$return = Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&task=edit', false, true);
 			App::redirect(
 				Route::url('index.php?option=com_users&view=login&return=' . base64_encode($return))
 			);

--- a/core/components/com_developer/site/views/api/tmpl/endpoint.php
+++ b/core/components/com_developer/site/views/api/tmpl/endpoint.php
@@ -179,7 +179,7 @@ $base = 'index.php?option=' . $this->option . '&controller=' . $this->controller
 												<?php echo $param['description']; ?>
 											</td>
 											<td>
-												<code class="nohighlight"><?php echo (!is_null($param['default'])) ? $param['default'] : 'null'; ?></code>
+												<code class="nohighlight"><?php echo (isset($param['default'])) ? $param['default'] : 'null'; ?></code>
 											</td>
 											<td>
 												<?php if (isset($param['allowedValues'])) : ?>


### PR DESCRIPTION

- **JIRA card**: none
- **Support ticket**: none
- **Brief summary of the issue**:  Encountered a couple 500 errors when trying to access and browse API docs. 
- **Brief summary of the fix/changed code**: 

  1. Removed undefined (and unnecessary) **id** parameter in a route (url). 
  2. Changed` !is_null()` to` isset()` for checking unset parameter.

- **Brief summary of your testing**:  Now works with errors on my dev machine.
- **Needs to be hotfixed to any production hubs?**  no
