### PR TITLE
[NCN-633] Rework user secret into core hubzero plugin

### DIFF
--- a/core/plugins/user/hubzero/hubzero.php
+++ b/core/plugins/user/hubzero/hubzero.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package    hubzero-cms
- * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @copyright  Copyright (c) 2005-2024 The Regents of the University of California.
  * @license    http://opensource.org/licenses/MIT MIT
  */
 

--- a/core/plugins/user/hubzero/hubzero.php
+++ b/core/plugins/user/hubzero/hubzero.php
@@ -311,6 +311,10 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
 			$db->query();
 		}
 
+		// Determine whether user has an existing Secret, and create if needed.
+		$userid = $instance->get('id');
+		$this->verifyUserSecret($userid);
+
 		// Hit the user last visit field
 		$instance->setLastVisit();
 
@@ -634,6 +638,9 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
         $update_UsersPointsSubscription_Query = "UPDATE `#__users_points_subscriptions` set contact=" . $db->quote($anonUserName) . " where uid=" . $db->quote($userId);
         $this->runUpdateOrDeleteQuery($update_UsersPointsSubscription_Query);
 
+		// replace user secret with null
+		$this->nullifyUserSecret($userId);
+
         // ----------- DELETE the user's home directory, with the path being /webdav/home/$userName. ----------
         if ($userName) {
             // as user Apache, we can't delete the directory so we need to delete all files.
@@ -650,4 +657,114 @@ class plgUserHubzero extends \Hubzero\Plugin\Plugin
 
 		return true;
     }
+
+	/**
+	 * This utility method checks whether current user has a secret set
+	 * in the database, and if not, it generates and saves one.
+	 *
+	 * @param   integer	$userId  Primary key identifying user in jos_users table
+	 * @return  boolean	True if user has secret column populated in database
+	 */
+	protected function verifyUserSecret($userId)
+	{
+		// create a new user secret if none exists in database:
+		if (!$this->checkForUserSecret($userId))
+		{
+			$newSecret = $this->createUserSecret();
+
+			// Attempt to save the new user secret to the database:
+			if (!$this->saveUserSecret($userId, $newSecret))
+			{
+				return false;
+			}
+		}
+		// User secret exists in database:
+		return true;
+	}
+
+	/**
+	 * This utility method will return true if current user has a secret set, false otherwise.
+	 *
+	 * @param   integer	$userId    Primary key identifying user in jos_users table
+	 * @return  boolean	$hasSecret True if user has secret column populated in database
+	 */
+	protected function checkForUserSecret($userId)
+	{
+		$query = new \Hubzero\Database\Query;
+
+		// Determine whether user's secret is different from null
+		$foundSecret = $query->select('*')
+               		->from('#__users')
+               		->whereEquals('id', $userId)
+               		->whereIsNotNull('secret')
+               		->fetch();
+
+		// User has secret set if one row was returned:
+       	if (is_array($foundSecret) && count($foundSecret) == 1)
+       	{
+       		return true;
+       	}
+       	return false;
+	}
+
+	/**
+	 * This utility method generates a new user secret.
+	 *
+	 * @return String user secret
+	 */
+	protected function createUserSecret()
+	{
+		// create 32-character secret:
+		$secretLength = 32;
+		$newSecret = \Hubzero\User\Password::genRandomPassword($secretLength);
+
+		if (!is_null($newSecret)) {
+			return $newSecret;
+		}
+		return false;
+	}
+
+	/**
+	 * This utility method saves a new user secret.
+	 *
+	 * @param   integer	$userId  Primary key identifying user in jos_users table
+	 * @param   String $secret   User secret
+	 * @return  boolean	True if secret column successfully populated in database
+	 */
+	protected function saveUserSecret($userId, $secret)
+	{
+		$query = new \Hubzero\Database\Query;
+
+		// Set the secret generated for this user:
+		$query->update('#__users')
+				->set(['secret' => $secret])
+				->whereEquals('id', $userId)
+				->execute();
+
+		return true;
+	}
+
+	/**
+	 * Replaces user secret with null.
+	 *
+	 * @param   integer	$userId  Primary key identifying user in jos_users table
+	 * @return  boolean	True if secret value was overwritten successfully.
+	 */
+	protected function nullifyUserSecret($userId)
+	{
+		$query = new \Hubzero\Database\Query;
+
+		// If user exists:
+		$user = User::oneOrFail($userId);
+		if (isset($user))
+		{
+			// NULL out any existing secret for this user:
+			$query->update('#__users')
+				->set(['secret' => NULL])
+				->whereEquals('id', $userId)
+				->execute();
+			return true;
+		}
+		return false;
+	}
 }

