### PR TITLE
[NCN-503] Fixed unit ordering on progress page of course

### DIFF
--- a/core/components/com_courses/models/offering.php
+++ b/core/components/com_courses/models/offering.php
@@ -319,12 +319,10 @@ class Offering extends Base
 	}
 
 	/**
-	 * Get a list of units for an offering
-	 *   Accepts either a numeric array index or a string [id, name]
-	 *   If index, it'll return the entry matching that index in the list
-	 *   If string, it'll return either a list of IDs or names
+	 * Get a list of sections for an offering
 	 *
-	 * @param      mixed $idx Index value
+	 * @param      array   $filters Filters to build query from
+	 * @param      boolean $clear   Force a new dataset?
 	 * @return     array
 	 */
 	public function sections($filters=array(), $clear=false)
@@ -404,14 +402,13 @@ class Offering extends Base
 
 	/**
 	 * Get a list of units for an offering
-	 *   Accepts either a numeric array index or a string [id, name]
-	 *   If index, it'll return the entry matching that index in the list
-	 *   If string, it'll return either a list of IDs or names
 	 *
-	 * @param      mixed $idx Index value
-	 * @return     array
+	 * @param      array   $filters Filters to build query from
+	 * @param      boolean $clear   Force a new dataset?
+	 * @param      boolean $order   order by unit ordering instead of key (id)
+	 * @return     Iterator
 	 */
-	public function units($filters=array(), $clear=false)
+	public function units($filters=array(), $clear=false, $order=false)
 	{
 		if (!isset($filters['offering_id']))
 		{
@@ -441,7 +438,20 @@ class Offering extends Base
 					{
 						$result->section_id = (int) $this->section()->get('id');
 					}
-					$results[$key] = new Unit($result);
+
+					if ($order)
+					{
+						$unit_order = $result->ordering;
+						$results[$unit_order] = new Unit($result);						
+					}
+					else
+					{
+						$results[$key] = new Unit($result);
+					}
+				}
+				if ($order)
+				{
+					ksort($results, 1);
 				}
 			}
 			else

--- a/core/plugins/courses/progress/views/report/tmpl/student.php
+++ b/core/plugins/courses/progress/views/report/tmpl/student.php
@@ -247,7 +247,7 @@ else
 }
 
 // Get the number of units in the course and figure out which is the current one
-$units     = $this->course->offering()->units();
+$units     = $this->course->offering()->units(array(),true);
 $num_units = $units->total();
 $index     = 1;
 $current_i = 0;
@@ -435,7 +435,7 @@ $progress_timeline .= '</div>';
 	</p>
 
 	<div class="units">
-	<?php foreach ($this->course->offering()->units() as $unit) : ?>
+	<?php foreach ($this->course->offering()->units(array(),true) as $unit) : ?>
 
 		<div class="unit-entry">
 			<div class="unit-overview">


### PR DESCRIPTION
### Fixed unit ordering on progress page of course

### Update 20240117-1107 - DRB
Issue NCN-503 cloned from original in Jira, new Jira card: https://sdx-sdsc.atlassian.net/browse/NCN-740
Original ticket is not completely finished

- **JIRA card:** https://sdx-sdsc.atlassian.net/browse/NCN-503
- **Support ticket**: https://nanohub.org/support/ticket/409872
- **Brief summary of the issue**: 
Units in progress bar (graphic) for course were sometimes out of order. Units were being ordered by ID instead of ordering field
- **Brief summary of the fix/changed code**: Added order parameter to units() method in offering model. If true, key in associative array was changed to ordering field instead of id (default key) and used ksort() to reorder array by key (now ordering). Passed order=true to call to offering->units() in student progress view in course progress plugin.
- **Brief summary of your testing**:. Tested and confirmed with course on personal dev machine.
- **Hotfix needed?** no
