### PR TITLE
[PURR-89] [PURR-150] rework failure logic in the custom extension repository

### DIFF
--- a/core/components/com_installer/admin/views/customexts/tmpl/fetched.php
+++ b/core/components/com_installer/admin/views/customexts/tmpl/fetched.php
@@ -31,6 +31,9 @@ Html::behavior('tooltip');
 				<?php foreach ($this->success as $success) : ?>
 					<tr>
 						<td class="merge-success">
+							<?php
+								echo '<strong>Extension: ' . $success['extension'] . '</strong>';
+							?>
 							<?php if ($success['message'][0] != Lang::txt('COM_INSTALLER_CUSTOMEXTS_CLONE_SUCCESSFUL')
 										&& $success['message'][0] != Lang::txt('COM_INSTALLER_CUSTOMEXTS_FETCH_CODE_UP_TO_DATE')
 										&& !preg_match('/ineligible/', $success['message'][0])) : ?>

--- a/core/components/com_installer/admin/views/customexts/tmpl/merged.php
+++ b/core/components/com_installer/admin/views/customexts/tmpl/merged.php
@@ -17,8 +17,6 @@ Html::behavior('tooltip');
 ?>
 
 <form action="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller); ?>" method="post" name="adminForm" id="adminForm">
-
-	<?php if (!empty($this->success)) : ?>
 		<table class="adminlist success">
 			<thead>
 				<tr>
@@ -26,46 +24,21 @@ Html::behavior('tooltip');
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($this->success as $success) : ?>
+				<?php foreach ($this->msg as $msg) : ?>
 					<tr>
 						<td>
 							<?php
-							echo '<strong> Extension:  ' . $success['extension'] . '</strong>';
+							echo '<strong> Extension:  ' . $msg['extension'] . '</strong>';
 							?>
 							<br />
 							<br />
-							<pre><?php echo $success['message']; ?></pre>
+							<pre><?php echo $msg['message']; ?></pre>
 						</td>
 					</tr>
 				<?php endforeach; ?>
 			</tbody>
 		</table>
-	<?php endif; ?>
 	<br /><br />
-
-	<?php if (!empty($this->failed)) : ?>
-		<table class="adminlist failed">
-			<thead>
-				<tr>
-					<th scope="col"><?php echo Lang::txt('COM_INSTALLER_CUSTOMEXTS_PULL_FAIL'); ?></th>
-				</tr>
-			</thead>
-			<tbody>
-				<?php foreach ($this->failed as $failed) : ?>
-					<tr>
-						<td>
-							<?php
-							echo '<strong> Extension:  ' . $failed['extension'] . '</strong>';
-							?>
-							<br />
-							<br />
-							<pre><?php echo implode(",", $failed['message']); ?></pre>
-						</td>
-					</tr>
-				<?php endforeach; ?>
-			</tbody>
-		</table>
-	<?php endif; ?>
 
 	<input type="hidden" name="option" value="<?php echo $this->option ?>" />
 	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>">

--- a/core/libraries/Hubzero/Console/Command/Repository.php
+++ b/core/libraries/Hubzero/Console/Command/Repository.php
@@ -235,8 +235,7 @@ class Repository extends Base implements CommandInterface
 	public function update()
 	{
 		$mode = $this->output->getMode();
-
-        if ($this->arguments->getOpt('f'))
+		if ($this->arguments->getOpt('f'))
 		{
 			if ($mode != 'minimal')
 			{
@@ -653,15 +652,15 @@ class Repository extends Base implements CommandInterface
 		{
 		$git_branch_arr = explode("/", $this->arguments->getOpt('git_branch'));
 		$git_branch = $git_branch_arr[1];
-	}
-	else
-	{
-		// get default remote
-		$default_remote = shell_exec("umask 0002 && cd " . $repoPath . " && git remote show");
-		// get remote default branch
-		$default_remote_branch_cmd = "git remote show " . trim($default_remote) . " | grep 'HEAD branch' | cut -d ':' -f 2";
-		$git_branch = shell_exec("umask 0002 && cd " . $repoPath . " && ". $default_remote_branch_cmd);
-	}
+		}
+		else
+		{
+			// get default remote
+			$default_remote = shell_exec("umask 0002 && cd " . $repoPath . " && git remote show");
+			// get remote default branch
+			$default_remote_branch_cmd = "git remote show " . trim($default_remote) . " | grep 'HEAD branch' | cut -d ':' -f 2";
+			$git_branch = shell_exec("umask 0002 && cd " . $repoPath . " && ". $default_remote_branch_cmd);
+		}
 
 		$cur_branch = "git rev-parse --abbrev-ref HEAD";
 		// Get current branch


### PR DESCRIPTION
- This issue might have multiple related PRs in the system, PURR-89 is only the most recent.
- Custom extension pulls via the admin were not working. The component would blankly report nothing during many scenarios and indicate nothing happening. There were multiple regular expression checks failing due to null values not being checked before doing regex checks.
- I reworked some of the logic that was looking for errors in the php. The code was fragile, doing very specific regex checks for some errors. No custom logic was done with the error detection, other than an attempt to format errors differently than success messages.
- I created a temp custom extension in gitlab, made various updates in that repo and tested this component to make sure it properly grabbed the new code.
- No hotfix changes needed, this code should be part of 2.2.27

Overall, this component needs some major refactoring. It is way over architected. But these fixes should get it up and running for now. 