### PR TITLE
[NCN-437] Create UI for managing Campaign and its secret

### DIFF
--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -28,7 +28,7 @@ class Campaigns extends AdminController
 	/**
 	 * Execute a task
 	 *
-	 * This appears to be an override?
+	 * This appears to be an override
 	 *
 	 * @return  void
 	 */
@@ -88,6 +88,8 @@ class Campaigns extends AdminController
 
 	/**
 	 * Edit or add Campaigns
+	 *
+	 * Display a form for adding or editing an entry
 	 * (swiped from admin/controllers/newsletters.php)
 	 *
 	 * @return  void
@@ -110,6 +112,10 @@ class Campaigns extends AdminController
 			$id = is_array($id) ? $id[0] : $id;
 
 			$row = Campaign::oneOrNew($id);
+
+			// Campaign expiration date: saved as GMT (see edit.php)
+			$expire_date = Date::of($row->expire_date);
+			$this->view->expire_date = $expire_date;
 		}
 
 		// Output the HTML
@@ -122,6 +128,8 @@ class Campaigns extends AdminController
 
 	/**
 	 * Save campaign task
+	 *
+	 * Save an entry
 	 * (swiped from admin/controllers/newsletters.php)
 	 *
 	 * @return 	void
@@ -142,6 +150,12 @@ class Campaigns extends AdminController
 
 		// Initiate model
 		$row = Campaign::oneOrNew($fields['id'])->set($fields);
+
+        // make sure we have an expire_date, default will be 90 days from current date
+        if (!$row->expire_date)
+        {
+			$row->expire_date = Date::of('+90 days')->setTimezone('GMT')->toSql();
+        }
 
 		// did we have params
 		// if so, it's a request to reset the secret
@@ -178,6 +192,8 @@ class Campaigns extends AdminController
 
 	/**
 	 * Delete Task
+	 *
+	 * Delete an entry
 	 * (Swiped from admin/controllers/templates.php)
 	 *
 	 * This task deletes campaigns from the database, unlike some other functionality in this component,

--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -151,11 +151,23 @@ class Campaigns extends AdminController
 		// Initiate model
 		$row = Campaign::oneOrNew($fields['id'])->set($fields);
 
-        // make sure we have an expire_date, default will be 90 days from current date
-        if (!$row->expire_date)
-        {
-			$row->expire_date = Date::of('+90 days')->setTimezone('GMT')->toSql();
-        }
+
+		// make sure we have an expire_date, default will be 90 days from current date
+		if (!$row->expire_date)
+		{
+			$row->expire_date = Date::of('+90 days', 'GMT')->toSql();
+		}
+		else
+		{
+			// If display date changed in the form, save new date: 
+			if ($fields['expire_date_display'] != $fields['expire_date_local'])
+			{
+				// get timezone identifier from user setting
+				$tz = \User::getParam('timezone', \Config::get('offset'));
+				// save the newly changed date, accounting for the user's local time zone, $tz:
+				$row->expire_date = Date::of($fields['expire_date_display'], $tz)->toSql();
+			}
+		}
 
 		// did we have params
 		// if so, it's a request to reset the secret

--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Admin\Controllers;
+
+use Components\Newsletter\Models\Campaign;
+use Hubzero\Component\AdminController;
+use stdClass;
+use Request;
+use Notify;
+use Route;
+use Lang;
+use App;
+
+// require the campaign model
+require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'campaign.php';
+
+/**
+ * Campaign Controller
+ */
+class Campaigns extends AdminController
+{
+	/**
+	 * Execute a task
+	 *
+	 * @return  void
+	 */
+	public function execute()
+	{
+		$this->registerTask('add', 'edit');
+		$this->registerTask('apply', 'save');
+		//$this->registerTask('publish', 'state');
+		//$this->registerTask('unpublish', 'state');
+
+		parent::execute();
+	}
+
+	/**
+	 * Display Campaigns
+	 *
+	 * @return  void
+	 */
+	public function displayTask()
+	{
+		$filters = array(
+			'search' => Request::getState(
+				$this->_option . '.' . $this->_controller . '.search',
+				'search',
+				''
+			),
+			'sort' => Request::getState(
+				$this->_option . '.' . $this->_controller . '.sort',
+				'filter_order',
+				'title'
+			),
+			'sort_Dir' => Request::getState(
+				$this->_option . '.' . $this->_controller . '.sortdir',
+				'filter_order_Dir',
+				'ASC'
+			)
+		);
+
+		$campaigns = Campaign::all();
+
+		if ($filters['search'])
+		{
+			$filters['search'] = strtolower((string)$filters['search']);
+			$campaigns->whereLike('title', $filters['search']);
+		}
+
+		$rows = $campaigns
+			->order($filters['sort'], $filters['sort_Dir'])
+			->paginated('limitstart', 'limit')
+			->rows();
+
+		// Output the HTML
+		$this->view
+			->setLayout('display')
+			->set('campaigns', $rows) // was 'campaigns'
+			->set('filters', $filters)
+			->display();
+	}
+
+	/**
+	 * Edit or add Campaigns
+	 * (swiped from admin/controllers/newsletters.php)
+	 *
+	 * @return  void
+	 */
+	public function editTask($row = null)
+	{
+		if (!User::authorise('core.edit', $this->_option)
+		 && !User::authorise('core.create', $this->_option))
+		{
+			App::abort(403, Lang::txt('JERROR_ALERTNOAUTHOR'));
+		}
+
+		Request::setVar('hidemainmenu', 1);
+
+		// Load or create object
+		if (!is_object($row))
+		{
+			// Incoming
+			$id = Request::getArray('id', array(0));
+			$id = is_array($id) ? $id[0] : $id;
+
+			$row = Campaign::oneOrNew($id);
+		}
+
+		// Output the HTML
+		$this->view
+			->set('campaign', $row)
+			->set('config', $this->config)
+			->setLayout('edit')
+			->display();		
+	}
+
+	/**
+	 * Save campaign task
+	 * (swiped from admin/controllers/newsletters.php)
+	 *
+	 * @return 	void
+	 */
+	public function saveTask()
+	{
+		// Check for request forgeries
+		Request::checkToken();
+
+		if (!User::authorise('core.edit', $this->_option)
+		 && !User::authorise('core.create', $this->_option))
+		{
+			App::abort(403, Lang::txt('JERROR_ALERTNOAUTHOR'));
+		}
+
+		// Incoming data from edit form
+		$fields = Request::getArray('campaign', array(), 'post');
+
+		// Initiate model
+		$row = Campaign::oneOrNew($fields['id'])->set($fields);
+
+		// did we have params
+		// if so, it's a request to reset the secret
+		$p = Request::getArray('params', array(), 'post');
+
+		if (!empty($p))
+		{
+			// set new secret if indicated
+			if (null !== $p['reset_secret'] && $p['reset_secret'] == 1)
+			{
+				$row->set('secret', Campaign::generateSecret(null));
+			}
+		}
+
+		// Save campaign
+		if (!$row->save())
+		{
+			Notify::error($row->getError());
+			return $this->editTask($row);
+		}
+
+		// Set success message
+		Notify::success(Lang::txt('COM_NEWSLETTER_SAVED_SUCCESS'));
+
+		if ($this->getTask() == 'apply')
+		{
+			// If we just created campaign go back to edit form so we can add content
+			return $this->editTask($row);
+		}
+
+		// Redirect back to campaigns list
+		$this->cancelTask();
+	}
+}

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -43,3 +43,12 @@ Note that the secret is not shown.</p>
 The Campaign will be saved. Regardless of whether it has been changed, the secret is not shown.</p>
 </p>
 
