### PR TITLE
"Ask a question" links do not work on tool pages

### DIFF
--- a/core/plugins/resources/questions/questions.php
+++ b/core/plugins/resources/questions/questions.php
@@ -269,6 +269,9 @@ class plgResourcesQuestions extends \Hubzero\Plugin\Plugin
 			$funds = $funds > 0 ?: 0;
 		}
 
+
+		// Probably need to set $funds
+		
 		$view = $this->view('new', 'question')
 			->set('option', $this->option)
 			->set('resource', $this->model)

--- a/core/plugins/resources/questions/questions.php
+++ b/core/plugins/resources/questions/questions.php
@@ -269,6 +269,7 @@ class plgResourcesQuestions extends \Hubzero\Plugin\Plugin
 
 			$funds = $funds > 0 ?: 0;
 		}
+		
 		$view = $this->view('new', 'question')
 			->set('option', $this->option)
 			->set('resource', $this->model)

--- a/core/plugins/resources/questions/questions.php
+++ b/core/plugins/resources/questions/questions.php
@@ -260,6 +260,7 @@ class plgResourcesQuestions extends \Hubzero\Plugin\Plugin
 		// Are we banking?
 		$upconfig = Component::params('com_members');
 		$banking = $upconfig->get('bankAccounts');
+		$funds = 0;
 
 		if ($banking)
 		{
@@ -268,9 +269,6 @@ class plgResourcesQuestions extends \Hubzero\Plugin\Plugin
 
 			$funds = $funds > 0 ?: 0;
 		}
-
-
-		// Probably need to set $funds
 		
 		$view = $this->view('new', 'question')
 			->set('option', $this->option)

--- a/core/plugins/resources/questions/questions.php
+++ b/core/plugins/resources/questions/questions.php
@@ -269,7 +269,7 @@ class plgResourcesQuestions extends \Hubzero\Plugin\Plugin
 
 			$funds = $funds > 0 ?: 0;
 		}
-		
+
 		$view = $this->view('new', 'question')
 			->set('option', $this->option)
 			->set('resource', $this->model)

--- a/core/plugins/resources/questions/questions.php
+++ b/core/plugins/resources/questions/questions.php
@@ -269,7 +269,6 @@ class plgResourcesQuestions extends \Hubzero\Plugin\Plugin
 
 			$funds = $funds > 0 ?: 0;
 		}
-		
 		$view = $this->view('new', 'question')
 			->set('option', $this->option)
 			->set('resource', $this->model)


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- https://sdx-sdsc.atlassian.net/browse/VHUB-20
- https://theghub.org/support/ticket/2675

**Brief summary of the issue**
"Ask a question" links do not work on tool pages, for example on the [ATM Based Crevasse Detection & Extraction workflow](https://theghub.org/resources/crevasseoib/questions). The error is a 500 error. 

**Brief summary of the fix**
- Using the debugger on production, the $funds variable wasn't set that was sent to the template page. 
- The error show !! Undefined variables: funds !!
- Before the variable gets passed, $funds is set with an initial value of 0

**Brief summary of your testing**
Manual testing on ghub production site with SSH. Screenshot on the Jira ticket show the fix. 

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
No

**Double check someone is assigned to review the ticket**
Yes - Nick and David