### PR TITLE
[UCCOMMHUB-11] fix rendering of menu on tool license page

### DIFF
--- a/core/components/com_tools/site/assets/css/pipeline.css
+++ b/core/components/com_tools/site/assets/css/pipeline.css
@@ -807,6 +807,7 @@
 	.shifted { 
 		position: absolute;
 		left: 200px;
+		max-width: 25%;
 		margin: 0 0 2em 0;
 		font-size: 1em;
 	}

--- a/core/components/com_tools/site/assets/css/pipeline.css
+++ b/core/components/com_tools/site/assets/css/pipeline.css
@@ -696,18 +696,24 @@
 		text-align: left;
 		padding: 0 0 1em 5.5em;
 	}
-	/*.required {
-		float: right;
-		color: red;
-		font-size: 85%;
-		text-transform: uppercase;
-	}*/
+
+	.label-with-choice-icon {
+		display: flex;
+		align-items: center;
+		gap: 20px;
+		padding-bottom: 10px;
+	}
+
+	.label-with-choice-icon label {
+		flex-grow: 1;
+	}
+
 	#choice-icon {
+		flex-basis: 24px;
 		width: 24px;
 		height: 24px;
 		display: inline-block;
-		margin-left: 180px;
-		position: absolute;
+		padding: 0;
 	}
 	#choice-icon.opensource {
 		background: url("/core/components/com_tools/site/assets/img/happyface_sm.png") 0 0 no-repeat;
@@ -804,13 +810,7 @@
 	.hide { 
 		display: none;
 	}
-	.shifted { 
-		position: absolute;
-		left: 200px;
-		max-width: 25%;
-		margin: 0 0 2em 0;
-		font-size: 1em;
-	}
+
 	#lic { 
 		padding: 1.5em 0 0.5em 0;
 		margin: 0 0 2em 0;

--- a/core/components/com_tools/site/views/pipeline/tmpl/license.php
+++ b/core/components/com_tools/site/views/pipeline/tmpl/license.php
@@ -64,9 +64,13 @@ $this->css('pipeline.css')
 			</h3>
 			<form action="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=license&app=' . $this->status['toolname']); ?>" method="post" id="licenseForm" name="licenseForm">
 				<fieldset class="versionfield">
-					<label><?php echo Lang::txt('COM_TOOLS_CODE_ACCESS'); ?>:</label>
+					<div class="label-with-choice-icon">
+						<label><?php echo Lang::txt('COM_TOOLS_CODE_ACCESS'); ?>:</label>
+						<span id="choice-icon">&nbsp;</span>
+					</div>
+					
 					<?php echo \Components\Tools\Helpers\Html::formSelect('t_code', 't_code', $codeChoices, $this->code, 'shifted', ''); ?>
-					<span id="choice-icon">&nbsp;</span>
+					
 					<div id="closed-source">
 						<h4><?php echo Lang::txt('COM_TOOLS_LICENSE_ARE_YOU_SURE'); ?></h4>
 						<div class="why-open"><?php echo Lang::txt('COM_TOOLS_LICENSE_WHY_OPEN_SOURCE'); ?></div>


### PR DESCRIPTION
### Tool license page is not rendered properly

- **JIRA card**: https://sdx-sdsc.atlassian.net/browse/UCCOMMHUB-11
- **Support ticket**: https://uccommunityhub.hubzero.org/support/ticket/46
- **Brief summary of the issue**: The dropdown menus on the tool license page of the tool create pipeline  was rendering full width of page.
- **Brief summary of the fix/changed code**: Added max-width (of 25%) to the .shifted entry in the pipeline CSS, which is used on those menu select tags.
- **Brief summary of your testing**:  Could not be tested directly on uccommunithhub.org, but Mona could mimic the proposed change within the browser inspector.
- **Hotfixed needed?**  no