+<h2>Deleting Campaigns</h2>
+
+<p>To delete a Campaign, click the checkbox next to a Campaign's name in the Campaigns display.
+    You may select multiple campaigns to delete.</p>
+ <p> Next, click the garbage can icon in the Campaigns display.
+You will be prompted to proceed with, or cancel, deletion.</p>
+<p>If you proceed with deletion, the Campaign will be permanently deleted. This will invalidate the existing
+    campaign, so delete only with caution!
+</p>

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -18,6 +18,8 @@ two features, Campaigns and Newsletters, are not presently related.</b></p>
 <p>Campaigns were developed to provide a random secret that could be hashed together with unique per-user secrets
 and a unique Hub secret to provide a unique code. This code can be used to form a URL that will be emailed to the user to provide them with secure access to Hub features.</p>
 
+<p>Campaigns are designed to expire after a period of time that defaults to 90 days. A campaign can be edited to
+    change the expiration date. After a campaign's expiration date has passed, it can no longer be used.</p>
 
 <h2>Viewing Campaigns</h2>
 
@@ -27,8 +29,12 @@ and a unique Hub secret to provide a unique code. This code can be used to form 
 <h2>Creating Campaigns</h2>
 
 <p>To create a Campaign, click the "+" sign in the Campaigns display. The Campaign Editor will be shown.
-Type the name and description of the campaign, then click the check mark (Save) or star (Save and Exit). 
+Type the name and description of the campaign and select an expiration date.
+The default expiration date is 90 days from the creation date.</p>
+
+<p>Then, click the check mark (Save) or star (Save and Exit).
 Or, click the X to cancel.</p>
+
 <p>The Campaign will be saved, along with a unique secret, your user information, and the creation date.
 Note that the secret is not shown.</p>
 
@@ -36,7 +42,7 @@ Note that the secret is not shown.</p>
 
 <p>To edit a Campaign, click an existing Campaign's name in the Campaigns display. Alternately, select an existing
     Campaign's checkbox and click the "Edit" icon. The Campaign Editor will be shown. </p>
