### PR TITLE
[PURR-125] anonymous ftp workflow - 2 download buttons

### DIFF
--- a/core/components/com_publications/admin/language/en-GB/en-GB.com_publications.ini
+++ b/core/components/com_publications/admin/language/en-GB/en-GB.com_publications.ini
@@ -649,7 +649,8 @@ COM_PUBLICATIONS_CONFIG_SFTP_PATH="SFTP Directory"
 COM_PUBLICATIONS_CONFIG_SFTP_PATH_DESC="Path for storing SFTP accessible publication bundle links"
 COM_PUBLICATIONS_CONFIG_SFTP_TYPE_BLACKLIST="FTP File Type Blacklist"
 COM_PUBLICATIONS_CONFIG_SFTP_TYPE_BLACKLIST_DESC="Comma Separated List of Publication Types that shouldn't/ can't be downloaded via sFTP"
-
+COM_PUBLICATIONS_CONFIG_FTP_DOC="FTP download guide"
+COM_PUBLICATIONS_CONFIG_FTP_DOC_DESC="A guide regarding how to download large dataset using ftp client"
 ; Types
 COM_PUBLICATIONS_TYPES="Types"
 COM_PUBLICATIONS_TYPES_DETAILS="Item Details"

--- a/core/components/com_publications/config/config.xml
+++ b/core/components/com_publications/config/config.xml
@@ -36,6 +36,7 @@
 		<field name="sftptypeblacklist" type="text" menu="hide" default="" label="COM_PUBLICATIONS_CONFIG_SFTP_TYPE_BLACKLIST" description="COM_PUBLICATIONS_CONFIG_SFTP_TYPE_BLACKLIST_DESC" />
 		<field name="documentation" type="text" menu="hide" default="" label="COM_PUBLICATIONS_CONFIG_DOCUMENTATION_PATH" description="COM_PUBLICATIONS_CONFIG_DOCUMENTATION_PATH_DESC" />
 		<field name="deposit_terms" type="text" menu="hide" default="" label="COM_PUBLICATIONS_CONFIG_TERMS_URL" description="COM_PUBLICATIONS_CONFIG_TERMS_URL_DESC" />
+		<field name="ftp_doc" type="text" menu="hide" default="https://purr.purdue.edu/kb/projects/access-datasets-using-ftp-client" label="COM_PUBLICATIONS_CONFIG_FTP_DOC" description="COM_PUBLICATIONS_CONFIG_FTP_DOC_DESC" />
 
 		<field name="include_author_name_in_search" type="list" default="0" label="COM_PUBLICATIONS_CONFIG_SEARCH_AUTHOR_NAME" description="COM_PUBLICATIONS_CONFIG_SEARCH_AUTHOR_NAME_DESC">
 			<option value="0">JNO</option>

--- a/core/components/com_publications/helpers/html.php
+++ b/core/components/com_publications/helpers/html.php
@@ -850,7 +850,7 @@ class Html
 	 * @param   array    $options
 	 * @return  string
 	 */
