### PR TITLE
Template Tweaks in Projects > To Do Feature

### DIFF
--- a/core/plugins/projects/todo/assets/css/todo.css
+++ b/core/plugins/projects/todo/assets/css/todo.css
@@ -458,12 +458,13 @@
 		display: block;
 		margin-top: 0;
 	}
+
+	/* Bottom of box with due date and overdue status is cut off  */
+	/* Making different adjustments to fix it being cut off */
 	.todo-due {
-		font-size: 75%;
+		font-size: 60%;
 		padding: 0 0.5em;
-		height: 15px;
 		color: #FFF;
-		display: block;
 		margin-top: 0.5em;
 		padding-bottom: 0.3em;
 		background: #666666;


### PR DESCRIPTION
**Source JIRA card(s) and hubzero ticket(s)**
- https://sdx-sdsc.atlassian.net/browse/HZ-550

**Brief summary of the issue**
Styling issues with to do stickies in the project plugins. The due date is clipped from it's display. 

**Brief summary of the fix**
- Updated css styling file

![image](https://github.com/hubzero/hubzero-cms/assets/12104578/9d5f3825-3254-46a6-8f65-628a5f56b559)
 
**Brief summary of your testing**
Used developer tools to adjust dev.nanohub.org - https://dev.nanohub.org/projects/philwoodsinglespehub/todo
Showed to @jsperhac 

**Do the change needs to be hotfixed to any production hubs before a normal core rollout**
No, could be rolled out with 2.2.26

**Double check someone is assigned to review the ticket**
Yes - @nkissebe and @dbenham 