-<p>You may edit the name and description of the campaign. You may also reset the Campaign's secret, by clicking
+<p>You may edit the name, description, and expiration date of the campaign. You may also reset the Campaign's secret, by clicking
     the checkbox labeled "Reset Campaign Secret". Use caution when resetting the secret. This action will 
     invalidate any URLs prepared with the Campaign!
 <p>To save your edits, click the check mark (Save) or star (Save and Exit). To cancel, click the X.

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+defined('_HZEXEC_') or die('Restricted access');
+?>
+<h1>Campaigns</h1>
+
+<p>Campaigns enable the admin user to create and maintain a unique 32-character random secret associated with a specific
+email or newsletter campaign.</p><p><b>Though the administrative interface for campaigns is located with Hubzero Newsletters, the
+two features, Campaigns and Newsletters, are not presently related.</b></p>
+
+<h2>Purpose</h2>
+
+<p>Campaigns were developed to provide a random secret that could be hashed together with unique per-user secrets
+and a unique Hub secret to provide a unique code. This code can be used to form a URL that will be emailed to the user to provide them with secure access to Hub features.</p>
+
+
+<h2>Viewing Campaigns</h2>
+
+<p>To view existing Campaigns, navigate to Components -> Newsletter, then select the Campaigns tab. </p>
+<p>In the Campaigns display, you may search for a specific Campaign name, or sort Campaigns by name or date.</p>
+
+<h2>Creating Campaigns</h2>
+
+<p>To create a Campaign, click the "+" sign in the Campaigns display. The Campaign Editor will be shown.
+Type the name and description of the campaign, then click the check mark (Save) or star (Save and Exit). 
+Or, click the X to cancel.</p>
+<p>The Campaign will be saved, along with a unique secret, your user information, and the creation date.
+Note that the secret is not shown.</p>
+
+<h2>Editing Campaigns</h2>
+
+<p>To edit a Campaign, click an existing Campaign's name in the Campaigns display. Alternately, select an existing
+    Campaign's checkbox and click the "Edit" icon. The Campaign Editor will be shown. </p>
+<p>You may edit the name and description of the campaign. You may also reset the Campaign's secret, by clicking
+    the checkbox labeled "Reset Campaign Secret". Use caution when resetting the secret. This action will 
+    invalidate any URLs prepared with the Campaign!
+<p>To save your edits, click the check mark (Save) or star (Save and Exit). To cancel, click the X.
+The Campaign will be saved. Regardless of whether it has been changed, the secret is not shown.</p>
+</p>
+

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -227,6 +227,10 @@ COM_NEWSLETTER_CAMPAIGN_DATE="Date Created"
 COM_NEWSLETTER_CAMPAIGN_MOD_DATE="Date Modified"
 COM_NEWSLETTER_NO_CAMPAIGNS="Currently there are no campaigns defined."
 COM_NEWSLETTER_CAMPAIGN_RESET_SECRET="Reset Secret"
+COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK="Are you sure you want to delete the selected Campaign(s)?"
+COM_NEWSLETTER_CAMPAIGN_NOT_FOUND="The specified campaign was not found."
+COM_NEWSLETTER_CAMPAIGN_DELETE_FAILED="Unable to delete selected campaign(s)."
+COM_NEWSLETTER_CAMPAIGN_DELETE_SUCCESS="Successfully deleted selected campaign(s)."
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -1,5 +1,5 @@
 ; @package      hubzero-cms
-; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @copyright    Copyright (c) 2005-2023 The Regents of the University of California.
 ; @license      http://opensource.org/licenses/MIT MIT
 
 ; Note : All ini files need to be saved as UTF-8 - No BOM
@@ -12,6 +12,8 @@ COM_NEWSLETTER_LISTS="Lists"
 COM_NEWSLETTER_TEMPLATES="Templates"
 COM_NEWSLETTER_TEMPLATE="Template"
 COM_NEWSLETTER_TOOLS="Tools"
+COM_NEWSLETTER_CAMPAIGNS="Campaigns"
+COM_NEWSLETTER_CAMPAIGN="Campaign"
 COM_NEWSLETTER_CONFIGURATION="Newsletter Configuration"
 
 
@@ -218,6 +220,13 @@ COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS="Click Throughs"
 COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS_URL="URL"
 COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS_COUNT="# of Clicks"
 COM_NEWSLETTER_NEWSLETTER_MAILING_NO_CLICK_THROUGHS="There are currently no click throughs for this mailing."
+
+; Campaigns
+COM_NEWSLETTER_CAMPAIGN_NAME="Campaign Title"
+COM_NEWSLETTER_CAMPAIGN_DATE="Date Created"
+COM_NEWSLETTER_CAMPAIGN_MOD_DATE="Date Modified"
+COM_NEWSLETTER_NO_CAMPAIGNS="Currently there are no campaigns defined."
+COM_NEWSLETTER_CAMPAIGN_RESET_SECRET="Reset Secret"
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -222,9 +222,9 @@ COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS_COUNT="# of Clicks"
 COM_NEWSLETTER_NEWSLETTER_MAILING_NO_CLICK_THROUGHS="There are currently no click throughs for this mailing."
 
 ; Campaigns
-COM_NEWSLETTER_CAMPAIGN_NAME="Campaign Title"
 COM_NEWSLETTER_CAMPAIGN_DATE="Date Created"
 COM_NEWSLETTER_CAMPAIGN_MOD_DATE="Date Modified"
+COM_NEWSLETTER_CAMPAIGN_MOD_BY="Modified By"
 COM_NEWSLETTER_NO_CAMPAIGNS="Currently there are no campaigns defined."
 COM_NEWSLETTER_CAMPAIGN_RESET_SECRET="Reset Secret"
 COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK="Are you sure you want to delete the selected Campaign(s)?"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -232,7 +232,6 @@ COM_NEWSLETTER_CAMPAIGN_NOT_FOUND="The specified campaign was not found."
 COM_NEWSLETTER_CAMPAIGN_DELETE_FAILED="Unable to delete selected campaign(s)."
 COM_NEWSLETTER_CAMPAIGN_DELETE_SUCCESS="Successfully deleted selected campaign(s)."
 COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE="Expiration Date"
-COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT="Expiration Date (GMT)"
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -231,6 +231,8 @@ COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK="Are you sure you want to delete the select
 COM_NEWSLETTER_CAMPAIGN_NOT_FOUND="The specified campaign was not found."
 COM_NEWSLETTER_CAMPAIGN_DELETE_FAILED="Unable to delete selected campaign(s)."
 COM_NEWSLETTER_CAMPAIGN_DELETE_SUCCESS="Successfully deleted selected campaign(s)."
+COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE="Expiration Date"
+COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT="Expiration Date (GMT)"
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/newsletter.php
+++ b/core/components/com_newsletter/admin/newsletter.php
@@ -16,6 +16,7 @@ if (!\User::authorise('core.manage', 'com_newsletter'))
 require_once dirname(__DIR__) . DS . 'models' . DS . 'newsletter.php';
 require_once dirname(__DIR__) . DS . 'models' . DS . 'mailinglist.php';
 require_once dirname(__DIR__) . DS . 'models' . DS . 'mailing.php';
+require_once dirname(__DIR__) . DS . 'models' . DS . 'campaign.php';
 
 // Include helpers
 require_once dirname(__DIR__) . DS . 'helpers' . DS . 'helper.php';
@@ -36,7 +37,8 @@ $menuItems = array(
 	'mailings'     => \Lang::txt('COM_NEWSLETTER_MAILINGS'),
 	'mailinglists' => \Lang::txt('COM_NEWSLETTER_LISTS'),
 	'templates'    => \Lang::txt('COM_NEWSLETTER_TEMPLATES'),
-	'tools'        => \Lang::txt('COM_NEWSLETTER_TOOLS')
+	'tools'        => \Lang::txt('COM_NEWSLETTER_TOOLS'),
+	'campaigns'    => \Lang::txt('COM_NEWSLETTER_CAMPAIGNS')
 );
 
 foreach ($menuItems as $k => $v)

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -22,6 +22,12 @@ if ($canDo->get('core.edit'))
 {
 	Toolbar::editList();
 }
+if ($canDo->get('core.delete'))
+{
+	Toolbar::spacer();
+	// TODO: add to language file
+	Toolbar::deleteList('COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK', 'delete');
+}
 Toolbar::spacer();
 Toolbar::help('campaign');
 

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -59,9 +59,9 @@ $this->js();
 				<th scope="col"><?php echo Lang::txt('Description');?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Date Modified', 'modified', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_DATE', 'modified', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Modified By', 'modified_by', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_BY', 'modified_by', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
 			</tr>
 		</thead> 

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -25,7 +25,6 @@ if ($canDo->get('core.edit'))
 if ($canDo->get('core.delete'))
 {
 	Toolbar::spacer();
-	// TODO: add to language file
 	Toolbar::deleteList('COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK', 'delete');
 }
 Toolbar::spacer();
@@ -56,7 +55,9 @@ $this->js();
 				</th>
 				<th scope="col"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN', 'title', @$this->filters['sort_Dir'], 
 					@$this->filters['sort']);?></th>
-				<th scope="col"><?php echo Lang::txt('Description');?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE', 'expire_date',
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+				<th scope="col"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC');?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_DATE', 'modified', 
@@ -85,19 +86,21 @@ $this->js();
 							<label for="cb<?php echo $k; ?>" class="sr-only visually-hidden"><?php echo $campaign->id; ?></label>
 						</td>
 						<td>
-							<?php //echo $campaign->title; ?>
 							<a href="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=edit&id=' . $campaign->id); ?>">
 								<?php echo $this->escape($campaign->title); ?>
 							</a>
 						</td>
 						<td class="priority-3">
+							<?php echo Date::of($campaign->expire_date)->toLocal("Y-m-d h:ma"); ?>
+						</td>
+						<td class="priority-3">
 							<?php echo $campaign->description; ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->campaign_date)->toLocal("F d, Y @ g:ia"); ?>
+							<?php echo Date::of($campaign->campaign_date)->toLocal("Y-m-d h:ma"); ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->modified)->toLocal("F d, Y @ g:ia"); ?>
+							<?php echo Date::of($campaign->modified)->toLocal("Y-m-d h:ma"); ?>
 						</td>
 						<td class="priority-3">
 							<?php echo User::one($campaign->modified_by)->name; ?>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -91,16 +91,16 @@ $this->js();
 							</a>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->expire_date)->toLocal("Y-m-d h:ma"); ?>
+							<?php echo Date::of($campaign->expire_date)->toLocal("Y-m-d H:ia"); ?>
 						</td>
 						<td class="priority-3">
 							<?php echo $campaign->description; ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->campaign_date)->toLocal("Y-m-d h:ma"); ?>
+							<?php echo Date::of($campaign->campaign_date)->toLocal("Y-m-d H:ia"); ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->modified)->toLocal("Y-m-d h:ma"); ?>
+							<?php echo Date::of($campaign->modified)->toLocal("Y-m-d H:ia"); ?>
 						</td>
 						<td class="priority-3">
 							<?php echo User::one($campaign->modified_by)->name; ?>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2023 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$canDo = Components\Newsletter\Helpers\Permissions::getActions('campaign');