-	public static function primaryButton($class, $href, $msg, $xtra = '', $title = '', $action = '', $disabled = false, $pop = '', $options = array())
+	public static function primaryButton($class, $href, $msg, $xtra = '', $title = '', $action = '', $disabled = false, $pop = '', $options = array(), $btnType = '')
 	{
 		$view = new \Hubzero\Component\View(array(
 			'base_path' => dirname(__DIR__) . DS . 'site',
@@ -867,6 +867,14 @@ class Html
 		$view->pop      = $pop;
 		$view->msg      = $msg;
 		$view->options  = $options;
+		
+		if (isset($btnType) && !empty($btnType))
+		{
+			$view->btnType = $btnType;
+			
+			$pubconfig = Component::params('com_publications');
+			$view->ftpDoc = $pubconfig->get('ftp_doc');
+		}
 
 		return $view->loadTemplate();
 	}

--- a/core/components/com_publications/migrations/Migration20220308111111ComPublications.php
+++ b/core/components/com_publications/migrations/Migration20220308111111ComPublications.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2022 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding ftp download document path to params in publication component 
+ **/
+class Migration20220308111111ComPublications extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		if ($this->db->tableExists('#__extensions'))
+		{			
+			$publicationParams = Component::params('com_publications');
+			$publicationParams->set('ftp_doc', 'https://purr.purdue.edu/kb/projects/access-datasets-using-ftp-client');
+			$table = '#__extensions';
+			$params = $publicationParams->toString();
+			if ($this->db->tableExists($table) && $this->db->tableHasField($table, 'params'))
+			{
+				$query = "UPDATE `$table` SET `params`='$params' WHERE `name`='com_publications'";
+				$this->db->setQuery($query);
+				$this->db->query();
+			}
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$publicationParams = Component::params('com_publications');
+		$publicationParams->set('ftp_doc', null);
+		$table = '#__extensions';
+		$params = $publicationParams->toString();
+		if ($this->db->tableExists($table) && $this->db->tableHasField($table, 'params'))
+		{
+			$query = "UPDATE `$table` SET `params`='$params' WHERE `name`='com_publications'";
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+}

--- a/core/components/com_publications/models/attachments.php
+++ b/core/components/com_publications/models/attachments.php
@@ -288,7 +288,7 @@ class Attachments extends Obj
 	 * @param   boolean  $authorized
 	 * @return  mixed    object or boolean
 	 */
-	public function drawLauncher($name = null, $pub = null, $element = null, $elements = null, $authorized = true)
+	public function drawLauncher($name = null, $pub = null, $element = null, $elements = null, $authorized = true, $httpsBtn = false)
 	{
 		if ($name === null || $element === null || $pub === null)
 		{
@@ -304,7 +304,7 @@ class Attachments extends Obj
 		}
 
 		// Draw link
-		return $type->drawLauncher($element->manifest, $element->id, $pub, $element->block, $elements, $authorized);
+		return $type->drawLauncher($element->manifest, $element->id, $pub, $element->block, $elements, $authorized, $httpsBtn);
 	}
 
 	/**

--- a/core/components/com_publications/models/attachments/file.php
+++ b/core/components/com_publications/models/attachments/file.php
@@ -463,7 +463,7 @@ class File extends Base
 	 * @param   boolean  $authorized
 	 * @return  boolean
 	 */
-	public function drawLauncher($element, $elementId, $pub, $blockParams, $elements, $authorized)
+	public function drawLauncher($element, $elementId, $pub, $blockParams, $elements, $authorized, $httpsBtn)
 	{
 		// Get configs
 		$configs = $this->getConfigs($element->params, $elementId, $pub, $blockParams);
@@ -572,13 +572,29 @@ class File extends Base
 						// Is sFTP enabled and is the file over the threshold?
 						if ($pub->config()->get('sftppath') && $size >= intval($pub->config()->get('sftpsize', 5000)))
 						{
-							$uri = \Hubzero\Utility\Uri::getInstance();
-							$uri->setScheme('ftp');
-							//$uri->setUser('guest');
-							//$uri->setPass('guest');
-							$uri->setPath($pub->_curationModel->getBundleName(true));
+							if ($httpsBtn)
+							{
+								$btnType = "https";
+								$label .= ' ' . Lang::txt('with https');
+								
+								$uri = \Hubzero\Utility\Uri::getInstance();
+								$uri->setScheme('https');
+								$uri->setPath('app' . DS . $pub->config()->get('sftppath') . DS . $pub->_curationModel->getBundleName(true));
+								$url = $uri->toString();
+							}
+							else
+							{
+								$btnType = "ftp";
+								$label .= ' ' . Lang::txt('with ftp');
+								
+								$uri = \Hubzero\Utility\Uri::getInstance();
+								$uri->setScheme('ftp');
+								//$uri->setUser('guest');
+								//$uri->setPass('guest');
+								$uri->setPath($pub->_curationModel->getBundleName(true));
 
-							$url = $uri->toString();
+								$url = $uri->toString();
+							}
 						}
 					}
 
@@ -599,8 +615,15 @@ class File extends Base
 				}
 				$class = 'btn btn-primary active'; //icon-next
 				$class .= $disabled ? ' link_disabled' : '';
-
-				$html  = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, '', $disabled, $pop, $options);
+				
+				if (isset($btnType))
+				{
+					$html = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, '', $disabled, $pop, $options, $btnType);
+				}
+				else
+				{
+					$html = \Components\Publications\Helpers\Html::primaryButton($class, $url, $label, null, $title, '', $disabled, $pop, $options);
+				}
 			}
 		}
 		elseif ($role == 2 && $attachments)

