### PR TITLE
[PURR-155][PURR-154] Fix issue that first name and last name are missing for …

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -611,8 +611,16 @@ class Doi extends Obj
 			{
 				$xmlfile.='	<contributor contributorType="ContactPerson">';
 				$xmlfile.='		<contributorName nameType="Personal">' . $contactPerson->name . '</contributorName>';
-				$xmlfile.='		<givenName>' . $contactPerson->givenName . '</givenName>';
-				$xmlfile.='		<familyName>' . $contactPerson->surname . '</familyName>';
+				if ($contactPerson->user_id)
+				{
+					$xmlfile.='		<givenName>' . $contactPerson->givenName . '</givenName>';
+					$xmlfile.='		<familyName>' . $contactPerson->surname . '</familyName>';
+				}
+				else
+				{
+					$xmlfile.='		<givenName>' . $contactPerson->firstName . '</givenName>';
+					$xmlfile.='		<familyName>' . $contactPerson->lastName . '</familyName>';
+				}
 				
 				if (isset($contactPerson->orcid) && !empty($contactPerson->orcid))
 				{

--- a/core/plugins/projects/publications/publications.php
+++ b/core/plugins/projects/publications/publications.php
@@ -2087,10 +2087,11 @@ class plgProjectsPublications extends \Hubzero\Plugin\Plugin
 					$this->setError(Lang::txt('PLG_PROJECTS_PUBLICATIONS_PUBLICATION_ERROR_CONTACT_NOT_FOUND'));
 					continue;
 				}
-				
-				// Prompt error message if an author is chosen as contact but the email address is empty
+
+				// Prompt error message if an invited author is chosen as contact but the email address is empty
 				$owner = $author->getAuthorByOwnerId($pub->version->id, $author->project_owner_id);
-				if (empty($owner->invited_email))
+				
+				if (empty($owner->user_id) && empty($owner->invited_email))
 				{
 					Notify::error(Lang::txt('PLG_PROJECTS_PUBLICATIONS_PUBLICATION_ERROR_CONTACT_EMAIL_ADDRESS_MISSING'), 'projects');
 					App::redirect(Route::url($pub->link('editversion') . '&action=' . $this->_task));


### PR DESCRIPTION
When checking the DOI metadata set on DataCite, I found that the first name and last name of publication contact who is invited author are missing. 

Both PURR user and invited author that were added in publication workflow can be set as publication contact. However, the first name and last name of PURR user refer to properties that are different from those of the invited author in PURR database. The changes are to reference the right first name and right last name separately for PURR user and invited author when they are set as contact person of a publication. 

Test:
1. Create a publication, add an author that is not a PURR user to the publication, as well as an existing PURR user to the publication.
2. On publication review page, click on the checkbox before the author name in contact setting box, and submit the publication, approve the publication.
3. Login on doi.test.datacite.org, find the published dataset, open the metadata xml and check whether the contact persons all have given name and family name set.

I tested it locally and the result passed.

[PURR][#2487]Fix issue that email address check not pass when submitting the dataset in publication workflow
When submitting an publication, we need to check whether the email address is empty for the publication contact. When the contact is an invited author, it's possible that the email address is not set in his or her profile. Because the invited author is not a PURR user, the PURR user_id for such kind of author is 0 in database. The change is to add checking for not only the email address but also the user_id to make the condition comprehensive. PURR user always has both none-zero user_id and valid email address, so we don't have to check the publication contact who is a PURR user when submitting a publication. I'm going to commit changes to hubzero git repository.

Test:
1. Create a file publication, add an invited author in author section, but without entering the email address
2. Click checkbox before the invited author on publication review page to set the author as contact of the publication
3. Submit the publication. The expected result is that it prompts that a valid email address is required for the contact who is invited author.
4. Following the prompt to edit the contact to add the email address and re-submit the publication. The expected result that the publication is successfully submitted.
I tested it locally and the result passed.