+
+//set title
+Toolbar::title(Lang::txt('COM_NEWSLETTER_CAMPAIGNS'), 'campaigns');
+
+// toolbar
+if ($canDo->get('core.create'))
+{
+	Toolbar::addNew();
+}
+if ($canDo->get('core.edit'))
+{
+	Toolbar::editList();
+}
+Toolbar::spacer();
+Toolbar::help('campaign');
+
+$this->js();
+?>
+
+<?php if ($this->getError()) : ?>
+	<p class="error"><?php echo $this->getError(); ?></p>
+<?php endif; ?>
+
+<form action="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller); ?>" method="post" name="adminForm" id="admin-form">
+	<fieldset id="filter-bar">
+		<label for="filter_search"><?php echo Lang::txt('JSEARCH_FILTER'); ?>:</label>
+		<input type="text" name="search" id="filter_search" class="filter" value="<?php echo $this->escape($this->filters['search']); ?>" placeholder="<?php echo Lang::txt('COM_NEWSLETTER_FILTER_SEARCH_PLACEHOLDER'); ?>" />
+
+		<input type="submit" value="<?php echo Lang::txt('COM_NEWSLETTER_GO'); ?>" />
+		<button type="button" class="filter-clear"><?php echo Lang::txt('JSEARCH_FILTER_CLEAR'); ?></button>
+	</fieldset>
+
+	<table class="adminlist">
+		<thead>
+			<tr>
+				<th scope="col">
+					<input type="checkbox" name="checkall-toggle" id="checkall-toggle" value="" class="checkbox-toggle toggle-all" />
+					<label for="checkall-toggle" class="sr-only visually-hidden"><?php echo Lang::txt('JGLOBAL_CHECK_ALL'); ?></label>
+				</th>
+				<th scope="col"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN', 'title', @$this->filters['sort_Dir'], 
+					@$this->filters['sort']);?></th>
+				<th scope="col"><?php echo Lang::txt('Description');?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Date Modified', 'modified', 
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Modified By', 'modified_by', 
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+			</tr>
+		</thead> 
+
+		<tfoot>
+			<tr>
+				<td colspan="5"><?php
+				// initiate paging
+				echo $this->campaigns->pagination;
+				$k = 0;
+
+				?></td>
+			</tr>
+		</tfoot>
+		<tbody>
+			<?php if (count($this->campaigns) > 0) { ?>
+				<?php foreach ($this->campaigns as $campaign) { ?>
+					<tr>
+						<td>
+							<input type="checkbox" name="id[]" id="cb<?php echo $k; ?>" value="<?php echo $campaign->id; ?>" class="checkbox-toggle" />
+							<label for="cb<?php echo $k; ?>" class="sr-only visually-hidden"><?php echo $campaign->id; ?></label>
+						</td>
+						<td>
+							<?php //echo $campaign->title; ?>
+							<a href="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=edit&id=' . $campaign->id); ?>">
+								<?php echo $this->escape($campaign->title); ?>
+							</a>
+						</td>
+						<td class="priority-3">
+							<?php echo $campaign->description; ?>
+						</td>
+						<td class="priority-3">
+							<?php echo Date::of($campaign->campaign_date)->toLocal("F d, Y @ g:ia"); ?>
+						</td>
+						<td class="priority-3">
+							<?php echo Date::of($campaign->modified)->toLocal("F d, Y @ g:ia"); ?>
+						</td>
+						<td class="priority-3">
+							<?php echo User::one($campaign->modified_by)->name; ?>
+						</td>
+					</tr>
+				<?php $k++; } ?>
+			<?php } else { ?>
+				<tr>
+					<td colspan="5">
+						<?php echo Lang::txt('COM_NEWSLETTER_NO_CAMPAIGNS'); ?>
+					</td>
+				</tr>
+			<?php } ?>
+		</tbody>
+	</table>
+
+	<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
+	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
+	<input type="hidden" name="task" value="display" autocomplete="off" />
+	<input type="hidden" name="boxchecked" value="0" />
+	<input type="hidden" name="filter_order" value="<?php echo $this->escape($this->filters['sort']); ?>" />
+	<input type="hidden" name="filter_order_Dir" value="<?php echo $this->escape($this->filters['sort_Dir']); ?>" />
+
+	<?php echo Html::input('token'); ?>
+</form>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
@@ -16,7 +16,7 @@ $hasSecret = strlen($this->campaign->secret) > 0;
 // Language to match whether we are adding or editing:
 $text = ($hasSecret ? Lang::txt('COM_NEWSLETTER_EDIT') : Lang::txt('COM_NEWSLETTER_NEW'));
 