--- a/core/plugins/user/hubzero/hubzero.xml
+++ b/core/plugins/user/hubzero/hubzero.xml
@@ -5,7 +5,7 @@
 	<author>HUBzero</author>
 	<authorUrl>hubzero.org</authorUrl>
 	<authorEmail>support@hubzero.org</authorEmail>
-	<copyright>Copyright (c) 2005-2020 The Regents of the University of California.</copyright>
+	<copyright>Copyright (c) 2005-2024 The Regents of the University of California.</copyright>
 	<license>http://opensource.org/licenses/MIT MIT</license>
 	<version>2.2.0</version>
 	<description>PLG_USER_HUBZERO_XML_DESCRIPTION</description>

--- a/core/plugins/user/hubzero/language/en-GB/en-GB.plg_user_hubzero.ini
+++ b/core/plugins/user/hubzero/language/en-GB/en-GB.plg_user_hubzero.ini
@@ -1,5 +1,5 @@
 ; @package      hubzero-cms
-; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @copyright    Copyright (c) 2005-2024 The Regents of the University of California.
 ; @license      http://opensource.org/licenses/MIT MIT
 
 ; Note : All ini files need to be saved as UTF-8 - No BOM

--- a/core/plugins/user/hubzero/language/en-GB/en-GB.plg_user_hubzero.sys.ini
+++ b/core/plugins/user/hubzero/language/en-GB/en-GB.plg_user_hubzero.sys.ini
@@ -1,5 +1,5 @@
 ; @package      hubzero-cms
-; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @copyright    Copyright (c) 2005-2024 The Regents of the University of California.
 ; @license      http://opensource.org/licenses/MIT MIT
 
 ; Note : All ini files need to be saved as UTF-8 - No BOM

--- a/core/plugins/user/hubzero/migrations/Migration20180109000000PlgUserHubzero.php
+++ b/core/plugins/user/hubzero/migrations/Migration20180109000000PlgUserHubzero.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package    hubzero-cms
- * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @copyright  Copyright (c) 2005-2024 The Regents of the University of California.
  * @license    http://opensource.org/licenses/MIT MIT
  */
 

--- a/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
+++ b/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package    hubzero-cms
- * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @copyright  Copyright (c) 2005-2024 The Regents of the University of California.
  * @license    http://opensource.org/licenses/MIT MIT
  */
 

--- a/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
+++ b/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
@@ -61,7 +61,7 @@ class Migration20230909000000PlgUserHubzero extends Base
 	/**
 	 * Down
 	 *
-	 * Drop 'secret' column from jos_users table.
+	 * No change is made for down migration.
 	 *
 	 **/
 	public function down()

--- a/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
+++ b/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
@@ -13,9 +13,9 @@ defined('_HZEXEC_') or die();
 /**
  * Migration script for adding User Secret to plugin
  *
- * This migration script creates a jos_users column for the plugin to populate
- * with a unique user secret, on user login. On 'down' migration the column
- * is dropped from the table.
+ * This migration script checks for jos_users column for the plugin to populate
+ * with a unique user secret, on user login. Creation of this column is done
+ * on up migration in com_members component.
  *
  **/
 class Migration20230909000000PlgUserHubzero extends Base
@@ -24,16 +24,16 @@ class Migration20230909000000PlgUserHubzero extends Base
 	static $tableName = '#__users';
 
 	// specify column to create
