### PR TITLE
Show tagged groups Public Users

### DIFF
--- a/core/plugins/tags/groups/groups.php
+++ b/core/plugins/tags/groups/groups.php
@@ -54,28 +54,40 @@ class plgTagsGroups extends \Hubzero\Plugin\Plugin
 		}
 		$ids = implode(',', $ids);
 
-		$from = '';
+		// The conditions allows tag search results to show groups in public view, not logged in.
+        if (User::isGuest()) {
+            $from = '';
+            $discoverability = " AND a.discoverability=0 ";
+        } else if (User::authorise('core.view', 'com_groups')) {
+            // user in role that can view all groups (admin)
+            $from = '';
+            $discoverability = "";
+        } else {
+            // @TODO: This produces a result for each member of the group which could grow quite large.
+            // The query reduces this with a GROUP BY a.gidNumber but it might be beneficial
+            // to generate a list of gidNumbers the user is a member of and include it in the
+            // query something like: (a.discoverability=0 OR a.gidNumber IN ($gidNumbers))
 
-		if (!User::authorise('core.view', 'com_groups'))
-		{
-			$from = " JOIN #__xgroups_members AS m ON m.gidNumber=a.gidNumber AND m.uidNumber=" . (int)User::get('id', 0);
-		}
+            $from = " JOIN #__xgroups_members AS m ON m.gidNumber=a.gidNumber ";
+            $discoverability = " AND (a.discoverability=0 OR m.uidNumber = " . (int) User::get('id', 0) . ") ";
+        }
 
-		// Build the query
-		$f_count = "SELECT COUNT(f.gidNumber) FROM (SELECT a.gidNumber, COUNT(DISTINCT t.tagid) AS uniques ";
+        // Build the query
+        $f_count = "SELECT COUNT(f.gidNumber) FROM (SELECT a.gidNumber, COUNT(DISTINCT t.tagid) AS uniques ";
 
