### PR TITLE
[#2505]Fix issue that contact author's organization is not set in DOI metadata set

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -630,7 +630,7 @@ class Doi extends Obj
 				if ($contactPerson->organization)
 				{
 					$orgidAtr = (isset($contactPerson->orgid) && !empty($contactPerson->orgid)) ? ' affiliationIdentifier="' . $contactPerson->orgid . '"' . ' affiliationIdentifierScheme="ROR" schemeURI="https://ror.org"' : "";
-					$xmlfile .= '		<affiliation' .  $orgidAtr . '>' . $author->organization . '</affiliation>';
+					$xmlfile .= '		<affiliation' .  $orgidAtr . '>' . $contactPerson->organization . '</affiliation>';
 				}
 				
 				$xmlfile.='	</contributor>';


### PR DESCRIPTION
PURR Ticket #: https://purr.purdue.edu/support/ticket/2505
Issue: The organization of the contact person to the publication is not set in the DOI metadata set on DataCite (doi.datacite.org)
Fix: Get the organization from the contactPerson, rather than from author.
Test: 1. Start a file publication, set the user who has affiliated organization as contact, , submit and approve the publication.
        2. login on doi.datacite.org to check if the organization of the contact author is showing up in contributors->contributor-?affiliation element.

Jerry 