-	static $columnData = 	[ ['name' => 'secret',
-								'type' => 'char(32)',
-								'restriction' => 'UNIQUE',
-								'default' => 'NULL'],
-							];
+	static $columnData = [['name' => 'secret',
+		'type' => 'char(32)',
+		'restriction' => 'UNIQUE',
+		'default' => 'NULL'],
+	];
 
 	/**
 	 * Up
 	 *
-	 * Create 'secret' column in jos_users if needed.
+	 * Check for 'secret' column in jos_users table.
 	 *
 	 * Note that we have logging callbacks, per
 	 * https://help.hubzero.org/documentation/22/webdevs/database/migrations
@@ -44,20 +44,17 @@ class Migration20230909000000PlgUserHubzero extends Base
 		$tableName = self::$tableName;
 		$columnData = self::$columnData;
 
-		// Add column to jos_users table to hold user secret
-		// If the table exists, add column if it is absent:
+		// Check for column in jos_users table to hold user secret
 		if ($this->db->tableExists($tableName))
 		{
-			if (!$this->db->tableHasField($tableName, $columnData['name'])) {
-				$this->log('No column `secret` found in table `jos_users`, creating...', 'info');
+			// If the table exists, and column is absent, err out:
+			if (!$this->db->tableHasField($tableName, $columnData[0]['name'])) {
+				$this->log('No column `secret` found in table `jos_users`, stopping...', 'error');
+				$this->setError('Run migration for com_members component first');
 
-				// generate and run query to create column
-				$query = $this->_generateSafeAddColumns($tableName, $columnData);
-				$this->_queryIfTableExists($tableName, $query);
-
+			} else {
+				$this->log('Found `secret` column in table `jos_users`, success...', 'success');
 			}
-			// Generate and save user secrets
-			$this->generateUserSecrets();
 		}
 	}
 
@@ -69,46 +66,6 @@ class Migration20230909000000PlgUserHubzero extends Base
 	 **/
 	public function down()
 	{
-		$tableName = self::$tableName;
-		$columnData = self::$columnData;
-
-		// generate query to drop column from table:
-		$query = $this->_generateSafeDropColumns($tableName, $columnData);
-
-		// execute the query, if column is found in the specified table:
-		$this->_queryIfTableExists($tableName, $query);
-
-		$this->log('Column `secret` dropped from table `jos_users`', 'info');
-	}
-
-	/**
-	 * generateUserSecrets()
-	 *
-	 * Populate 'secret' column in jos_users table for those users who have
-	 * logged in over the last year, but have no secret set. Each secret is a
-	 * unique, random 32-character string.
-	 *
-	 **/
-	private function generateUserSecrets()
-	{
-		// User secret will have length 32 characters:
-		$secretLength = 32;
-
-		// Criteria: create secrets for users that have logged in during the last year
-		$criteria = 'DATE_SUB(CURDATE(), INTERVAL 1 YEAR';
-
-		// Fetch ids for all such users who have no secret
-		$targetUsers = \Hubzero\User\User::all()
-						->where('lastvisitdate', '>', $criteria)
-						->whereIsNull('secret');
-
-		// Create and save a unique secret for each such user:
-		foreach ($targetUsers as $oneUser)
-		{
-			$newSecret = \Hubzero\User\Password::genRandomPassword($secretLength);
-			$oneUser->set('secret', $newSecret);
-			$oneUser->save();
-		}
-		$this->log('Saved new secrets for target users', 'info');
+		// No-op
 	}
 }

--- a/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
+++ b/core/plugins/user/hubzero/migrations/Migration20230909000000PlgUserHubzero.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding User Secret to plugin
+ *
+ * This migration script creates a jos_users column for the plugin to populate
+ * with a unique user secret, on user login. On 'down' migration the column
+ * is dropped from the table.
+ *
+ **/
+class Migration20230909000000PlgUserHubzero extends Base
+{
+	// specify table name
+	static $tableName = '#__users';
+
+	// specify column to create
+	static $columnData = 	[ ['name' => 'secret',
+								'type' => 'char(32)',
+								'restriction' => 'UNIQUE',
+								'default' => 'NULL'],
+							];
+
+	/**
+	 * Up
+	 *
+	 * Create 'secret' column in jos_users if needed.
+	 *
+	 * Note that we have logging callbacks, per
+	 * https://help.hubzero.org/documentation/22/webdevs/database/migrations
+	 *
+	 **/
+	public function up()
+	{
+		$tableName = self::$tableName;
+		$columnData = self::$columnData;
+
+		// Add column to jos_users table to hold user secret
+		// If the table exists, add column if it is absent:
+		if ($this->db->tableExists($tableName))
+		{
+			if (!$this->db->tableHasField($tableName, $columnData['name'])) {
+				$this->log('No column `secret` found in table `jos_users`, creating...', 'info');
+
+				// generate and run query to create column
+				$query = $this->_generateSafeAddColumns($tableName, $columnData);
+				$this->_queryIfTableExists($tableName, $query);
+
+			}
+			// Generate and save user secrets
+			$this->generateUserSecrets();
+		}
+	}
+
+	/**
+	 * Down
+	 *
+	 * Drop 'secret' column from jos_users table.
+	 *
+	 **/
+	public function down()
+	{
+		$tableName = self::$tableName;
+		$columnData = self::$columnData;
+
+		// generate query to drop column from table:
+		$query = $this->_generateSafeDropColumns($tableName, $columnData);
+
+		// execute the query, if column is found in the specified table:
+		$this->_queryIfTableExists($tableName, $query);
+
+		$this->log('Column `secret` dropped from table `jos_users`', 'info');
+	}
+
+	/**
+	 * generateUserSecrets()
+	 *
+	 * Populate 'secret' column in jos_users table for those users who have
+	 * logged in over the last year, but have no secret set. Each secret is a
+	 * unique, random 32-character string.
+	 *
+	 **/
+	private function generateUserSecrets()
+	{
+		// User secret will have length 32 characters:
+		$secretLength = 32;
+
+		// Criteria: create secrets for users that have logged in during the last year
+		$criteria = 'DATE_SUB(CURDATE(), INTERVAL 1 YEAR';
+
+		// Fetch ids for all such users who have no secret
+		$targetUsers = \Hubzero\User\User::all()
+						->where('lastvisitdate', '>', $criteria)
+						->whereIsNull('secret');
+
+		// Create and save a unique secret for each such user:
+		foreach ($targetUsers as $oneUser)
+		{
+			$newSecret = \Hubzero\User\Password::genRandomPassword($secretLength);
+			$oneUser->set('secret', $newSecret);
+			$oneUser->save();
+		}
+		$this->log('Saved new secrets for target users', 'info');
+	}
+}