-Toolbar::title(Lang::txt('Campaign') . ': ' . $text, 'campaign');
+Toolbar::title(Lang::txt('COM_NEWSLETTER_CAMPAIGN') . ': ' . $text, 'campaign');
 if ($canDo->get('core.edit'))
 {
 	Toolbar::apply();
@@ -29,40 +29,42 @@ Toolbar::help('campaign');
 ?>
 <form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="item-form">
 	<fieldset class="adminform">
-		<legend><span><?php echo $text; ?> <?php echo Lang::txt('Campaign'); ?></span></legend>
+		<legend><span><?php echo $text; ?> <?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN'); ?></span></legend>
 
 		<div class="input-wrap">
-			<label for="campaign-title"><?php echo Lang::txt('Name'); ?>:</label><br />
+			<label for="campaign-title"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_NAME'); ?></label><br />
 			<input type="text" name="campaign[title]" id="campaign-title" value="<?php echo $this->escape($this->campaign->title); ?>" /></td>
 		</div>
 
 		<!-- Campaign expiration date: adapted from com_events/admin/views/events/tmpl/edit.php -->
-		<!-- If a new record, default 90 days; display as GMT -->
+		<!-- If a new record, default 90 days -->
 		<?php if (!$this->campaign->expire_date) {
-			$exDate  = Date::of('+90 days', 'GMT');
+			$exDate  = Date::of('+90 days');
 		} else {
-			$exDate  = Date::of($this->campaign->expire_date, 'GMT');
+			$exDate  = Date::of($this->campaign->expire_date);
 		} ?>
 		<div class="input-wrap">
-			<label for="campaign-expire_date"><?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT'); ?></label><br />
-			<?php echo Html::input('calendar', 'campaign[expire_date]', $exDate, array('id' => 'campaign-expire_date')); ?>
+			<label for="campaign-expire_date"><?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE'); ?></label><br />
+			<?php echo Html::input('calendar', 'campaign[expire_date_display]', Date::of($exDate)->toLocal(), array('id' => 'campaign-expire_date')); ?>
 		</div>
 
 		<div class="input-wrap">
-			<label for="campaign-description"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC'); ?>:</label><br />
+			<label for="campaign-description"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC'); ?></label><br />
 			<textarea name="campaign[description]" id="campaign-description" rows="5"><?php echo $this->escape($this->campaign->description); ?></textarea>
 		</div>
 
-	<!-- Display Reset Secret only if editing the campaign -->
-	<?php if ($hasSecret) { ?> 
-		<div class="input-wrap">
-			<input type="checkbox" name="params[reset_secret]" id="cb-reset-secret" value="1" class="checkbox-toggle" />
-			<label for="cb-reset-secret">Reset Campaign Secret</label>
-		</div>
-	<?php } ?> 
+		<!-- Display Reset Secret only if editing the campaign -->
+		<?php if ($hasSecret) { ?>
+			<div class="input-wrap">
+				<input type="checkbox" name="params[reset_secret]" id="cb-reset-secret" value="1" class="checkbox-toggle" />
+				<label for="cb-reset-secret">Reset Campaign Secret</label>
+			</div>
+		<?php } ?>
 	</fieldset>
 
 	<input type="hidden" name="campaign[id]" value="<?php echo $this->campaign->id; ?>" />
+	<input type="hidden" name="campaign[expire_date_gmt]" value="<?php echo Date::of($exDate, 'GMT'); ?>" />
+	<input type="hidden" name="campaign[expire_date_local]" value="<?php echo Date::of($exDate)->toLocal(); ?>" />
 	<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
 	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
 	<input type="hidden" name="task" value="save" />

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2023 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$canDo = Components\Newsletter\Helpers\Permissions::getActions('campaign');
+
+// If current record has a secret, then we are editing, otherwise we are new.
+$hasSecret = strlen($this->campaign->secret) > 0;
+
+// Language to match whether we are adding or editing:
+$text = ($hasSecret ? Lang::txt('COM_NEWSLETTER_EDIT') : Lang::txt('COM_NEWSLETTER_NEW'));
+
+Toolbar::title(Lang::txt('Campaign') . ': ' . $text, 'campaign');
+if ($canDo->get('core.edit'))
+{
+	Toolbar::apply();
+	Toolbar::save();
+	Toolbar::spacer();
+}
+Toolbar::cancel();
+?>
+<form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="item-form">
+	<fieldset class="adminform">
+		<legend><span><?php echo $text; ?> <?php echo Lang::txt('Campaign'); ?></span></legend>
+
+		<div class="input-wrap">
+			<label for="campaign-title"><?php echo Lang::txt('Name'); ?>:</label><br />
+			<input type="text" name="campaign[title]" id="campaign-title" value="<?php echo $this->escape($this->campaign->title); ?>" /></td>
+		</div>
+
+		<div class="input-wrap">
+			<label for="campaign-description"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC'); ?>:</label><br />
+			<textarea name="campaign[description]" id="campaign-description" rows="5"><?php echo $this->escape($this->campaign->description); ?></textarea>
+		</div>
+
+	<!-- Display Reset Secret only if editing the campaign -->
+	<?php if ($hasSecret) { ?> 
+		<div class="input-wrap">
+			<input type="checkbox" name="params[reset_secret]" id="cb-reset-secret" value="1" class="checkbox-toggle" />
+			<label for="cb-reset-secret">Reset Campaign Secret</label>
+		</div>
+	<?php } ?> 
+	</fieldset>
+
+	<input type="hidden" name="campaign[id]" value="<?php echo $this->campaign->id; ?>" />
+	<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
+	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
+	<input type="hidden" name="task" value="save" />
+
+	<?php echo Html::input('token'); ?>
+</form>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
@@ -24,6 +24,8 @@ if ($canDo->get('core.edit'))
 	Toolbar::spacer();
 }
 Toolbar::cancel();
+Toolbar::spacer();
+Toolbar::help('campaign');
 ?>
 <form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="item-form">
 	<fieldset class="adminform">