-		$f_fields = "SELECT a.gidNumber AS id, a.description AS title, a.cn AS alias, NULL AS itext, a.public_desc AS ftext, a.type AS state, a.created,
-					a.created_by, NULL AS modified, NULL AS publish_up,
-					NULL AS publish_down, CONCAT('index.php?option=com_groups&cn=', a.cn) AS href, 'groups' AS section, COUNT(DISTINCT t.tagid) AS uniques,
-					a.params, NULL AS rcount, NULL AS data1, NULL AS data2, NULL AS data3 ";
-		$f_from = " FROM #__xgroups AS a $from
-					JOIN #__tags_object AS t
-					WHERE (a.type=1 OR a.type=3) AND a.discoverability=0
-					AND a.gidNumber=t.objectid
-					AND t.tbl='groups'
-					AND t.tagid IN ($ids)";
-		$f_from .= " GROUP BY a.gidNumber HAVING uniques=" . count($tags);
-		$order_by  = " ORDER BY ";
+        $f_fields = "SELECT a.gidNumber AS id, a.description AS title, a.cn AS alias, NULL AS itext, a.public_desc AS ftext, a.type AS state, a.created,
+                                        a.created_by, NULL AS modified, NULL AS publish_up,
+                                        NULL AS publish_down, CONCAT('index.php?option=com_groups&cn=', a.cn) AS href, 'groups' AS section, COUNT(DISTINCT t.tagid) AS uniques,
+                                        a.params, NULL AS rcount, NULL AS data1, NULL AS data2, NULL AS data3 ";
+        $f_from = " FROM #__xgroups AS a $from
+                                        JOIN #__tags_object AS t
+                                        WHERE (a.type=1 OR a.type=3) $discoverability
+                                        AND a.gidNumber=t.objectid
+                                        AND t.tbl='groups'
+                                        AND t.tagid IN ($ids)";
+        $f_from .= " GROUP BY a.gidNumber HAVING uniques=" . count($tags);
+        $order_by  = " ORDER BY ";
+
 		switch ($sort)
 		{
 			case 'title':

--- a/core/plugins/tags/groups/groups.php
+++ b/core/plugins/tags/groups/groups.php
@@ -55,38 +55,38 @@ class plgTagsGroups extends \Hubzero\Plugin\Plugin
 		$ids = implode(',', $ids);
 
 		// The conditions allows tag search results to show groups in public view, not logged in.
-        if (User::isGuest()) {
-            $from = '';
-            $discoverability = " AND a.discoverability=0 ";
-        } else if (User::authorise('core.view', 'com_groups')) {
-            // user in role that can view all groups (admin)
-            $from = '';
-            $discoverability = "";
-        } else {
-            // @TODO: This produces a result for each member of the group which could grow quite large.
-            // The query reduces this with a GROUP BY a.gidNumber but it might be beneficial
-            // to generate a list of gidNumbers the user is a member of and include it in the
-            // query something like: (a.discoverability=0 OR a.gidNumber IN ($gidNumbers))
+		if (User::isGuest()) {
+			$from = '';
+			$discoverability = " AND a.discoverability=0 ";
+		} else if (User::authorise('core.view', 'com_groups')) {
+			// user in role that can view all groups (admin)
+			$from = '';
+			$discoverability = "";
+		} else {
+			// @TODO: This produces a result for each member of the group which could grow quite large.
+			// The query reduces this with a GROUP BY a.gidNumber but it might be beneficial
+			// to generate a list of gidNumbers the user is a member of and include it in the
+			// query something like: (a.discoverability=0 OR a.gidNumber IN ($gidNumbers))
 
-            $from = " JOIN #__xgroups_members AS m ON m.gidNumber=a.gidNumber ";
-            $discoverability = " AND (a.discoverability=0 OR m.uidNumber = " . (int) User::get('id', 0) . ") ";
-        }
+			$from = " JOIN #__xgroups_members AS m ON m.gidNumber=a.gidNumber ";
+			$discoverability = " AND (a.discoverability=0 OR m.uidNumber = " . (int) User::get('id', 0) . ") ";
+		}
 
-        // Build the query
-        $f_count = "SELECT COUNT(f.gidNumber) FROM (SELECT a.gidNumber, COUNT(DISTINCT t.tagid) AS uniques ";
+		// Build the query
+		$f_count = "SELECT COUNT(f.gidNumber) FROM (SELECT a.gidNumber, COUNT(DISTINCT t.tagid) AS uniques ";
 
-        $f_fields = "SELECT a.gidNumber AS id, a.description AS title, a.cn AS alias, NULL AS itext, a.public_desc AS ftext, a.type AS state, a.created,
-                                        a.created_by, NULL AS modified, NULL AS publish_up,
-                                        NULL AS publish_down, CONCAT('index.php?option=com_groups&cn=', a.cn) AS href, 'groups' AS section, COUNT(DISTINCT t.tagid) AS uniques,
-                                        a.params, NULL AS rcount, NULL AS data1, NULL AS data2, NULL AS data3 ";
-        $f_from = " FROM #__xgroups AS a $from
-                                        JOIN #__tags_object AS t
-                                        WHERE (a.type=1 OR a.type=3) $discoverability
-                                        AND a.gidNumber=t.objectid
-                                        AND t.tbl='groups'
-                                        AND t.tagid IN ($ids)";
-        $f_from .= " GROUP BY a.gidNumber HAVING uniques=" . count($tags);
-        $order_by  = " ORDER BY ";
+		$f_fields = "SELECT a.gidNumber AS id, a.description AS title, a.cn AS alias, NULL AS itext, a.public_desc AS ftext, a.type AS state, a.created,
+						a.created_by, NULL AS modified, NULL AS publish_up,
+						NULL AS publish_down, CONCAT('index.php?option=com_groups&cn=', a.cn) AS href, 'groups' AS section, COUNT(DISTINCT t.tagid) AS uniques,
+						a.params, NULL AS rcount, NULL AS data1, NULL AS data2, NULL AS data3 ";
+		$f_from = " FROM #__xgroups AS a $from
+						JOIN #__tags_object AS t
+						WHERE (a.type=1 OR a.type=3) $discoverability
+						AND a.gidNumber=t.objectid
+						AND t.tbl='groups'
+						AND t.tagid IN ($ids)";
+		$f_from .= " GROUP BY a.gidNumber HAVING uniques=" . count($tags);
+		$order_by  = " ORDER BY ";
 
 		switch ($sort)
 		{


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- Previous PR: https://github.com/hubzero/hubzero-cms/pull/1615
- https://sdx-sdsc.atlassian.net/browse/VHUB-9
- https://theghub.org/support/ticket/2601

**Brief summary of the issue**
When a user adds a tag to a group, and upon searching for a tag, that specific group won't appear in the search results for public visitors but will appear for registered and logged in users. 

An example is on the search results of https://theghub.org/tags/ghub. The ISMIP6 group has the associated "Ghub" tag. But that ISMIP6 group only shows up in the results when the user is registered and logged in. The issue is how we can make groups show up for specific tags in the search results for non-registered (public) users.

**Brief summary of the fix**
- The search SQL statement originally filtered out those groups. Talking it over, Nick added conditions to removed the "from" from guests and users in role that view all groups (admin). 

**Brief summary of your testing**
Manual testing locally. It works where group shows up logged in or public. 

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
No

**Double check someone is assigned to review the ticket**
Yes - Nick and David