--- a/core/plugins/user/hubzero/views/emails/tmpl/admincreate_html.php
+++ b/core/plugins/user/hubzero/views/emails/tmpl/admincreate_html.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package    hubzero-cms
- * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @copyright  Copyright (c) 2005-2024 The Regents of the University of California.
  * @license    http://opensource.org/licenses/MIT MIT
  */
 

--- a/core/plugins/user/hubzero/views/emails/tmpl/admincreate_plain.php
+++ b/core/plugins/user/hubzero/views/emails/tmpl/admincreate_plain.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package    hubzero-cms
- * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @copyright  Copyright (c) 2005-2024 The Regents of the University of California.
  * @license    http://opensource.org/licenses/MIT MIT
  */
 


### PR DESCRIPTION
### Dependencies

This work is part of Epic [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434), whose PRs should all be deployed together:
- #1693, NCN-633 `plgUserHubzero` (on user login, ensure user has a secret in the DB)
- #1683 NCN-439 `com_members` (manage user secret)
- #1676  NCN-437 `com_newsletter` (manage campaign secret)
- #1675 NCN-438 `com_config` (manage hub secret)
- #1695 NCN-702, NCN-440: `com_newsletter` (update access verification)

## Summary

This code adds functionality to the existing Hubzero core plugin, `plgUserHubzero`. The new functionality creates and maintains a unique 32 character user secret for each Hub user, at login time. If the user has an existing secret, that secret is retained. If the user is ever deidentified, the plugin will null out the user secret. 

User secrets are stored in the `jos_users.secret` column, which is created on up migration of this plugin. At up migration time, new unique secrets are then generated for all users who have logged in during the past 1 year. The `jos_users.secret` column is removed on down migration of this plugin.

## Motivation

The goal is to create the secret once per user under normal conditions. The user secret can then be hashed with a unique Hub secret and a unique email campaign secret to create a unique code. This code can be used to form a URL that will be emailed to the user to provide them with link-based access to a secure Hub page without requiring login. Should a security incident occur, the user secret can be reset in the admin interface; this is done in `com_members` [PR #1683](https://github.com/hubzero/hubzero-cms/pull/1683/)

## Development

This development was done for Nanohub, as part of the Epic [NCN-434, "Salesforce Newsletter Expiration Token Rewrite"](https://sdx-sdsc.atlassian.net/browse/NCN-434). Details of development task cards:

### Epic: [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434)

- Initial Dev Task: [NCN-435](https://sdx-sdsc.atlassian.net/browse/NCN-435)
- Rework Dev Task: [NCN-633](https://sdx-sdsc.atlassian.net/browse/NCN-633)
- Initial secret population: [NCN-436](https://sdx-sdsc.atlassian.net/browse/NCN-436)
- Migration script secret population: [NCN-693](https://sdx-sdsc.atlassian.net/browse/NCN-693)

## Code Description

The functionality uses the standard Hubzero plugin architecture, including a migration script that creates and populates, or drops, the `secret` database column. The changes here add to the existing plugin's public `onUserLogin()` and `onUserDeidentify()` functions, as well as creating several protected functions that generate the secret, check for the secret, and save or null the secret.

## Testing

This plugin was tested on an AWS Hubzero instance running on CentOS7 and previously on a local VirtualBox Hubzero instance. Tests included: 

- up/down migration to create and populate/drop database column
- login of site and admin users to create non-null secret if needed:
  - on login with null secret column: secret is created
  - on login with non-null secret column: secret is retained
- logout of site and admin users
- simultaneous login of several users
- test of nulling the `secret` database column for a single user

## Deployment

This plugin should be deployed with other changes stemming from Nanohub epic [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434). Hotfixing should not be necessary.

## Revisions

This work was initially developed as a standalone plugin, found in PR [#1663](https://github.com/hubzero/hubzero-cms/pull/1663). 

Following initial code review, these revisions were completed (as of 14 Sep 23):

- removed composer.json file
- update copyright years to 2023, on all files
- discuss appropriate table location of secret column, with Pascal
- Use Hubzero library function Password::genRandomPassword()  in createUserSecret() 
- improve the README
- indicate where the log() statements in migration script write to (that’s informational muse output)

This work was subsequently moved to the `plgUserHubzero` plugin.