@@ -32,6 +34,18 @@ Toolbar::cancel();
 		<div class="input-wrap">
 			<label for="campaign-title"><?php echo Lang::txt('Name'); ?>:</label><br />
 			<input type="text" name="campaign[title]" id="campaign-title" value="<?php echo $this->escape($this->campaign->title); ?>" /></td>
+		</div>
+
+		<!-- Campaign expiration date: adapted from com_events/admin/views/events/tmpl/edit.php -->
+		<!-- If a new record, default 90 days; display as GMT -->
+		<?php if (!$this->campaign->expire_date) {
+			$exDate  = Date::of('+90 days', 'GMT');
+		} else {
+			$exDate  = Date::of($this->campaign->expire_date, 'GMT');
+		} ?>
+		<div class="input-wrap">
+			<label for="campaign-expire_date"><?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT'); ?></label><br />
+			<?php echo Html::input('calendar', 'campaign[expire_date]', $exDate, array('id' => 'campaign-expire_date')); ?>
 		</div>
 
 		<div class="input-wrap">

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/index.html
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -25,11 +25,12 @@ class Migration20230920000000ComNewsletter extends Base
 			$query = "CREATE TABLE IF NOT EXISTS `campaign` (
     			id INT(11) NOT NULL AUTO_INCREMENT,
     			title VARCHAR(50),
-    			description TEXT,
-    			campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
-				secret CHAR(32) UNIQUE NULL,
+				`description` TEXT,
+				campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+				`secret` CHAR(32) UNIQUE NULL,
 				modified  DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
-    			modified_by int(11) DEFAULT NULL,
+				expire_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+				modified_by int(11) DEFAULT NULL,
 				PRIMARY KEY (id),
 				KEY idx_title (title)
 			) ENGINE=MyISAM DEFAULT CHARSET=utf8;";

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -28,7 +28,10 @@ class Migration20230920000000ComNewsletter extends Base
     			description TEXT,
     			campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
 				secret CHAR(32) UNIQUE NULL,
-				PRIMARY KEY (id)
+				modified  DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+    			modified_by int(11) DEFAULT NULL,
+				PRIMARY KEY (id),
+				KEY idx_title (title)
 			) ENGINE=MyISAM DEFAULT CHARSET=utf8;";
 
 			$this->db->setQuery($query);

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for managing campaigns and their secrets via com_newsletter
+ **/
+class Migration20230920000000ComNewsletter extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		if (!$this->db->tableExists('campaign'))
+		{
+			$query = "CREATE TABLE IF NOT EXISTS `campaign` (
+    			id INT(11) NOT NULL AUTO_INCREMENT,
+    			title VARCHAR(50),
+    			description TEXT,
+    			campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+				secret CHAR(32) UNIQUE NULL,
+				PRIMARY KEY (id)
+			) ENGINE=MyISAM DEFAULT CHARSET=utf8;";
+
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		if ($this->db->tableExists('campaign'))
+		{
+			$query = "DROP TABLE IF EXISTS `campaign`;";
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+}