--- a/core/components/com_publications/site/assets/css/publications.css
+++ b/core/components/com_publications/site/assets/css/publications.css
@@ -549,12 +549,15 @@ div.sample p {
 #primary-document {
 	width: 100%;
 	text-align: left;
+	margin-bottom: 2px;
 }
 #primary-document .btn:first-child {
-	width: calc(100% - (1.5em + 8px));
+	width: calc(100%);
+	padding-left: 8px;
+	padding-right: 8px;
 }
 #primary-document .dropdown-menu {
-	width: 100%;
+	width: calc(100% + 30px);
 }
 #primary-document_pop {
 	display: none;
@@ -1450,6 +1453,19 @@ table.resource {
 .launch-wrap #primary-document {
 	width: 60%;
 	padding-top: 6em;
+}
+.ftpIntro {
+	border: 0;
+	background: none;
+	font-size: 85%;
+	margin-top:0px;
+	margin-bottom:2px;
+	padding-left:7px;
+	padding-bottom:2px;
+}
+p.ftpIntro > a {
+	color: #333333;
+	text-decoration: underline;
 }
 .launch-choices {
 	position: absolute;

--- a/core/components/com_publications/site/views/view/tmpl/_primary.php
+++ b/core/components/com_publications/site/views/view/tmpl/_primary.php
@@ -29,6 +29,9 @@ if ($this->disabled): ?>
 				<?php endforeach; ?>
 			</ul>
 		</div>
+		<?php if (isset($this->btnType) && !empty($this->btnType) && $this->btnType == "ftp"):?>		
+			<p class="ftpIntro"><a href="<?php echo ($this->ftpDoc) ? $this->ftpDoc : '';?>" target="_blank"><?php echo Lang::txt('FTP download guide');?></a></p>
+		<?php endif; ?>
 	<?php else: ?>
 		<p id="primary-document">
 			<a class="btn btn-primary<?php echo ($this->class)  ? ' ' . $this->class : ''; ?>" <?php

--- a/core/components/com_publications/site/views/view/tmpl/default.php
+++ b/core/components/com_publications/site/views/view/tmpl/default.php
@@ -104,6 +104,31 @@ else
 						);
 
 						echo $launcher;
+							// Check if an https download button is needed
+							$path = $this->publication->path('base', true) . DS . $this->publication->_curationModel->getBundleName();
+							
+							if ($path && file_exists($path))
+							{
+								$size = filesize($path);
+
+								// Convert to MB
+								$size = (($size / 1024) / 1024);
+								
+								if ($this->publication->config()->get('sftppath') && $size >= intval($this->publication->config()->get('sftpsize', 5000)))
+								{
+									// Draw https button
+									$launcherHttps = $attModel->drawLauncher(
+										$element->manifest->params->type,
+										$this->publication,
+										$element,
+										$elements,
+										$this->publication->access('view-all'),
+										true
+									);
+
+									echo $launcherHttps;
+								}
+							}
 					}
 				}
 


### PR DESCRIPTION
- JIRA task: https://sdx-sdsc.atlassian.net/browse/PURR-125
- Support ticket: https://purr.purdue.edu/support/ticket/2383
- PURR core addition: 8 - anonymous ftp workflow
- Summary of Issue: Popular browsers stopped supporting anonymous FTP. Instead, a popup dialog is presented to download an FTP client, which is not convenient. Pascal made backend changes to apache to transfer file via https, and now we need two download buttons to support both types of download.
- Summary of Fix/Changes: Created two download buttons: one for HTTPS and another for FTP.
- Summary of Testing: Testing done by PURR staff on their dev environment. This will be tested again on PURR production hub by PURR staff.
- Hotfix needed? This will be pulled to PURR prod as part of testing and targeted for next CMS release (2.2.27)
- NOTE: This update contains a migration, but it only provides a default value for param field.