--- a/core/components/com_newsletter/models/campaign.php
+++ b/core/components/com_newsletter/models/campaign.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2023 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+use Date;
+use User;
+
+/**
+ * Model for a campaign
+ */
+class Campaign extends Relational
+{
+	/**
+	 * The table name
+	 *
+	 * @var  string
+	 */
+	protected $table = 'campaign';
+
+	/**
+	 * Default order by for model
+	 *
+	 * @var  string
+	 */
+	public $orderBy = 'id';
+
+	/**
+	 * Default order direction for select queries
+	 *
+	 * @var  string
+	 */
+	public $orderDir = 'asc';
+
+	/**
+	 * Fields and their validation criteria
+	 *
+	 * @var  array
+	 */
+	protected $rules = array(
+		'title' => 'notempty'
+	);
+	/**
+	 * Automatic fields to populate every time a row is created
+	 *
+	 * @var  array
+	 */
+	public $initiate = array(
+		'campaign_date',
+		'secret'
+	);
+
+	/**
+	 * Automatically fillable fields
+	 *
+	 * @var  array
+	 **/
+	public $always = array(
+		'modified',
+		'modified_by',
+	);
+
+	/**
+	 * Generates automatic current date field value for campaign_date
+	 * TODO: Ensure this is UTC.
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function automaticCampaignDate($data)
+	{
+		return Date::of('now')->toSql();
+	}
+
+	/**
+	 * Generates automatic modified by field value
+	 *
+	 * @param   array    $data  the data being saved
+	 * @return  integer
+	 */
+	public function automaticModifiedBy($data)
+	{
+		return User::get('id'); 
+	}
+
+	/**
+	 * Generates automatic created field value
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function automaticModified($data)
+	{
+		return $this->automaticCampaignDate($data);
+	}
+
+	/**
+	 * Generates automatic secret value on creation of new record
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function automaticSecret($data)
+	{
+		return $this->generateSecret($data);
+	}
+
+	/**
+	 * Generates new secret value 
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function generateSecret($data)
+	{
+		// create 32-character secret:
+		$secretLength = 32;
+		return \Hubzero\User\Password::genRandomPassword($secretLength);
+	}
+}

--- a/core/components/com_newsletter/models/campaign.php
+++ b/core/components/com_newsletter/models/campaign.php
@@ -67,7 +67,6 @@ class Campaign extends Relational
 
 	/**
 	 * Generates automatic current date field value for campaign_date
-	 * TODO: Ensure this is UTC.
 	 *
 	 * @param   array   $data  the data being saved
 	 * @return  string
@@ -116,7 +115,7 @@ class Campaign extends Relational
 	 * @param   array   $data  the data being saved
 	 * @return  string
 	 */
-	public function generateSecret($data)
+	public static function generateSecret($data)
 	{
 		// create 32-character secret:
 		$secretLength = 32;


### PR DESCRIPTION
### Dependencies

This work is part of Epic [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434), whose PRs should all be deployed together:
- #1693, NCN-633 `plgUserHubzero` (on user login, ensure user has a secret in the DB)
- #1683 NCN-439 `com_members` (manage user secret)
- #1676  NCN-437 `com_newsletter` (manage campaign secret)
- #1675 NCN-438 `com_config` (manage hub secret)
- #1695 NCN-702, NCN-440: `com_newsletter` (update access verification)

## Summary

As part of the Nanohub Epic [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434) we will create and maintain individual Campaign secrets (each secret consists of 32 random characters). This PR provides an interface for the Admin user to manage Campaigns, and reset their secrets, if needed.

The Campaign landing page with example records is shown below:

![new-campaign-landing-page](https://github.com/hubzero/hubzero-cms/assets/3996484/651b7369-33fe-46c2-8ce4-ce2f5e6368f8)

## Development

This development was undertaken for Nanohub, as part of the Epic NCN-434, ["Salesforce Newsletter Expiration Token Rewrite"](https://sdx-sdsc.atlassian.net/browse/NCN-434). 

### Epic [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434)

- Original development: "Hub admin campaign management - create admin UI" [NCN-437](https://sdx-sdsc.atlassian.net/browse/NCN-437)
- Revisions: "Updates to PR #1676 following code review" [NCN-618](https://sdx-sdsc.atlassian.net/browse/NCN-618)

## Motivation

The goal of this work is to enable the admin user to manage and reset secrets associated with individual Campaigns. Campaigns might be created for single-click access to secure Hub pages. The campaign information, including the name and description, the secret, the date created, the modification and expiration dates, and the modifying user, is stored in a database table named `campaign`. This Campaign secret can be hashed together with a user's unique secret and a secret unique to the Hub to create a unique code. This code can be used to form a URL that will be emailed to the user (as part of an email campaign) to provide them with access to a Hub newsletter or other resource, without requiring user login. This is general enough functionality to justify its inclusion in core.

Note that resetting the Campaign secret will invalidate any mailings that have utilized it in a hash. 

The reasoning for locating this secret-and-hash functionality entirely in the Hub database is that it fulfills needs of the target client, Nanohub. Nanohub uses the third-party software Salesforce, in conjunction with user, usage, and Hub data duplicated from the Nanohub back-end database, to generate and send email campaign and newsletters. Their duplications of the campaign, Hub, and user secrets will enable them to send email campaigns in their preferred way.

## Code Description

The Hub Campaign management UI was built into the `com_newsletter` component. Campaign management is manifested as a tab in the Newsletter component. It's present only on the administrator interface. Though these new Campaigns have nothing to do with Hubzero Newsletters, they *could* be used together in the future.

In this PR, the Newsletter component is expanded to add a tab for Campaign management. This interface enables the admin user to create and save a name and description with which the secret (not shown in the interface) is associated. The user has the option to edit an existing Campaign to reset its secret.

Architecturally, the present work required creation of an admin controller, display and edit views, a help page, a migration file, and a model for the Campaign.  

A new help file describing the use and purpose of Campaigns is linked from the Campaign landing page in the Newsletter component. A migration file is also included. This file creates the required `campaign` database table, on up migration; it drops the table on down migration.

## Testing

This feature was tested by creating, editing, and viewing Campaigns using the Admin site's Newsletter component, and by viewing the `campaign` database table to verify when secrets are regenerated.

Up and down migration was also tested successfully, as follows:

- down: php muse migration --file=Migration20230920000000ComNewsletter.php -d=down -f
 On down migration, this script drops the `campaign` table

- up: php muse migration --file=Migration20230920000000ComNewsletter.php -d=up -f
 On up migration it recreates the table.

The admin user can edit an individual campaign and optionally reset its secret. Only the secret selected should be updated (this was verified in dev testing). All changes to the title, description, modifying user, and timestamps should be correct (also verified in dev testing). 


![new-edit-campaign](https://github.com/hubzero/hubzero-cms/assets/3996484/26862cef-eec6-4fe9-a7ff-ae85c76d2336)

Queries against the `campaign` table were also used during dev testing to ensure that the secret is changed when prompted:

![campaign-table](https://github.com/hubzero/hubzero-cms/assets/3996484/47d6e814-ae28-43e9-9abc-79ce0cf2e25f)

## Deployment

This PR should be deployed alongside other PRs stemming from Nanohub Epic [NCN-434]. No hotfixes should be needed.

## Revisions

This work was revised as part of [NCN-618](https://sdx-sdsc.atlassian.net/browse/NCN-434) to include:

- ability to Delete a Campaign
- expiration date with default value 90 days
- verified that the timestamps in this work use UTC on the back-end and report local time on the front end
- verified that CSRF tokens are employed in all forms
- added strings in the language file instead of hardcoding