### PR TITLE
[NCN-440] Update validation for one-click access

### DIFF
--- a/core/components/com_newsletter/README.md
+++ b/core/components/com_newsletter/README.md
@@ -1,10 +1,19 @@
 
-## Reply Component
+## Reply functionality: single-click validation
 
 ### Use Case
-This component allows users to submit responses and update their preferences without first completing the primary hub authentication procedure.
 
-This component authenticates users via randomly-generated codes that are associated with their CMS record.
+"Reply" functionality allows users to submit survey responses or update their preferences without first completing the primary hub authentication procedure.
+
+This feature provides user authentication via hashes of randomly-generated codes that are associated with the user's CMS record, the campaign, and the Hub.
+
+This functionality is now part of the `com_newsletter` core component. It was originally found in custom component `com_reply`.
+
+Related features:
+
+* Per-user randomly generated codes are managed under Member password management.
+* Per-campaign randomly generated codes are managed under the Newsletter component's Campaign tab, on the administrative interface.
+* The Hub's randomly generated code is managed under Global Configuration on the administrative interface.
 
 ### Install
 1. Get this code to `app/components` e.g. via `git clone ...` 
@@ -15,6 +24,7 @@ This component authenticates users via randomly-generated codes that are associa
 To add a form-based page:
 1.  Add a record to `jos_reply_pages`
 1. Create a view for the page in `site/views/pages` 
+1. Create records in `jos_reply_access_codes` enabling users to access the page.
 
 ### Adding an Email Subscription Option
 1. Create or confirm name of the corresponding profile field
@@ -22,16 +32,21 @@ To add a form-based page:
 1. Create a view (content to appear beneath label) if desired 
 
 ### Gotchas
-* Set the email page ID in `secrets/code.php`
+* Set the email page ID in `secrets/code.php`, using `secrets/code_example.php` as a model.
 * `jos_email_subscriptions.profile_field_name` must correspond with a `jos_user_profile_fields.name`
 * `jos_user_profile_options` must be populated for the user profile fields. `jos_user_profile_options.field_id` must correspond with id from `jos_user_profile_fields.id`
 * Populate the codes table
 
 ### Component-Specific Tables
-* `jos_reply_access_codes` - user-specific access codes
+* `jos_reply_access_codes` - user-page associations to enable access
 * `jos_reply_pages` - pages for collecting data
 * `jos_reply_replies` - user-submitted responses
 * `jos_email_subscriptions` - email subscription options
+
+### Access-Related Tables
+* `jos_users` - contains a `secret` for each user
+* `campaign` - contains a `secret` for each campaign
+* `campaign_hub` - contains a single `secret` for the Hub
 
 ### Integrations
 The email subscription update functionality integrates with the core user profile data.
@@ -39,6 +54,14 @@ The email subscription update functionality integrates with the core user profil
 * `jos_user_profile_options` - profile field response options
 * `jos_user_profiles` - associates user data with profile fields
 
-### Manually Generating Access Codes
+### Generating Access Codes
 
-See the [record generator project repo](https://github.com/hubzero/nano-sf-record-generator) for instructions on how to manually generate access codes.
+The stored procedure `hash_access_code` is used to generate and verify codes for page access. 
+
+### Example URLs
+
+#### pages
+`https://jsperhac.aws.hubzero.org/newsletter/pages/2?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`
+
+#### subscriptions
+`https://jsperhac.aws.hubzero.org/newsletter/email-subscriptions?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`

--- a/core/components/com_newsletter/README.md
+++ b/core/components/com_newsletter/README.md
@@ -1,0 +1,44 @@
+
+## Reply Component
+
+### Use Case
+This component allows users to submit responses and update their preferences without first completing the primary hub authentication procedure.
+
+This component authenticates users via randomly-generated codes that are associated with their CMS record.
+
+### Install
+1. Get this code to `app/components` e.g. via `git clone ...` 
+1. Run the migrations e.g. via `muse migration run ...`
+1. Populate the codes table - `jos_reply_access_codes`
+
+### Adding a Page
+To add a form-based page:
+1.  Add a record to `jos_reply_pages`
+1. Create a view for the page in `site/views/pages` 
+
+### Adding an Email Subscription Option
+1. Create or confirm name of the corresponding profile field
+1.  Add a record to `jos_email_subscriptions`
+1. Create a view (content to appear beneath label) if desired 
+
+### Gotchas
+* Set the email page ID in `secrets/code.php`
+* `jos_email_subscriptions.profile_field_name` must correspond with a `jos_user_profile_fields.name`
+* `jos_user_profile_options` must be populated for the user profile fields. `jos_user_profile_options.field_id` must correspond with id from `jos_user_profile_fields.id`
+* Populate the codes table
+
+### Component-Specific Tables
+* `jos_reply_access_codes` - user-specific access codes
+* `jos_reply_pages` - pages for collecting data
+* `jos_reply_replies` - user-submitted responses
+* `jos_email_subscriptions` - email subscription options
+
+### Integrations
+The email subscription update functionality integrates with the core user profile data.
+* `jos_user_profile_fields` - profile fields
+* `jos_user_profile_options` - profile field response options
+* `jos_user_profiles` - associates user data with profile fields
+
+### Manually Generating Access Codes
+
+See the [record generator project repo](https://github.com/hubzero/nano-sf-record-generator) for instructions on how to manually generate access codes.

--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -123,7 +123,7 @@ class Campaigns extends AdminController
 			->set('campaign', $row)
 			->set('config', $this->config)
 			->setLayout('edit')
-			->display();		
+			->display();
 	}
 
 	/**
@@ -159,7 +159,7 @@ class Campaigns extends AdminController
 		}
 		else
 		{
-			// If display date changed in the form, save new date: 
+			// If display date changed in the form, save new date:
 			if ($fields['expire_date_display'] != $fields['expire_date_local'])
 			{
 				// get timezone identifier from user setting

--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -28,7 +28,7 @@ class Campaigns extends AdminController
 	/**
 	 * Execute a task
 	 *
-	 * This appears to be an override?
+	 * This appears to be an override
 	 *
 	 * @return  void
 	 */
@@ -88,6 +88,8 @@ class Campaigns extends AdminController
 
 	/**
 	 * Edit or add Campaigns
+	 *
+	 * Display a form for adding or editing an entry
 	 * (swiped from admin/controllers/newsletters.php)
 	 *
 	 * @return  void
@@ -110,6 +112,10 @@ class Campaigns extends AdminController
 			$id = is_array($id) ? $id[0] : $id;
 
 			$row = Campaign::oneOrNew($id);
+
+			// Campaign expiration date: saved as GMT (see edit.php)
+			$expire_date = Date::of($row->expire_date);
+			$this->view->expire_date = $expire_date;
 		}
 
 		// Output the HTML
@@ -122,6 +128,8 @@ class Campaigns extends AdminController
 
 	/**
 	 * Save campaign task
+	 *
+	 * Save an entry
 	 * (swiped from admin/controllers/newsletters.php)
 	 *
 	 * @return 	void
@@ -142,6 +150,12 @@ class Campaigns extends AdminController
 
 		// Initiate model
 		$row = Campaign::oneOrNew($fields['id'])->set($fields);
+
+        // make sure we have an expire_date, default will be 90 days from current date
+        if (!$row->expire_date)
+        {
+			$row->expire_date = Date::of('+90 days')->setTimezone('GMT')->toSql();
+        }
 
 		// did we have params
 		// if so, it's a request to reset the secret
@@ -178,6 +192,8 @@ class Campaigns extends AdminController
 
 	/**
 	 * Delete Task
+	 *
+	 * Delete an entry
 	 * (Swiped from admin/controllers/templates.php)
 	 *
 	 * This task deletes campaigns from the database, unlike some other functionality in this component,

--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -151,11 +151,23 @@ class Campaigns extends AdminController
 		// Initiate model
 		$row = Campaign::oneOrNew($fields['id'])->set($fields);
 
-        // make sure we have an expire_date, default will be 90 days from current date
-        if (!$row->expire_date)
-        {
-			$row->expire_date = Date::of('+90 days')->setTimezone('GMT')->toSql();
-        }
+
+		// make sure we have an expire_date, default will be 90 days from current date
+		if (!$row->expire_date)
+		{
+			$row->expire_date = Date::of('+90 days', 'GMT')->toSql();
+		}
+		else
+		{
+			// If display date changed in the form, save new date: 
+			if ($fields['expire_date_display'] != $fields['expire_date_local'])
+			{
+				// get timezone identifier from user setting
+				$tz = \User::getParam('timezone', \Config::get('offset'));
+				// save the newly changed date, accounting for the user's local time zone, $tz:
+				$row->expire_date = Date::of($fields['expire_date_display'], $tz)->toSql();
+			}
+		}
 
 		// did we have params
 		// if so, it's a request to reset the secret

--- a/core/components/com_newsletter/admin/controllers/campaigns.php
+++ b/core/components/com_newsletter/admin/controllers/campaigns.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Admin\Controllers;
+
+use Components\Newsletter\Models\Campaign;
+use Hubzero\Component\AdminController;
+use stdClass;
+use Request;
+use Notify;
+use Route;
+use Lang;
+use App;
+
+// require the campaign model
+require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'campaign.php';
+
+/**
+ * Campaign Controller
+ */
+class Campaigns extends AdminController
+{
+	/**
+	 * Execute a task
+	 *
+	 * @return  void
+	 */
+	public function execute()
+	{
+		$this->registerTask('add', 'edit');
+		$this->registerTask('apply', 'save');
+		//$this->registerTask('publish', 'state');
+		//$this->registerTask('unpublish', 'state');
+
+		parent::execute();
+	}
+
+	/**
+	 * Display Campaigns
+	 *
+	 * @return  void
+	 */
+	public function displayTask()
+	{
+		$filters = array(
+			'search' => Request::getState(
+				$this->_option . '.' . $this->_controller . '.search',
+				'search',
+				''
+			),
+			'sort' => Request::getState(
+				$this->_option . '.' . $this->_controller . '.sort',
+				'filter_order',
+				'title'
+			),
+			'sort_Dir' => Request::getState(
+				$this->_option . '.' . $this->_controller . '.sortdir',
+				'filter_order_Dir',
+				'ASC'
+			)
+		);
+
+		$campaigns = Campaign::all();
+
+		if ($filters['search'])
+		{
+			$filters['search'] = strtolower((string)$filters['search']);
+			$campaigns->whereLike('title', $filters['search']);
+		}
+
+		$rows = $campaigns
+			->order($filters['sort'], $filters['sort_Dir'])
+			->paginated('limitstart', 'limit')
+			->rows();
+
+		// Output the HTML
+		$this->view
+			->setLayout('display')
+			->set('campaigns', $rows) // was 'campaigns'
+			->set('filters', $filters)
+			->display();
+	}
+
+	/**
+	 * Edit or add Campaigns
+	 * (swiped from admin/controllers/newsletters.php)
+	 *
+	 * @return  void
+	 */
+	public function editTask($row = null)
+	{
+		if (!User::authorise('core.edit', $this->_option)
+		 && !User::authorise('core.create', $this->_option))
+		{
+			App::abort(403, Lang::txt('JERROR_ALERTNOAUTHOR'));
+		}
+
+		Request::setVar('hidemainmenu', 1);
+
+		// Load or create object
+		if (!is_object($row))
+		{
+			// Incoming
+			$id = Request::getArray('id', array(0));
+			$id = is_array($id) ? $id[0] : $id;
+
+			$row = Campaign::oneOrNew($id);
+		}
+
+		// Output the HTML
+		$this->view
+			->set('campaign', $row)
+			->set('config', $this->config)
+			->setLayout('edit')
+			->display();		
+	}
+
+	/**
+	 * Save campaign task
+	 * (swiped from admin/controllers/newsletters.php)
+	 *
+	 * @return 	void
+	 */
+	public function saveTask()
+	{
+		// Check for request forgeries
+		Request::checkToken();
+
+		if (!User::authorise('core.edit', $this->_option)
+		 && !User::authorise('core.create', $this->_option))
+		{
+			App::abort(403, Lang::txt('JERROR_ALERTNOAUTHOR'));
+		}
+
+		// Incoming data from edit form
+		$fields = Request::getArray('campaign', array(), 'post');
+
+		// Initiate model
+		$row = Campaign::oneOrNew($fields['id'])->set($fields);
+
+		// did we have params
+		// if so, it's a request to reset the secret
+		$p = Request::getArray('params', array(), 'post');
+
+		if (!empty($p))
+		{
+			// set new secret if indicated
+			if (null !== $p['reset_secret'] && $p['reset_secret'] == 1)
+			{
+				$row->set('secret', Campaign::generateSecret(null));
+			}
+		}
+
+		// Save campaign
+		if (!$row->save())
+		{
+			Notify::error($row->getError());
+			return $this->editTask($row);
+		}
+
+		// Set success message
+		Notify::success(Lang::txt('COM_NEWSLETTER_SAVED_SUCCESS'));
+
+		if ($this->getTask() == 'apply')
+		{
+			// If we just created campaign go back to edit form so we can add content
+			return $this->editTask($row);
+		}
+
+		// Redirect back to campaigns list
+		$this->cancelTask();
+	}
+}

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -43,3 +43,12 @@ Note that the secret is not shown.</p>
 The Campaign will be saved. Regardless of whether it has been changed, the secret is not shown.</p>
 </p>
 
+<h2>Deleting Campaigns</h2>
+
+<p>To delete a Campaign, click the checkbox next to a Campaign's name in the Campaigns display.
+    You may select multiple campaigns to delete.</p>
+ <p> Next, click the garbage can icon in the Campaigns display.
+You will be prompted to proceed with, or cancel, deletion.</p>
+<p>If you proceed with deletion, the Campaign will be permanently deleted. This will invalidate the existing
+    campaign, so delete only with caution!
+</p>

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -18,6 +18,8 @@ two features, Campaigns and Newsletters, are not presently related.</b></p>
 <p>Campaigns were developed to provide a random secret that could be hashed together with unique per-user secrets
 and a unique Hub secret to provide a unique code. This code can be used to form a URL that will be emailed to the user to provide them with secure access to Hub features.</p>
 
+<p>Campaigns are designed to expire after a period of time that defaults to 90 days. A campaign can be edited to
+    change the expiration date. After a campaign's expiration date has passed, it can no longer be used.</p>
 
 <h2>Viewing Campaigns</h2>
 
@@ -27,8 +29,12 @@ and a unique Hub secret to provide a unique code. This code can be used to form 
 <h2>Creating Campaigns</h2>
 
 <p>To create a Campaign, click the "+" sign in the Campaigns display. The Campaign Editor will be shown.
-Type the name and description of the campaign, then click the check mark (Save) or star (Save and Exit). 
+Type the name and description of the campaign and select an expiration date.
+The default expiration date is 90 days from the creation date.</p>
+
+<p>Then, click the check mark (Save) or star (Save and Exit).
 Or, click the X to cancel.</p>
+
 <p>The Campaign will be saved, along with a unique secret, your user information, and the creation date.
 Note that the secret is not shown.</p>
 
@@ -36,7 +42,7 @@ Note that the secret is not shown.</p>
 
 <p>To edit a Campaign, click an existing Campaign's name in the Campaigns display. Alternately, select an existing
     Campaign's checkbox and click the "Edit" icon. The Campaign Editor will be shown. </p>
-<p>You may edit the name and description of the campaign. You may also reset the Campaign's secret, by clicking
+<p>You may edit the name, description, and expiration date of the campaign. You may also reset the Campaign's secret, by clicking
     the checkbox labeled "Reset Campaign Secret". Use caution when resetting the secret. This action will 
     invalidate any URLs prepared with the Campaign!
 <p>To save your edits, click the check mark (Save) or star (Save and Exit). To cancel, click the X.

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+defined('_HZEXEC_') or die('Restricted access');
+?>
+<h1>Campaigns</h1>
+
+<p>Campaigns enable the admin user to create and maintain a unique 32-character random secret associated with a specific
+email or newsletter campaign.</p><p><b>Though the administrative interface for campaigns is located with Hubzero Newsletters, the
+two features, Campaigns and Newsletters, are not presently related.</b></p>
+
+<h2>Purpose</h2>
+
+<p>Campaigns were developed to provide a random secret that could be hashed together with unique per-user secrets
+and a unique Hub secret to provide a unique code. This code can be used to form a URL that will be emailed to the user to provide them with secure access to Hub features.</p>
+
+
+<h2>Viewing Campaigns</h2>
+
+<p>To view existing Campaigns, navigate to Components -> Newsletter, then select the Campaigns tab. </p>
+<p>In the Campaigns display, you may search for a specific Campaign name, or sort Campaigns by name or date.</p>
+
+<h2>Creating Campaigns</h2>
+
+<p>To create a Campaign, click the "+" sign in the Campaigns display. The Campaign Editor will be shown.
+Type the name and description of the campaign, then click the check mark (Save) or star (Save and Exit). 
+Or, click the X to cancel.</p>
+<p>The Campaign will be saved, along with a unique secret, your user information, and the creation date.
+Note that the secret is not shown.</p>
+
+<h2>Editing Campaigns</h2>
+
+<p>To edit a Campaign, click an existing Campaign's name in the Campaigns display. Alternately, select an existing
+    Campaign's checkbox and click the "Edit" icon. The Campaign Editor will be shown. </p>
+<p>You may edit the name and description of the campaign. You may also reset the Campaign's secret, by clicking
+    the checkbox labeled "Reset Campaign Secret". Use caution when resetting the secret. This action will 
+    invalidate any URLs prepared with the Campaign!
+<p>To save your edits, click the check mark (Save) or star (Save and Exit). To cancel, click the X.
+The Campaign will be saved. Regardless of whether it has been changed, the secret is not shown.</p>
+</p>
+

--- a/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
+++ b/core/components/com_newsletter/admin/help/en-GB/campaign.phtml
@@ -43,7 +43,7 @@ Note that the secret is not shown.</p>
 <p>To edit a Campaign, click an existing Campaign's name in the Campaigns display. Alternately, select an existing
     Campaign's checkbox and click the "Edit" icon. The Campaign Editor will be shown. </p>
 <p>You may edit the name, description, and expiration date of the campaign. You may also reset the Campaign's secret, by clicking
-    the checkbox labeled "Reset Campaign Secret". Use caution when resetting the secret. This action will 
+    the checkbox labeled "Reset Campaign Secret". Use caution when resetting the secret. This action will
     invalidate any URLs prepared with the Campaign!
 <p>To save your edits, click the check mark (Save) or star (Save and Exit). To cancel, click the X.
 The Campaign will be saved. Regardless of whether it has been changed, the secret is not shown.</p>

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -227,6 +227,10 @@ COM_NEWSLETTER_CAMPAIGN_DATE="Date Created"
 COM_NEWSLETTER_CAMPAIGN_MOD_DATE="Date Modified"
 COM_NEWSLETTER_NO_CAMPAIGNS="Currently there are no campaigns defined."
 COM_NEWSLETTER_CAMPAIGN_RESET_SECRET="Reset Secret"
+COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK="Are you sure you want to delete the selected Campaign(s)?"
+COM_NEWSLETTER_CAMPAIGN_NOT_FOUND="The specified campaign was not found."
+COM_NEWSLETTER_CAMPAIGN_DELETE_FAILED="Unable to delete selected campaign(s)."
+COM_NEWSLETTER_CAMPAIGN_DELETE_SUCCESS="Successfully deleted selected campaign(s)."
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -1,5 +1,5 @@
 ; @package      hubzero-cms
-; @copyright    Copyright (c) 2005-2020 The Regents of the University of California.
+; @copyright    Copyright (c) 2005-2023 The Regents of the University of California.
 ; @license      http://opensource.org/licenses/MIT MIT
 
 ; Note : All ini files need to be saved as UTF-8 - No BOM
@@ -12,6 +12,8 @@ COM_NEWSLETTER_LISTS="Lists"
 COM_NEWSLETTER_TEMPLATES="Templates"
 COM_NEWSLETTER_TEMPLATE="Template"
 COM_NEWSLETTER_TOOLS="Tools"
+COM_NEWSLETTER_CAMPAIGNS="Campaigns"
+COM_NEWSLETTER_CAMPAIGN="Campaign"
 COM_NEWSLETTER_CONFIGURATION="Newsletter Configuration"
 
 
@@ -218,6 +220,13 @@ COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS="Click Throughs"
 COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS_URL="URL"
 COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS_COUNT="# of Clicks"
 COM_NEWSLETTER_NEWSLETTER_MAILING_NO_CLICK_THROUGHS="There are currently no click throughs for this mailing."
+
+; Campaigns
+COM_NEWSLETTER_CAMPAIGN_NAME="Campaign Title"
+COM_NEWSLETTER_CAMPAIGN_DATE="Date Created"
+COM_NEWSLETTER_CAMPAIGN_MOD_DATE="Date Modified"
+COM_NEWSLETTER_NO_CAMPAIGNS="Currently there are no campaigns defined."
+COM_NEWSLETTER_CAMPAIGN_RESET_SECRET="Reset Secret"
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -222,9 +222,9 @@ COM_NEWSLETTER_NEWSLETTER_MAILING_CLICK_THROUGHS_COUNT="# of Clicks"
 COM_NEWSLETTER_NEWSLETTER_MAILING_NO_CLICK_THROUGHS="There are currently no click throughs for this mailing."
 
 ; Campaigns
-COM_NEWSLETTER_CAMPAIGN_NAME="Campaign Title"
 COM_NEWSLETTER_CAMPAIGN_DATE="Date Created"
 COM_NEWSLETTER_CAMPAIGN_MOD_DATE="Date Modified"
+COM_NEWSLETTER_CAMPAIGN_MOD_BY="Modified By"
 COM_NEWSLETTER_NO_CAMPAIGNS="Currently there are no campaigns defined."
 COM_NEWSLETTER_CAMPAIGN_RESET_SECRET="Reset Secret"
 COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK="Are you sure you want to delete the selected Campaign(s)?"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -232,7 +232,6 @@ COM_NEWSLETTER_CAMPAIGN_NOT_FOUND="The specified campaign was not found."
 COM_NEWSLETTER_CAMPAIGN_DELETE_FAILED="Unable to delete selected campaign(s)."
 COM_NEWSLETTER_CAMPAIGN_DELETE_SUCCESS="Successfully deleted selected campaign(s)."
 COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE="Expiration Date"
-COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT="Expiration Date (GMT)"
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/admin/language/en-GB/en-GB.com_newsletter.ini
@@ -231,6 +231,8 @@ COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK="Are you sure you want to delete the select
 COM_NEWSLETTER_CAMPAIGN_NOT_FOUND="The specified campaign was not found."
 COM_NEWSLETTER_CAMPAIGN_DELETE_FAILED="Unable to delete selected campaign(s)."
 COM_NEWSLETTER_CAMPAIGN_DELETE_SUCCESS="Successfully deleted selected campaign(s)."
+COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE="Expiration Date"
+COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT="Expiration Date (GMT)"
 
 ; Mailing Lists
 COM_NEWSLETTER_MAILINGLIST_SAVE_SUCCESS="Campaign Mailing List Successfully Saved"

--- a/core/components/com_newsletter/admin/newsletter.php
+++ b/core/components/com_newsletter/admin/newsletter.php
@@ -16,6 +16,7 @@ if (!\User::authorise('core.manage', 'com_newsletter'))
 require_once dirname(__DIR__) . DS . 'models' . DS . 'newsletter.php';
 require_once dirname(__DIR__) . DS . 'models' . DS . 'mailinglist.php';
 require_once dirname(__DIR__) . DS . 'models' . DS . 'mailing.php';
+require_once dirname(__DIR__) . DS . 'models' . DS . 'campaign.php';
 
 // Include helpers
 require_once dirname(__DIR__) . DS . 'helpers' . DS . 'helper.php';
@@ -36,7 +37,8 @@ $menuItems = array(
 	'mailings'     => \Lang::txt('COM_NEWSLETTER_MAILINGS'),
 	'mailinglists' => \Lang::txt('COM_NEWSLETTER_LISTS'),
 	'templates'    => \Lang::txt('COM_NEWSLETTER_TEMPLATES'),
-	'tools'        => \Lang::txt('COM_NEWSLETTER_TOOLS')
+	'tools'        => \Lang::txt('COM_NEWSLETTER_TOOLS'),
+	'campaigns'    => \Lang::txt('COM_NEWSLETTER_CAMPAIGNS')
 );
 
 foreach ($menuItems as $k => $v)

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -22,6 +22,12 @@ if ($canDo->get('core.edit'))
 {
 	Toolbar::editList();
 }
+if ($canDo->get('core.delete'))
+{
+	Toolbar::spacer();
+	// TODO: add to language file
+	Toolbar::deleteList('COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK', 'delete');
+}
 Toolbar::spacer();
 Toolbar::help('campaign');
 

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -59,9 +59,9 @@ $this->js();
 				<th scope="col"><?php echo Lang::txt('Description');?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Date Modified', 'modified', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_DATE', 'modified', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Modified By', 'modified_by', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_BY', 'modified_by', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
 			</tr>
 		</thead> 

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -25,7 +25,6 @@ if ($canDo->get('core.edit'))
 if ($canDo->get('core.delete'))
 {
 	Toolbar::spacer();
-	// TODO: add to language file
 	Toolbar::deleteList('COM_NEWSLETTER_CAMPAIGN_DELETE_CHECK', 'delete');
 }
 Toolbar::spacer();
@@ -56,7 +55,9 @@ $this->js();
 				</th>
 				<th scope="col"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN', 'title', @$this->filters['sort_Dir'], 
 					@$this->filters['sort']);?></th>
-				<th scope="col"><?php echo Lang::txt('Description');?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE', 'expire_date',
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+				<th scope="col"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC');?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_DATE', 'modified', 
@@ -85,19 +86,21 @@ $this->js();
 							<label for="cb<?php echo $k; ?>" class="sr-only visually-hidden"><?php echo $campaign->id; ?></label>
 						</td>
 						<td>
-							<?php //echo $campaign->title; ?>
 							<a href="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=edit&id=' . $campaign->id); ?>">
 								<?php echo $this->escape($campaign->title); ?>
 							</a>
 						</td>
 						<td class="priority-3">
+							<?php echo Date::of($campaign->expire_date)->toLocal("Y-m-d h:ma"); ?>
+						</td>
+						<td class="priority-3">
 							<?php echo $campaign->description; ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->campaign_date)->toLocal("F d, Y @ g:ia"); ?>
+							<?php echo Date::of($campaign->campaign_date)->toLocal("Y-m-d h:ma"); ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->modified)->toLocal("F d, Y @ g:ia"); ?>
+							<?php echo Date::of($campaign->modified)->toLocal("Y-m-d h:ma"); ?>
 						</td>
 						<td class="priority-3">
 							<?php echo User::one($campaign->modified_by)->name; ?>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -53,19 +53,19 @@ $this->js();
 					<input type="checkbox" name="checkall-toggle" id="checkall-toggle" value="" class="checkbox-toggle toggle-all" />
 					<label for="checkall-toggle" class="sr-only visually-hidden"><?php echo Lang::txt('JGLOBAL_CHECK_ALL'); ?></label>
 				</th>
-				<th scope="col"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN', 'title', @$this->filters['sort_Dir'], 
+				<th scope="col"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN', 'title', @$this->filters['sort_Dir'],
 					@$this->filters['sort']);?></th>
 				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE', 'expire_date',
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
 				<th scope="col"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC');?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date',
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_DATE', 'modified', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_DATE', 'modified',
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
-				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_BY', 'modified_by', 
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_MOD_BY', 'modified_by',
 					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
 			</tr>
-		</thead> 
+		</thead>
 
 		<tfoot>
 			<tr>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -91,16 +91,16 @@ $this->js();
 							</a>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->expire_date)->toLocal("Y-m-d h:ma"); ?>
+							<?php echo Date::of($campaign->expire_date)->toLocal("Y-m-d H:ia"); ?>
 						</td>
 						<td class="priority-3">
 							<?php echo $campaign->description; ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->campaign_date)->toLocal("Y-m-d h:ma"); ?>
+							<?php echo Date::of($campaign->campaign_date)->toLocal("Y-m-d H:ia"); ?>
 						</td>
 						<td class="priority-3">
-							<?php echo Date::of($campaign->modified)->toLocal("Y-m-d h:ma"); ?>
+							<?php echo Date::of($campaign->modified)->toLocal("Y-m-d H:ia"); ?>
 						</td>
 						<td class="priority-3">
 							<?php echo User::one($campaign->modified_by)->name; ?>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/display.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2023 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$canDo = Components\Newsletter\Helpers\Permissions::getActions('campaign');
+
+//set title
+Toolbar::title(Lang::txt('COM_NEWSLETTER_CAMPAIGNS'), 'campaigns');
+
+// toolbar
+if ($canDo->get('core.create'))
+{
+	Toolbar::addNew();
+}
+if ($canDo->get('core.edit'))
+{
+	Toolbar::editList();
+}
+Toolbar::spacer();
+Toolbar::help('campaign');
+
+$this->js();
+?>
+
+<?php if ($this->getError()) : ?>
+	<p class="error"><?php echo $this->getError(); ?></p>
+<?php endif; ?>
+
+<form action="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller); ?>" method="post" name="adminForm" id="admin-form">
+	<fieldset id="filter-bar">
+		<label for="filter_search"><?php echo Lang::txt('JSEARCH_FILTER'); ?>:</label>
+		<input type="text" name="search" id="filter_search" class="filter" value="<?php echo $this->escape($this->filters['search']); ?>" placeholder="<?php echo Lang::txt('COM_NEWSLETTER_FILTER_SEARCH_PLACEHOLDER'); ?>" />
+
+		<input type="submit" value="<?php echo Lang::txt('COM_NEWSLETTER_GO'); ?>" />
+		<button type="button" class="filter-clear"><?php echo Lang::txt('JSEARCH_FILTER_CLEAR'); ?></button>
+	</fieldset>
+
+	<table class="adminlist">
+		<thead>
+			<tr>
+				<th scope="col">
+					<input type="checkbox" name="checkall-toggle" id="checkall-toggle" value="" class="checkbox-toggle toggle-all" />
+					<label for="checkall-toggle" class="sr-only visually-hidden"><?php echo Lang::txt('JGLOBAL_CHECK_ALL'); ?></label>
+				</th>
+				<th scope="col"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN', 'title', @$this->filters['sort_Dir'], 
+					@$this->filters['sort']);?></th>
+				<th scope="col"><?php echo Lang::txt('Description');?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'COM_NEWSLETTER_CAMPAIGN_DATE', 'campaign_date', 
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Date Modified', 'modified', 
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+				<th scope="col" class="priority-3"><?php echo Html::grid('sort', 'Modified By', 'modified_by', 
+					@$this->filters['sort_Dir'], @$this->filters['sort']); ?></th>
+			</tr>
+		</thead> 
+
+		<tfoot>
+			<tr>
+				<td colspan="5"><?php
+				// initiate paging
+				echo $this->campaigns->pagination;
+				$k = 0;
+
+				?></td>
+			</tr>
+		</tfoot>
+		<tbody>
+			<?php if (count($this->campaigns) > 0) { ?>
+				<?php foreach ($this->campaigns as $campaign) { ?>
+					<tr>
+						<td>
+							<input type="checkbox" name="id[]" id="cb<?php echo $k; ?>" value="<?php echo $campaign->id; ?>" class="checkbox-toggle" />
+							<label for="cb<?php echo $k; ?>" class="sr-only visually-hidden"><?php echo $campaign->id; ?></label>
+						</td>
+						<td>
+							<?php //echo $campaign->title; ?>
+							<a href="<?php echo Route::url('index.php?option=' . $this->option . '&controller=' . $this->controller . '&task=edit&id=' . $campaign->id); ?>">
+								<?php echo $this->escape($campaign->title); ?>
+							</a>
+						</td>
+						<td class="priority-3">
+							<?php echo $campaign->description; ?>
+						</td>
+						<td class="priority-3">
+							<?php echo Date::of($campaign->campaign_date)->toLocal("F d, Y @ g:ia"); ?>
+						</td>
+						<td class="priority-3">
+							<?php echo Date::of($campaign->modified)->toLocal("F d, Y @ g:ia"); ?>
+						</td>
+						<td class="priority-3">
+							<?php echo User::one($campaign->modified_by)->name; ?>
+						</td>
+					</tr>
+				<?php $k++; } ?>
+			<?php } else { ?>
+				<tr>
+					<td colspan="5">
+						<?php echo Lang::txt('COM_NEWSLETTER_NO_CAMPAIGNS'); ?>
+					</td>
+				</tr>
+			<?php } ?>
+		</tbody>
+	</table>
+
+	<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
+	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
+	<input type="hidden" name="task" value="display" autocomplete="off" />
+	<input type="hidden" name="boxchecked" value="0" />
+	<input type="hidden" name="filter_order" value="<?php echo $this->escape($this->filters['sort']); ?>" />
+	<input type="hidden" name="filter_order_Dir" value="<?php echo $this->escape($this->filters['sort_Dir']); ?>" />
+
+	<?php echo Html::input('token'); ?>
+</form>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
@@ -16,7 +16,7 @@ $hasSecret = strlen($this->campaign->secret) > 0;
 // Language to match whether we are adding or editing:
 $text = ($hasSecret ? Lang::txt('COM_NEWSLETTER_EDIT') : Lang::txt('COM_NEWSLETTER_NEW'));
 
-Toolbar::title(Lang::txt('Campaign') . ': ' . $text, 'campaign');
+Toolbar::title(Lang::txt('COM_NEWSLETTER_CAMPAIGN') . ': ' . $text, 'campaign');
 if ($canDo->get('core.edit'))
 {
 	Toolbar::apply();
@@ -29,40 +29,42 @@ Toolbar::help('campaign');
 ?>
 <form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="item-form">
 	<fieldset class="adminform">
-		<legend><span><?php echo $text; ?> <?php echo Lang::txt('Campaign'); ?></span></legend>
+		<legend><span><?php echo $text; ?> <?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN'); ?></span></legend>
 
 		<div class="input-wrap">
-			<label for="campaign-title"><?php echo Lang::txt('Name'); ?>:</label><br />
+			<label for="campaign-title"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_NAME'); ?></label><br />
 			<input type="text" name="campaign[title]" id="campaign-title" value="<?php echo $this->escape($this->campaign->title); ?>" /></td>
 		</div>
 
 		<!-- Campaign expiration date: adapted from com_events/admin/views/events/tmpl/edit.php -->
-		<!-- If a new record, default 90 days; display as GMT -->
+		<!-- If a new record, default 90 days -->
 		<?php if (!$this->campaign->expire_date) {
-			$exDate  = Date::of('+90 days', 'GMT');
+			$exDate  = Date::of('+90 days');
 		} else {
-			$exDate  = Date::of($this->campaign->expire_date, 'GMT');
+			$exDate  = Date::of($this->campaign->expire_date);
 		} ?>
 		<div class="input-wrap">
-			<label for="campaign-expire_date"><?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT'); ?></label><br />
-			<?php echo Html::input('calendar', 'campaign[expire_date]', $exDate, array('id' => 'campaign-expire_date')); ?>
+			<label for="campaign-expire_date"><?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE'); ?></label><br />
+			<?php echo Html::input('calendar', 'campaign[expire_date_display]', Date::of($exDate)->toLocal(), array('id' => 'campaign-expire_date')); ?>
 		</div>
 
 		<div class="input-wrap">
-			<label for="campaign-description"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC'); ?>:</label><br />
+			<label for="campaign-description"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC'); ?></label><br />
 			<textarea name="campaign[description]" id="campaign-description" rows="5"><?php echo $this->escape($this->campaign->description); ?></textarea>
 		</div>
 
-	<!-- Display Reset Secret only if editing the campaign -->
-	<?php if ($hasSecret) { ?> 
-		<div class="input-wrap">
-			<input type="checkbox" name="params[reset_secret]" id="cb-reset-secret" value="1" class="checkbox-toggle" />
-			<label for="cb-reset-secret">Reset Campaign Secret</label>
-		</div>
-	<?php } ?> 
+		<!-- Display Reset Secret only if editing the campaign -->
+		<?php if ($hasSecret) { ?>
+			<div class="input-wrap">
+				<input type="checkbox" name="params[reset_secret]" id="cb-reset-secret" value="1" class="checkbox-toggle" />
+				<label for="cb-reset-secret">Reset Campaign Secret</label>
+			</div>
+		<?php } ?>
 	</fieldset>
 
 	<input type="hidden" name="campaign[id]" value="<?php echo $this->campaign->id; ?>" />
+	<input type="hidden" name="campaign[expire_date_gmt]" value="<?php echo Date::of($exDate, 'GMT'); ?>" />
+	<input type="hidden" name="campaign[expire_date_local]" value="<?php echo Date::of($exDate)->toLocal(); ?>" />
 	<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
 	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
 	<input type="hidden" name="task" value="save" />

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2023 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$canDo = Components\Newsletter\Helpers\Permissions::getActions('campaign');
+
+// If current record has a secret, then we are editing, otherwise we are new.
+$hasSecret = strlen($this->campaign->secret) > 0;
+
+// Language to match whether we are adding or editing:
+$text = ($hasSecret ? Lang::txt('COM_NEWSLETTER_EDIT') : Lang::txt('COM_NEWSLETTER_NEW'));
+
+Toolbar::title(Lang::txt('Campaign') . ': ' . $text, 'campaign');
+if ($canDo->get('core.edit'))
+{
+	Toolbar::apply();
+	Toolbar::save();
+	Toolbar::spacer();
+}
+Toolbar::cancel();
+?>
+<form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="item-form">
+	<fieldset class="adminform">
+		<legend><span><?php echo $text; ?> <?php echo Lang::txt('Campaign'); ?></span></legend>
+
+		<div class="input-wrap">
+			<label for="campaign-title"><?php echo Lang::txt('Name'); ?>:</label><br />
+			<input type="text" name="campaign[title]" id="campaign-title" value="<?php echo $this->escape($this->campaign->title); ?>" /></td>
+		</div>
+
+		<div class="input-wrap">
+			<label for="campaign-description"><?php echo Lang::txt('COM_NEWSLETTER_MAILINGLIST_DESC'); ?>:</label><br />
+			<textarea name="campaign[description]" id="campaign-description" rows="5"><?php echo $this->escape($this->campaign->description); ?></textarea>
+		</div>
+
+	<!-- Display Reset Secret only if editing the campaign -->
+	<?php if ($hasSecret) { ?> 
+		<div class="input-wrap">
+			<input type="checkbox" name="params[reset_secret]" id="cb-reset-secret" value="1" class="checkbox-toggle" />
+			<label for="cb-reset-secret">Reset Campaign Secret</label>
+		</div>
+	<?php } ?> 
+	</fieldset>
+
+	<input type="hidden" name="campaign[id]" value="<?php echo $this->campaign->id; ?>" />
+	<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
+	<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
+	<input type="hidden" name="task" value="save" />
+
+	<?php echo Html::input('token'); ?>
+</form>

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/edit.php
@@ -24,6 +24,8 @@ if ($canDo->get('core.edit'))
 	Toolbar::spacer();
 }
 Toolbar::cancel();
+Toolbar::spacer();
+Toolbar::help('campaign');
 ?>
 <form action="<?php echo Route::url('index.php?option=' . $this->option); ?>" method="post" name="adminForm" id="item-form">
 	<fieldset class="adminform">
@@ -32,6 +34,18 @@ Toolbar::cancel();
 		<div class="input-wrap">
 			<label for="campaign-title"><?php echo Lang::txt('Name'); ?>:</label><br />
 			<input type="text" name="campaign[title]" id="campaign-title" value="<?php echo $this->escape($this->campaign->title); ?>" /></td>
+		</div>
+
+		<!-- Campaign expiration date: adapted from com_events/admin/views/events/tmpl/edit.php -->
+		<!-- If a new record, default 90 days; display as GMT -->
+		<?php if (!$this->campaign->expire_date) {
+			$exDate  = Date::of('+90 days', 'GMT');
+		} else {
+			$exDate  = Date::of($this->campaign->expire_date, 'GMT');
+		} ?>
+		<div class="input-wrap">
+			<label for="campaign-expire_date"><?php echo Lang::txt('COM_NEWSLETTER_CAMPAIGN_EXPIRE_DATE_GMT'); ?></label><br />
+			<?php echo Html::input('calendar', 'campaign[expire_date]', $exDate, array('id' => 'campaign-expire_date')); ?>
 		</div>
 
 		<div class="input-wrap">

--- a/core/components/com_newsletter/admin/views/campaigns/tmpl/index.html
+++ b/core/components/com_newsletter/admin/views/campaigns/tmpl/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/core/components/com_newsletter/helpers/codeHelper.php
+++ b/core/components/com_newsletter/helpers/codeHelper.php
@@ -41,31 +41,11 @@ class CodeHelper
 		return ($hashMatches && $campNotExpired && $codeMatchesPage);
 	}
 
-	// TODO: delete
-	public static function oldValidateCode($code, $pageId)
-	{
-		$codeModel = AccessCode::all()->whereEquals('code', $code)->row();
-
-		$exists = !$codeModel->isNew();
-		$notExpired = !$codeModel->isExpired();
-		$matchesPage = $codeModel->get('page_id') == $pageId;
-
-		return $exists && $notExpired && $matchesPage;
-	}
-
 	// Validate code obtained from user's URL, using email subscription page id
 	public static function validateEmailSubscriptionsCode($username, $campaignId, $code)
 	{
 		$emailSubsPageId = CODE_SECRETS['email_subscriptions_page_id'];
 
 		return self::validateCode($username, $campaignId, $emailSubsPageId, $code);
-	}
-
-	// TODO: delete
-	public static function oldValidateEmailSubscriptionsCode($code)
-	{
-		$emailSubsPageId = CODE_SECRETS['email_subscriptions_page_id'];
-
-		return self::oldValidateCode($code, $emailSubsPageId);
 	}
 }

--- a/core/components/com_newsletter/helpers/codeHelper.php
+++ b/core/components/com_newsletter/helpers/codeHelper.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Helpers;
+
+$componentPath = Component::path('com_newsletter');
+
+require_once  "$componentPath/models/accessCode.php";
+require_once  "$componentPath/secrets/code.php";
+
+use Components\Newsletter\Models\AccessCode;
+
+class CodeHelper
+{
+
+	public static function validateCode($code, $pageId)
+	{
+		$codeModel = AccessCode::all()->whereEquals('code', $code)->row();
+
+		$exists = !$codeModel->isNew();
+		$notExpired = !$codeModel->isExpired();
+		$matchesPage = $codeModel->get('page_id') == $pageId;
+
+		return $exists && $notExpired && $matchesPage;
+	}
+
+	public static function validateEmailSubscriptionsCode($code)
+	{
+		$emailSubsPageId = CODE_SECRETS['email_subscriptions_page_id'];
+
+		return self::validateCode($code, $emailSubsPageId);
+	}
+
+}

--- a/core/components/com_newsletter/helpers/codeHelper.php
+++ b/core/components/com_newsletter/helpers/codeHelper.php
@@ -10,9 +10,11 @@ namespace Components\Newsletter\Helpers;
 $componentPath = Component::path('com_newsletter');
 
 require_once  "$componentPath/models/accessCode.php";
+require_once  "$componentPath/models/campaign.php";
 require_once  "$componentPath/secrets/code.php";
 
 use Components\Newsletter\Models\AccessCode;
+use Components\Newsletter\Models\Campaign;
 
 class CodeHelper
 {
@@ -21,7 +23,7 @@ class CodeHelper
 	public static function validateCode($username, $campaignId, $pageId, $code)
 	{
 		// acquire user info
-		$userId = User::all()->whereEquals('username', $username)->get('id');
+		$userId = User::whereEquals('username', $username)->row()->get('id');
 
 		// acquire campaign info
 		$campModel = Campaign::all()->whereEquals('id', $campaignId)->row();

--- a/core/components/com_newsletter/helpers/codeHelper.php
+++ b/core/components/com_newsletter/helpers/codeHelper.php
@@ -17,6 +17,7 @@ use Components\Newsletter\Models\AccessCode;
 class CodeHelper
 {
 
+	// Validate code passed in user's URL, with user, campaign, and page information.
 	public static function validateCode($username, $campaignId, $pageId, $code)
 	{
 		// acquire user info
@@ -37,7 +38,7 @@ class CodeHelper
 
 		$hashMatches = ($code == $database->loadResult());
 
-		return ($hashMatches && $campNotExpired && $codeNotExpired && $codeMatchesPage);
+		return ($hashMatches && $campNotExpired && $codeMatchesPage);
 	}
 
 	// TODO: delete
@@ -52,12 +53,19 @@ class CodeHelper
 		return $exists && $notExpired && $matchesPage;
 	}
 
-	// TODO: 
-	public static function validateEmailSubscriptionsCode($code)
+	// Validate code obtained from user's URL, using email subscription page id
+	public static function validateEmailSubscriptionsCode($username, $campaignId, $code)
 	{
 		$emailSubsPageId = CODE_SECRETS['email_subscriptions_page_id'];
 
-		return self::validateCode($code, $emailSubsPageId);
+		return self::validateCode($username, $campaignId, $emailSubsPageId, $code);
 	}
 
+	// TODO: delete
+	public static function oldValidateEmailSubscriptionsCode($code)
+	{
+		$emailSubsPageId = CODE_SECRETS['email_subscriptions_page_id'];
+
+		return self::oldValidateCode($code, $emailSubsPageId);
+	}
 }

--- a/core/components/com_newsletter/helpers/subscriptionsHelper.php
+++ b/core/components/com_newsletter/helpers/subscriptionsHelper.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Helpers;
+
+use Exception;
+
+class SubscriptionsHelper
+{
+
+	private static $activeReferenceField = 'preference';
+	private static $activePattern = '/^yes/i';
+	private static $badDataSubmitted = 'Unable to process your updates';
+	private static $subscriptionNotFound = 'Selected user subscription not found';
+	private static $userProfileOptionNotFound = 'Selected user profile option not found';
+
+	public function __construct() {
+		$this->db = App::get('db');
+	}
+
+	public function loadSubscriptions($userId)
+	{
+		$activeRef = self::$activeReferenceField;
+
+		$this->db->setQuery("
+			select pf.id, pf.label, es.order, es.view, up.profile_value as $activeRef,
+			       pf.name as foreign_key
+			from jos_email_subscriptions es
+			left join jos_user_profile_fields pf on es.profile_field_name = pf.name
+			left join jos_user_profiles up on pf.name = up.profile_key and up.user_id = $userId;");
+
+		return array_map(function($sub) {
+			return $this->subToMap($sub);
+		}, $this->db->loadObjectList());
+	}
+
+	private function subToMap($sub)
+	{
+		$activeRef = self::$activeReferenceField;
+		$subMap = (array) $sub;
+
+		$subMap['active'] = preg_match(self::$activePattern, $sub->$activeRef);
+		$subMap['options'] = self::loadSubscriptionOptions($sub->id);
+
+		return $subMap;
+	}
+
+	// Added exception handling to provide feedback if database has not been set up correctly for com_reply features:
+	private function loadSubscriptionOptions($profileFieldId)
+	{
+		// If empty profileFieldId passed, we were unable to look up the subscription:
+		if ($profileFieldId) {
+			$this->db->setQuery("select value
+		                     from jos_user_profile_options
+		                     where field_id = $profileFieldId");
+		} else {
+			throw new Exception(self::$subscriptionNotFound, 400);
+		}
+
+		// If profile option cannot be found, pass friendlier error:
+		if ($this->db->loadColumn())
+		{
+			return $this->db->loadColumn();
+		} else {
+			throw new Exception(self::$userProfileOptionNotFound, 400);
+		}
+	}
+
+	public function updateSubscriptions($userId, $updatedSubscriptions)
+	{
+		foreach ($updatedSubscriptions as $s)
+		{
+			$this->updateSubscription($userId, $s);
+		}
+	}
+
+	private function updateSubscription($userId, $updatedSubscription)
+	{
+		$updateQuery = $this->buildUpdateQuery($userId, $updatedSubscription);
+
+		$this->db->setQuery($updateQuery);
+
+		$this->db->execute();
+	}
+
+	private function buildUpdateQuery($userId, $updatedSubscription)
+	{
+		$preference = $updatedSubscription['preference'];
+		$profileFieldFk = $updatedSubscription['foreign_key'];
+
+		$this->validateSubmittedSubscription($profileFieldFk, $preference);
+
+		if ($this->subscriptionExists($userId, $updatedSubscription))
+		{
+			$query = $this->generateUpdateQuery($userId, $updatedSubscription);
+		}
+		else
+		{
+			$query = $this->generateInsertQuery($userId, $updatedSubscription);
+		}
+
+		return $query;
+	}
+
+	private function subscriptionExists($userId, $subscription) {
+		$profileFieldFk = $subscription['foreign_key'];
+
+		$countQuery = "select id
+		               from jos_user_profiles
+		               where user_id = $userId and profile_key = '$profileFieldFk';";
+
+		$this->db->setQuery($countQuery);
+
+		$count = $this->db->execute()->getNumRows();
+
+		return $count > 0;
+	}
+
+	private function generateUpdateQuery($userId, $subscription) {
+		$preference = $subscription['preference'];
+		$profileFieldFk = $subscription['foreign_key'];
+
+		return "update jos_user_profiles
+		        set profile_value = '$preference'
+		        where profile_key = '$profileFieldFk' and user_id = $userId;";
+	}
+
+	private function generateInsertQuery($userId, $subscription) {
+		$preference = $subscription['preference'];
+		$profileFieldFk = $subscription['foreign_key'];
+
+		return "insert into jos_user_profiles
+		        (user_id, profile_key, profile_value)
+		        values($userId, '$profileFieldFk', '$preference');";
+	}
+
+	private function validateSubmittedSubscription($profileFieldFk,	$preference)
+	{
+		$this->validateProfileFieldFk($profileFieldFk);
+		$this->validatePreference($preference);
+	}
+
+	private function validateProfileFieldFk($profileFieldFk)
+	{
+		$validProfileFieldFks = $this->loadProfileFieldFks();
+
+		if (!in_array($profileFieldFk, $validProfileFieldFks)) {
+			throw new Exception(self::$badDataSubmitted, 400);
+		}
+	}
+
+	private function loadProfileFieldFks()
+	{
+		$this->db->setQuery("
+				select pf.name
+				from jos_email_subscriptions es
+				left join jos_user_profile_fields pf on es.profile_field_name = pf.name;");
+
+		return $this->db->loadColumn();
+	}
+
+	private function validatePreference($preference)
+	{
+		$validPreferences = $this->loadProfileOptionValues();
+
+		if (!in_array($preference, $validPreferences)) {
+			throw new Exception(self::$badDataSubmitted, 400);
+		}
+	}
+
+	private function loadProfileOptionValues()
+	{
+		$this->db->setQuery("
+				select po.value
+				from jos_email_subscriptions es
+				left join jos_user_profile_fields pf on es.profile_field_name = pf.name
+				left join jos_user_profile_options po on pf.id = po.field_id;");
+
+		return $this->db->loadColumn();
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200707105156CreatePagesTable.php
+++ b/core/components/com_newsletter/migrations/Migration20200707105156CreatePagesTable.php
@@ -1,0 +1,44 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200707105156CreatePagesTable extends Base
+{
+
+	static $tableName = '#__reply_pages';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`description` varchar(255) NOT NULL,
+			`created` timestamp NULL DEFAULT NULL,
+			PRIMARY KEY (`id`)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$dropTable = "DROP TABLE $tableName";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200708093025CreateRepliesTable.php
+++ b/core/components/com_newsletter/migrations/Migration20200708093025CreateRepliesTable.php
@@ -1,0 +1,46 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200708093025CreateRepliesTable extends Base
+{
+
+	static $tableName = '#__reply_replies';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`user_id` int(11) unsigned NOT NULL,
+			`page_id` int(11) unsigned NOT NULL,
+			`input` text NOT NULL,
+			`created` timestamp NOT NULL,
+			PRIMARY KEY (`id`)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$dropTable = "DROP TABLE $tableName";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200709062801CreateEmailSubscriptionsTable.php
+++ b/core/components/com_newsletter/migrations/Migration20200709062801CreateEmailSubscriptionsTable.php
@@ -1,0 +1,49 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200709062801CreateEmailSubscriptionsTable extends Base
+{
+
+	static $tableName = '#__email_subscriptions';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`description` varchar(255) NOT NULL,
+			`order` int(11) NOT NULL,
+			`view` varchar(255) NULL DEFAULT NULL,
+			`required` tinyint(1) NOT NULL DEFAULT 0,
+			`created` timestamp NULL DEFAULT NULL,
+			`modified` timestamp NULL DEFAULT NULL,
+			`modified_by` int(11) unsigned NULL DEFAULT NULL,
+			PRIMARY KEY (`id`)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$dropTable = "DROP TABLE $tableName";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200709072644CreateUsersEmailSubscriptionsTable.php
+++ b/core/components/com_newsletter/migrations/Migration20200709072644CreateUsersEmailSubscriptionsTable.php
@@ -1,0 +1,47 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200709072644CreateUsersEmailSubscriptionsTable extends Base
+{
+
+	static $tableName = '#__users_email_subscriptions';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`user_id` int(11) unsigned NOT NULL,
+			`email_subscription_id` int(11) unsigned NOT NULL,
+			`subscribed` bool NULL DEFAULT NULL,
+			`created` timestamp NULL DEFAULT NULL,
+			`modified` timestamp NULL DEFAULT NULL,
+			PRIMARY KEY (`id`)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$dropTable = "DROP TABLE $tableName";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200710061306CreateAccessCodesTable.php
+++ b/core/components/com_newsletter/migrations/Migration20200710061306CreateAccessCodesTable.php
@@ -1,0 +1,49 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200710061306CreateAccessCodesTable extends Base
+{
+
+	static $tableName = '#__reply_access_codes';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`user_id` int(11) unsigned NOT NULL,
+			`page_id` int(11) unsigned NOT NULL,
+			`code` char(64) NOT NULL,
+			`expiration` timestamp NULL DEFAULT NULL,
+			`created` timestamp NULL DEFAULT NULL,
+			PRIMARY KEY (`id`),
+			UNIQUE KEY(code),
+			INDEX(user_id)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$dropTable = "DROP TABLE $tableName";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200727063146PopulateStartingEmailSubscriptions.php
+++ b/core/components/com_newsletter/migrations/Migration20200727063146PopulateStartingEmailSubscriptions.php
@@ -1,0 +1,36 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200727063146PopulateStartingEmailSubscriptions extends Base
+{
+
+	static $tableName = '#__email_subscriptions';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+		$now = Date::toSql();
+
+		$insertRecords = "INSERT INTO $tableName
+			(`description`, `order`, `view`, `required`, `created`)
+			VALUES
+			('personalizedcommunication', 1, '_personalized_communications_by_interest', 0, '$now'),
+			('updates_news', 2, '_updates_and_news', 0, '$now');";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($insertRecords);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		// manually delete records
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200731133740AlterEmailSubscriptionsTable.php
+++ b/core/components/com_newsletter/migrations/Migration20200731133740AlterEmailSubscriptionsTable.php
@@ -1,0 +1,54 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20200731133740AlterEmailSubscriptionsTable extends Base
+{
+
+	static $tableName = '#__email_subscriptions';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+		$now = Date::toSql();
+
+		$renameDescription = "ALTER TABLE $tableName
+													CHANGE COLUMN description profile_field_name varchar(255);";
+
+		$dropRequired = "ALTER TABLE $tableName DROP COLUMN required;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($renameDescription);
+			$this->db->query();
+
+			$this->db->setQuery($dropRequired);
+			$this->db->query();
+
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+		$now = Date::toSql();
+
+		$renameDescription = "ALTER TABLE $tableName
+													CHANGE COLUMN profile_field_name description varchar(255);";
+
+		$addRequired = "ALTER TABLE $tableName ADD required tinyint(1);";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($renameDescription);
+			$this->db->query();
+
+			$this->db->setQuery($dropRequired);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20200915135039AddPageExpirationCol.php
+++ b/core/components/com_newsletter/migrations/Migration20200915135039AddPageExpirationCol.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+defined('_HZEXEC_') or die();
+
+use Hubzero\Content\Migration\Base;
+
+class Migration20200915135039AddPageExpirationCol extends Base
+{
+
+	static $tableName = '#__reply_pages';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$alterTable = "ALTER TABLE $tableName
+			ADD COLUMN next_expiration timestamp NOT NULL;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($alterTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$alterTable = "ALTER TABLE $tableName
+			DROP COLUMN next_expiration;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($alterTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -25,11 +25,12 @@ class Migration20230920000000ComNewsletter extends Base
 			$query = "CREATE TABLE IF NOT EXISTS `campaign` (
     			id INT(11) NOT NULL AUTO_INCREMENT,
     			title VARCHAR(50),
-    			description TEXT,
-    			campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
-				secret CHAR(32) UNIQUE NULL,
+				`description` TEXT,
+				campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+				`secret` CHAR(32) UNIQUE NULL,
 				modified  DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
-    			modified_by int(11) DEFAULT NULL,
+				expire_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+				modified_by int(11) DEFAULT NULL,
 				PRIMARY KEY (id),
 				KEY idx_title (title)
 			) ENGINE=MyISAM DEFAULT CHARSET=utf8;";

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -28,7 +28,10 @@ class Migration20230920000000ComNewsletter extends Base
     			description TEXT,
     			campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
 				secret CHAR(32) UNIQUE NULL,
-				PRIMARY KEY (id)
+				modified  DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+    			modified_by int(11) DEFAULT NULL,
+				PRIMARY KEY (id),
+				KEY idx_title (title)
 			) ENGINE=MyISAM DEFAULT CHARSET=utf8;";
 
 			$this->db->setQuery($query);

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for managing campaigns and their secrets via com_newsletter
+ **/
+class Migration20230920000000ComNewsletter extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		if (!$this->db->tableExists('campaign'))
+		{
+			$query = "CREATE TABLE IF NOT EXISTS `campaign` (
+    			id INT(11) NOT NULL AUTO_INCREMENT,
+    			title VARCHAR(50),
+    			description TEXT,
+    			campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+				secret CHAR(32) UNIQUE NULL,
+				PRIMARY KEY (id)
+			) ENGINE=MyISAM DEFAULT CHARSET=utf8;";
+
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		if ($this->db->tableExists('campaign'))
+		{
+			$query = "DROP TABLE IF EXISTS `campaign`;";
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+}

--- a/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
+++ b/core/components/com_newsletter/migrations/Migration20230920000000ComNewsletter.php
@@ -23,8 +23,8 @@ class Migration20230920000000ComNewsletter extends Base
 		if (!$this->db->tableExists('campaign'))
 		{
 			$query = "CREATE TABLE IF NOT EXISTS `campaign` (
-    			id INT(11) NOT NULL AUTO_INCREMENT,
-    			title VARCHAR(50),
+				id INT(11) NOT NULL AUTO_INCREMENT,
+				title VARCHAR(50),
 				`description` TEXT,
 				campaign_date DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
 				`secret` CHAR(32) UNIQUE NULL,

--- a/core/components/com_newsletter/migrations/Migration20231222155000AlterReplyAccessCodesTable.php
+++ b/core/components/com_newsletter/migrations/Migration20231222155000AlterReplyAccessCodesTable.php
@@ -1,0 +1,50 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20231222155000AlterReplyAccessCodesTable extends Base
+{
+
+	static $tableName = '#__reply_access_codes';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+		$now = Date::toSql();
+
+		$dropCode = "ALTER TABLE $tableName DROP COLUMN code;";
+		$dropExpire = "ALTER TABLE $tableName DROP COLUMN expiration;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropCode);
+			$this->db->query();
+
+			$this->db->setQuery($dropExpire);
+			$this->db->query();
+
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+		$now = Date::toSql();
+
+		$addCode = "ALTER TABLE $tableName ADD code char(64);";
+		$addExpire = "ALTER TABLE $tableName ADD expiration timestamp;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($addCode);
+			$this->db->query();
+
+			$this->db->setQuery($addExpire);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20231222155500CreateHashStoredProc.php
+++ b/core/components/com_newsletter/migrations/Migration20231222155500CreateHashStoredProc.php
@@ -1,0 +1,36 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20231222155500CreateHashStoredProc extends Base
+{
+
+	public function up()
+	{
+		$createSP = "CREATE FUNCTION hash_access_code (campaign_id INT(11), user_name VARCHAR(150)) ".
+                "RETURNS CHAR(64) ".
+                "BEGIN ".
+                "    SET @cs = (SELECT secret FROM campaign WHERE id=campaign_id); ".
+                "    SET @hs = (SELECT secret FROM campaign_hub); ".
+                "    SET @us = (SELECT secret FROM jos_users WHERE username=user_name); ".
+                "RETURN SHA2(CONCAT(@cs,@hs,@us), 256); ".
+                "END;";
+
+
+		$this->db->setQuery($createSP);
+		$this->db->query();
+	}
+
+	public function down()
+	{
+
+		$dropSP = "DROP FUNCTION IF EXISTS hash_access_code;";
+
+		$this->db->setQuery($dropSP);
+		$this->db->query();
+	}
+
+}

--- a/core/components/com_newsletter/models/accessCode.php
+++ b/core/components/com_newsletter/models/accessCode.php
@@ -14,14 +14,4 @@ class AccessCode extends Relational
 	protected $table = '#__reply_access_codes';
 
 	public $initiate = ['created'];
-
-	public function isExpired()
-	{
-		$expiration = $this->get('expiration');
-
-		$invalidExpiration = empty($expiration);
-		$isExpired = strtotime(Date::of()) > strtotime($expiration);
-
-		return $invalidExpiration || $isExpired;
-	}
 }

--- a/core/components/com_newsletter/models/accessCode.php
+++ b/core/components/com_newsletter/models/accessCode.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+
+class AccessCode extends Relational
+{
+	protected $table = '#__reply_access_codes';
+
+	public $initiate = ['created'];
+
+	public function isExpired()
+	{
+		$expiration = $this->get('expiration');
+
+		$invalidExpiration = empty($expiration);
+		$isExpired = strtotime(Date::of()) > strtotime($expiration);
+
+		return $invalidExpiration || $isExpired;
+	}
+}

--- a/core/components/com_newsletter/models/campaign.php
+++ b/core/components/com_newsletter/models/campaign.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2023 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+use Date;
+use User;
+
+/**
+ * Model for a campaign
+ */
+class Campaign extends Relational
+{
+	/**
+	 * The table name
+	 *
+	 * @var  string
+	 */
+	protected $table = 'campaign';
+
+	/**
+	 * Default order by for model
+	 *
+	 * @var  string
+	 */
+	public $orderBy = 'id';
+
+	/**
+	 * Default order direction for select queries
+	 *
+	 * @var  string
+	 */
+	public $orderDir = 'asc';
+
+	/**
+	 * Fields and their validation criteria
+	 *
+	 * @var  array
+	 */
+	protected $rules = array(
+		'title' => 'notempty'
+	);
+	/**
+	 * Automatic fields to populate every time a row is created
+	 *
+	 * @var  array
+	 */
+	public $initiate = array(
+		'campaign_date',
+		'secret'
+	);
+
+	/**
+	 * Automatically fillable fields
+	 *
+	 * @var  array
+	 **/
+	public $always = array(
+		'modified',
+		'modified_by',
+	);
+
+	/**
+	 * Generates automatic current date field value for campaign_date
+	 * TODO: Ensure this is UTC.
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function automaticCampaignDate($data)
+	{
+		return Date::of('now')->toSql();
+	}
+
+	/**
+	 * Generates automatic modified by field value
+	 *
+	 * @param   array    $data  the data being saved
+	 * @return  integer
+	 */
+	public function automaticModifiedBy($data)
+	{
+		return User::get('id'); 
+	}
+
+	/**
+	 * Generates automatic created field value
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function automaticModified($data)
+	{
+		return $this->automaticCampaignDate($data);
+	}
+
+	/**
+	 * Generates automatic secret value on creation of new record
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function automaticSecret($data)
+	{
+		return $this->generateSecret($data);
+	}
+
+	/**
+	 * Generates new secret value 
+	 *
+	 * @param   array   $data  the data being saved
+	 * @return  string
+	 */
+	public function generateSecret($data)
+	{
+		// create 32-character secret:
+		$secretLength = 32;
+		return \Hubzero\User\Password::genRandomPassword($secretLength);
+	}
+}

--- a/core/components/com_newsletter/models/campaign.php
+++ b/core/components/com_newsletter/models/campaign.php
@@ -121,4 +121,14 @@ class Campaign extends Relational
 		$secretLength = 32;
 		return \Hubzero\User\Password::genRandomPassword($secretLength);
 	}
+
+	public function isExpired()
+	{
+		$expiration = $this->get('expire_date');
+
+		$invalidExpiration = empty($expiration);
+		$isExpired = strtotime(Date::of()) > strtotime($expiration);
+
+		return $invalidExpiration || $isExpired;
+	}
 }

--- a/core/components/com_newsletter/models/campaign.php
+++ b/core/components/com_newsletter/models/campaign.php
@@ -67,7 +67,6 @@ class Campaign extends Relational
 
 	/**
 	 * Generates automatic current date field value for campaign_date
-	 * TODO: Ensure this is UTC.
 	 *
 	 * @param   array   $data  the data being saved
 	 * @return  string
@@ -116,7 +115,7 @@ class Campaign extends Relational
 	 * @param   array   $data  the data being saved
 	 * @return  string
 	 */
-	public function generateSecret($data)
+	public static function generateSecret($data)
 	{
 		// create 32-character secret:
 		$secretLength = 32;

--- a/core/components/com_newsletter/models/campaign.php
+++ b/core/components/com_newsletter/models/campaign.php
@@ -84,7 +84,7 @@ class Campaign extends Relational
 	 */
 	public function automaticModifiedBy($data)
 	{
-		return User::get('id'); 
+		return User::get('id');
 	}
 
 	/**
@@ -110,7 +110,7 @@ class Campaign extends Relational
 	}
 
 	/**
-	 * Generates new secret value 
+	 * Generates new secret value
 	 *
 	 * @param   array   $data  the data being saved
 	 * @return  string

--- a/core/components/com_newsletter/models/emailSubscription.php
+++ b/core/components/com_newsletter/models/emailSubscription.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+
+class EmailSubscription extends Relational
+{
+	protected $table = '#__email_subscriptions';
+}

--- a/core/components/com_newsletter/models/reply.php
+++ b/core/components/com_newsletter/models/reply.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+
+class Reply extends Relational
+{
+	protected $table = '#__reply_replies';
+}

--- a/core/components/com_newsletter/models/usersEmailSubscription.php
+++ b/core/components/com_newsletter/models/usersEmailSubscription.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+
+class UsersEmailSubscription extends Relational
+{
+	protected $table = '#__users_email_subscriptions';
+
+	public $initiate = ['created'];
+
+	public function save() {
+		if (!$this->isNew())
+		{
+			$this->set('modified', date("Y-m-d H:i:s"));
+		}
+
+		return parent::save();
+	}
+
+}

--- a/core/components/com_newsletter/secrets/code_example.php
+++ b/core/components/com_newsletter/secrets/code_example.php
@@ -1,0 +1,6 @@
+<?php
+
+const CODE_SECRETS = [
+	'email_subscriptions_page_id' => 0 //<email_subscriptions_page_id>
+];
+?>

--- a/core/components/com_newsletter/site/assets/css/basicForm.css
+++ b/core/components/com_newsletter/site/assets/css/basicForm.css
@@ -1,0 +1,4 @@
+
+.btn-success {
+	float: right;
+}

--- a/core/components/com_newsletter/site/assets/css/emailSubscriptionsDisplay.css
+++ b/core/components/com_newsletter/site/assets/css/emailSubscriptionsDisplay.css
@@ -1,0 +1,11 @@
+#hubForm label {
+	display: block;
+}
+
+.comms-notice {
+	padding: .5em 1em;
+}
+
+.sub {
+	margin: 0 0 2em 0;
+}

--- a/core/components/com_newsletter/site/assets/css/page2.css
+++ b/core/components/com_newsletter/site/assets/css/page2.css
@@ -1,0 +1,4 @@
+
+#hubForm textarea {
+	height: 500px;
+}

--- a/core/components/com_newsletter/site/controllers/emailsubscriptions.php
+++ b/core/components/com_newsletter/site/controllers/emailsubscriptions.php
@@ -29,16 +29,19 @@ class Emailsubscriptions extends SiteController
 	public function displayTask()
 	{
 		$code = Request::getString('code');
+		// TODO: obtain values
+		$username = Request::getString('username');
+		$campaignId = Request::getString('campaignId');
 
-		if (!CodeHelper::validateEmailSubscriptionsCode($code, false))
+		// Verify that the user-supplied URL enables access:
+		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
 			App::redirect('/');
 		}
 
 		$subHelper = new SubscriptionsHelper();
-		$codeM = AccessCode::all()->whereEquals('code', $code)->row();
-		$userId = $codeM->get('user_id');
+		$userId = User::whereEquals('username', $username)->get('id');
 		$subscriptions = $subHelper->loadSubscriptions($userId);
 
 		$this->view->set('userId', $userId);
@@ -52,19 +55,24 @@ class Emailsubscriptions extends SiteController
 		Request::checkToken();
 
 		$code = Request::getString('code');
+		// TODO: obtain values
+		$username = Request::getString('username');
+		$campaignId = Request::getString('campaignId');
 
-		if (!CodeHelper::validateEmailSubscriptionsCode($code, false))
+		// Verify that the user-supplied URL enables access:
+		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
 			App::redirect('/');
 		}
 
-		$codeM = AccessCode::all()->whereEquals('code', $code)->row();
+		// Look up the subscription based on user id:
+		$userId = User::whereEquals('username', $username)->get('id');
 		$updatedSubscriptions = Request::getArray('subscriptions');
 		$subHelper = new SubscriptionsHelper();
 
 		$subHelper->updateSubscriptions(
-			$codeM->get('user_id'),
+			$userId,
 			$updatedSubscriptions
 		);
 

--- a/core/components/com_newsletter/site/controllers/emailsubscriptions.php
+++ b/core/components/com_newsletter/site/controllers/emailsubscriptions.php
@@ -31,7 +31,7 @@ class Emailsubscriptions extends SiteController
 		$code = Request::getString('code');
 		// TODO: obtain values
 		$username = Request::getString('username');
-		$campaignId = Request::getString('campaignId');
+		$campaignId = Request::getInt('campaignId');
 
 		// Verify that the user-supplied URL enables access:
 		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
@@ -57,7 +57,7 @@ class Emailsubscriptions extends SiteController
 		$code = Request::getString('code');
 		// TODO: obtain values
 		$username = Request::getString('username');
-		$campaignId = Request::getString('campaignId');
+		$campaignId = Request::getInt('campaignId');
 
 		// Verify that the user-supplied URL enables access:
 		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))

--- a/core/components/com_newsletter/site/controllers/emailsubscriptions.php
+++ b/core/components/com_newsletter/site/controllers/emailsubscriptions.php
@@ -29,9 +29,8 @@ class Emailsubscriptions extends SiteController
 	public function displayTask()
 	{
 		$code = Request::getString('code');
-		// TODO: obtain values
-		$username = Request::getString('username');
-		$campaignId = Request::getInt('campaignId');
+		$username = Request::getString('user');
+		$campaignId = Request::getInt('campaign');
 
 		// Verify that the user-supplied URL enables access:
 		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
@@ -41,7 +40,10 @@ class Emailsubscriptions extends SiteController
 		}
 
 		$subHelper = new SubscriptionsHelper();
-		$userId = User::whereEquals('username', $username)->get('id');
+
+		// acquire user info
+		$userId = User::whereEquals('username', $username)->row()->get('id');
+
 		$subscriptions = $subHelper->loadSubscriptions($userId);
 
 		$this->view->set('userId', $userId);
@@ -55,9 +57,8 @@ class Emailsubscriptions extends SiteController
 		Request::checkToken();
 
 		$code = Request::getString('code');
-		// TODO: obtain values
-		$username = Request::getString('username');
-		$campaignId = Request::getInt('campaignId');
+		$username = Request::getString('user');
+		$campaignId = Request::getInt('campaign');
 
 		// Verify that the user-supplied URL enables access:
 		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
@@ -67,7 +68,8 @@ class Emailsubscriptions extends SiteController
 		}
 
 		// Look up the subscription based on user id:
-		$userId = User::whereEquals('username', $username)->get('id');
+		$user = User::whereEquals('username', $username)->row();
+		$userId = $user->get('id');
 		$updatedSubscriptions = Request::getArray('subscriptions');
 		$subHelper = new SubscriptionsHelper();
 

--- a/core/components/com_newsletter/site/controllers/emailsubscriptions.php
+++ b/core/components/com_newsletter/site/controllers/emailsubscriptions.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Site\Controllers;
+
+use Hubzero\Component\SiteController;
+
+$componentPath = Component::path('com_newsletter');
+
+require_once  "$componentPath/helpers/codeHelper.php";
+require_once  "$componentPath/helpers/subscriptionsHelper.php";
+require_once  "$componentPath/models/accessCode.php";
+require_once  "$componentPath/models/emailSubscription.php";
+require_once  "$componentPath/models/usersEmailSubscription.php";
+
+use Components\Newsletter\Helpers\CodeHelper;
+use Components\Newsletter\Helpers\SubscriptionsHelper;
+use Components\Newsletter\Models\AccessCode;
+use Components\Newsletter\Models\EmailSubscription;
+use Components\Newsletter\Models\UsersEmailSubscription;
+
+class Emailsubscriptions extends SiteController
+{
+
+	public function displayTask()
+	{
+		$code = Request::getString('code');
+
+		if (!CodeHelper::validateEmailSubscriptionsCode($code, false))
+		{
+			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
+			App::redirect('/');
+		}
+
+		$subHelper = new SubscriptionsHelper();
+		$codeM = AccessCode::all()->whereEquals('code', $code)->row();
+		$userId = $codeM->get('user_id');
+		$subscriptions = $subHelper->loadSubscriptions($userId);
+
+		$this->view->set('userId', $userId);
+		$this->view->set('subs', $subscriptions);
+		$this->view->set('code', $code);
+		$this->view->display();
+	}
+
+	public function updateTask()
+	{
+		Request::checkToken();
+
+		$code = Request::getString('code');
+
+		if (!CodeHelper::validateEmailSubscriptionsCode($code, false))
+		{
+			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
+			App::redirect('/');
+		}
+
+		$codeM = AccessCode::all()->whereEquals('code', $code)->row();
+		$updatedSubscriptions = Request::getArray('subscriptions');
+		$subHelper = new SubscriptionsHelper();
+
+		$subHelper->updateSubscriptions(
+			$codeM->get('user_id'),
+			$updatedSubscriptions
+		);
+
+		Notify::success(Lang::txt('SUBSCRIPTION_UPDATE_SUCCESS'));
+		App::redirect('/');
+	}
+
+}

--- a/core/components/com_newsletter/site/controllers/emailsubscriptions.php
+++ b/core/components/com_newsletter/site/controllers/emailsubscriptions.php
@@ -32,7 +32,7 @@ class Emailsubscriptions extends SiteController
 		$username = Request::getString('user');
 		$campaignId = Request::getInt('campaign');
 
-		// Verify that the user-supplied URL enables access:
+		// Verify that the user-supplied URL and code are valid:
 		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
@@ -60,7 +60,7 @@ class Emailsubscriptions extends SiteController
 		$username = Request::getString('user');
 		$campaignId = Request::getInt('campaign');
 
-		// Verify that the user-supplied URL enables access:
+		// Verify that the user-supplied URL and code are valid:
 		if (!CodeHelper::validateEmailSubscriptionsCode($username, $campaignId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
@@ -68,8 +68,7 @@ class Emailsubscriptions extends SiteController
 		}
 
 		// Look up the subscription based on user id:
-		$user = User::whereEquals('username', $username)->row();
-		$userId = $user->get('id');
+		$userId = User::whereEquals('username', $username)->row()->get('id');
 		$updatedSubscriptions = Request::getArray('subscriptions');
 		$subHelper = new SubscriptionsHelper();
 

--- a/core/components/com_newsletter/site/controllers/mailinglists.php
+++ b/core/components/com_newsletter/site/controllers/mailinglists.php
@@ -99,6 +99,9 @@ class Mailinglists extends SiteController
 	 */
 	public function subscribeTask()
 	{
+		//check to make sure we have a valid token
+		Request::checkToken();
+
 		//get email
 		if (User::isGuest())
 		{
@@ -272,6 +275,9 @@ class Mailinglists extends SiteController
 	 */
 	public function doMultiSubscribeTask()
 	{
+		//check to make sure we have a valid token
+		Request::checkToken();
+
 		//get request vars
 		$lists = Request::getArray('lists', array(), 'post');
 
@@ -427,7 +433,7 @@ class Mailinglists extends SiteController
 					'description' => Lang::txt('COM_NEWSLETTER_MAILINGLIST_UNSUBSCRIBE_DEFAULTLIST')
 				));
 		}
-		else
+	else
 		{
 			//load mailing list
 			$mailinglist = Mailinglist::oneOrFail($mailing->lid);
@@ -506,6 +512,9 @@ class Mailinglists extends SiteController
 	 */
 	public function doUnsubscribeTask()
 	{
+		//check to make sure we have a valid token
+		Request::checkToken();
+
 		//get request vars
 		$email      = urldecode(Request::getString('e', ''));
 		$token      = Request::getString('t', '');

--- a/core/components/com_newsletter/site/controllers/pages.php
+++ b/core/components/com_newsletter/site/controllers/pages.php
@@ -21,11 +21,9 @@ class Pages extends SiteController
 	{
 		$code = Request::getString('code');
 		$pageId = Request::getInt('id');
-		// TODO: pass these values
 		$username = Request::getString('user');
 		$campaignId = Request::getInt('campaign');
 
-		//if (!CodeHelper::validateCode($code, $pageId))
 		if (!CodeHelper::validateCode($username, $campaignId, $pageId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));

--- a/core/components/com_newsletter/site/controllers/pages.php
+++ b/core/components/com_newsletter/site/controllers/pages.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Site\Controllers;
+
+$componentPath = Component::path('com_newsletter');
+
+require_once  "$componentPath/helpers/codeHelper.php";
+
+use Hubzero\Component\SiteController;
+use Components\Newsletter\Helpers\CodeHelper;
+
+class Pages extends SiteController
+{
+
+	public function displayTask()
+	{
+		$code = Request::getString('code');
+		$pageId = Request::getInt('id');
+
+		if (!CodeHelper::validateCode($code, $pageId))
+		{
+			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
+			App::redirect('/');
+		}
+
+		$this->setView('pages', "page$pageId");
+		$this->view->set('code', $code);
+		$this->view->set('pageId', $pageId);
+		$this->view->display();
+	}
+
+}

--- a/core/components/com_newsletter/site/controllers/pages.php
+++ b/core/components/com_newsletter/site/controllers/pages.php
@@ -22,8 +22,8 @@ class Pages extends SiteController
 		$code = Request::getString('code');
 		$pageId = Request::getInt('id');
 		// TODO: pass these values
-		$username = Request::getString('user_name');
-		$campaign_id = Request::getInt('campaign_id');
+		$username = Request::getString('user');
+		$campaignId = Request::getInt('campaign');
 
 		//if (!CodeHelper::validateCode($code, $pageId))
 		if (!CodeHelper::validateCode($username, $campaignId, $pageId, $code))

--- a/core/components/com_newsletter/site/controllers/pages.php
+++ b/core/components/com_newsletter/site/controllers/pages.php
@@ -21,8 +21,12 @@ class Pages extends SiteController
 	{
 		$code = Request::getString('code');
 		$pageId = Request::getInt('id');
+		// TODO: pass these values
+		$username = Request::getString('user_name');
+		$campaign_id = Request::getInt('campaign_id');
 
-		if (!CodeHelper::validateCode($code, $pageId))
+		//if (!CodeHelper::validateCode($code, $pageId))
+		if (!CodeHelper::validateCode($username, $campaignId, $pageId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
 			App::redirect('/');

--- a/core/components/com_newsletter/site/controllers/replies.php
+++ b/core/components/com_newsletter/site/controllers/replies.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Site\Controllers;
+
+$componentPath = Component::path('com_newsletter');
+
+require_once  "$componentPath/helpers/codeHelper.php";
+require_once  "$componentPath/models/accessCode.php";
+require_once  "$componentPath/models/reply.php";
+
+use Components\Newsletter\Helpers\CodeHelper;
+use Components\Newsletter\Models\AccessCode;
+use Components\Newsletter\Models\Reply;
+use Hubzero\Component\SiteController;
+
+class Replies extends SiteController
+{
+
+	public function createTask()
+	{
+		Request::checkToken();
+
+		$code = Request::getString('code');
+		$pageId = Request::getInt('page_id');
+
+		if (!CodeHelper::validateCode($code, $pageId, false))
+		{
+			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
+			App::redirect('/');
+		}
+
+		$codeM = AccessCode::all()->whereEquals('code', $code)->row();
+		$reply = Reply::blank();
+		$reply->set([
+			'input'=> json_encode(Request::getArray('reply')),
+			'page_id' => $codeM->get('page_id'),
+			'user_id' => $codeM->get('user_id'),
+			'created' => Date::toSql()
+		]);
+
+		if ($reply->save())
+		{
+			Notify::success(Lang::txt('REPLY_CREATION_SUCCESS'));
+			App::redirect('/');
+		}
+		else
+		{
+			Notify::error(Lang::txt('REPLY_CREATION_FAILURE'));
+			App::redirect("/newsletter/pages/$pageId?code=$code");
+		}
+	}
+
+}

--- a/core/components/com_newsletter/site/controllers/replies.php
+++ b/core/components/com_newsletter/site/controllers/replies.php
@@ -28,7 +28,13 @@ class Replies extends SiteController
 		$code = Request::getString('code');
 		$pageId = Request::getInt('page_id');
 
-		if (!CodeHelper::validateCode($code, $pageId, false))
+		// TODO: pass these values
+		$username = Request::getString('user_name');
+		$campaign_id = Request::getInt('campaign_id');
+
+		// TODO: why false?
+		//if (!CodeHelper::validateCode($code, $pageId, false))
+		if (!CodeHelper::validateCode($username, $campaignId, $pageId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
 			App::redirect('/');

--- a/core/components/com_newsletter/site/controllers/replies.php
+++ b/core/components/com_newsletter/site/controllers/replies.php
@@ -40,12 +40,13 @@ class Replies extends SiteController
 			App::redirect('/');
 		}
 
-		$codeM = AccessCode::all()->whereEquals('code', $code)->row();
+		$userId = User::whereEquals('username', $username)->get('id');
+
 		$reply = Reply::blank();
 		$reply->set([
 			'input'=> json_encode(Request::getArray('reply')),
-			'page_id' => $codeM->get('page_id'),
-			'user_id' => $codeM->get('user_id'),
+			'page_id' => $pageId,
+			'user_id' => $userId,
 			'created' => Date::toSql()
 		]);
 

--- a/core/components/com_newsletter/site/controllers/replies.php
+++ b/core/components/com_newsletter/site/controllers/replies.php
@@ -27,13 +27,10 @@ class Replies extends SiteController
 
 		$code = Request::getString('code');
 		$pageId = Request::getInt('page_id');
-
-		// TODO: pass these values
 		$username = Request::getString('user');
 		$campaignid = Request::getInt('campaign');
 
-		// TODO: why false?
-		//if (!CodeHelper::validateCode($code, $pageId, false))
+		// Validate that the user-supplied URL and code are valid:
 		if (!CodeHelper::validateCode($username, $campaignId, $pageId, $code))
 		{
 			Notify::warning(Lang::txt('AUTH_CODE_INVALID'));
@@ -58,7 +55,7 @@ class Replies extends SiteController
 		else
 		{
 			Notify::error(Lang::txt('REPLY_CREATION_FAILURE'));
-			App::redirect("/newsletter/pages/$pageId?code=$code");
+			App::redirect("/newsletter/pages/$pageId?campaign=$campaignId&user=$username&code=$code");
 		}
 	}
 

--- a/core/components/com_newsletter/site/controllers/replies.php
+++ b/core/components/com_newsletter/site/controllers/replies.php
@@ -29,8 +29,8 @@ class Replies extends SiteController
 		$pageId = Request::getInt('page_id');
 
 		// TODO: pass these values
-		$username = Request::getString('user_name');
-		$campaign_id = Request::getInt('campaign_id');
+		$username = Request::getString('user');
+		$campaignid = Request::getInt('campaign');
 
 		// TODO: why false?
 		//if (!CodeHelper::validateCode($code, $pageId, false))
@@ -40,7 +40,7 @@ class Replies extends SiteController
 			App::redirect('/');
 		}
 
-		$userId = User::whereEquals('username', $username)->get('id');
+		$userId = User::whereEquals('username', $username)->row()->get('id');
 
 		$reply = Reply::blank();
 		$reply->set([

--- a/core/components/com_newsletter/site/language/en-GB/en-GB.com_newsletter.ini
+++ b/core/components/com_newsletter/site/language/en-GB/en-GB.com_newsletter.ini
@@ -65,3 +65,14 @@ COM_NEWSLETTER_MAILINGLIST_UNSUBSCRIBE_ALREADY_UNSUBSCRIBED="You are already uns
 COM_NEWSLETTER_MAILINGLISTS_GUEST_PROMPT="Please Login or Enter Your Email Address"
 COM_NEWSLETTER_MAILINGLISTS_EMAIL="Email Address"
 COM_NEWSLETTER_MAILINGLISTS_CONTINUE_GUEST="Continue as Guest"
+
+; moved in from com_reply
+; Notifications
+AUTH_CODE_INVALID="The code provided has expired"
+REPLY_CREATION_FAILURE="An error prevented your reply from being saved"
+REPLY_CREATION_SUCCESS="Thank you for taking the time to reply"
+SUBSCRIPTION_UPDATE_FAILURE="An error prevented your email subscriptions from being updated"
+SUBSCRIPTION_UPDATE_SUCCESS="Email subscriptions successfully updated"
+
+; Inputs
+INPUT_SUBMIT="Submit"

--- a/core/components/com_newsletter/site/newsletter.php
+++ b/core/components/com_newsletter/site/newsletter.php
@@ -6,18 +6,45 @@
  */
 
 namespace Components\Newsletter\Site;
+use Hubzero\Utility\Arr;
+use Request;
 
 require_once dirname(__DIR__) . DS . 'models' . DS . 'newsletter.php';
 require_once dirname(__DIR__) . DS . 'models' . DS . 'mailinglist.php';
 require_once dirname(__DIR__) . DS . 'models' . DS . 'mailing.php';
+require_once dirname(__DIR__) . DS . 'models' . DS . 'accessCode.php';
+require_once dirname(__DIR__) . DS . 'models' . DS . 'emailSubscription.php';
+
 
 require_once dirname(__DIR__) . DS . 'helpers' . DS . 'helper.php';
+require_once dirname(__DIR__) . DS . 'helpers' . DS . 'codeHelper.php';
+require_once dirname(__DIR__) . DS . 'helpers' . DS . 'subscriptionsHelper.php';
 
-//build controller path and name
-$controllerName = \Request::getCmd('controller', 'newsletters');
+// determine the controller to use:
+$defaultController = 'newsletters';
+
+// controllers from the reply functionality
+$controllerNameMap = [
+	'email-subscriptions' => 'emailsubscriptions',
+	'pages' => 'pages',
+	'replies' => 'replies'
+];
+
+// if we had a controller request, set it, otherwise set 'newsletters':
+$requestedController = Request::getString('controller');
+if (!empty($requestedController))
+{
+	// from reply component
+	$controllerName = Arr::getValue($controllerNameMap, $requestedController);
+} else {
+	// from newsletter
+	$controllerName = \Request::getCmd('controller', $defaultController);
+}
+
+//build controller path and require it
 if (!file_exists(__DIR__ . DS . 'controllers' . DS . $controllerName . '.php'))
 {
-	$controllerName = 'newsletters';
+	$controllerName = $defaultController;
 }
 require_once __DIR__ . DS . 'controllers' . DS . $controllerName . '.php';
 $controllerName = __NAMESPACE__ . '\\Controllers\\' . ucfirst(strtolower($controllerName));

--- a/core/components/com_newsletter/site/router.php
+++ b/core/components/com_newsletter/site/router.php
@@ -14,6 +14,9 @@ use Hubzero\Component\Router\Base;
  */
 class Router extends Base
 {
+	// Accommodate specific controllers used by com_reply
+	// so is there a dash or not?
+	private	$replyControllers = ['email-subscriptions', 'emailsubscriptions', 'pages', 'replies'];
 	/**
 	 * Build the route for the component.
 	 *
@@ -23,7 +26,45 @@ class Router extends Base
 	public function build(&$query)
 	{
 		$segments = array();
+		$isReply = false;
 
+		// Accommodate specifics from com_reply
+		//$replyControllers = ['email-subscriptions', 'emailsubscriptions', 'pages', 'replies'];
+		$replyTasks = ['display', 'update', 'create'];
+
+		// TODO validate this assumption:
+		// assumption: com_reply query params will always specify a controller
+		// 		if no reply task is specified, that task will not be picked up
+		if (!empty($query['controller']))
+		{
+			if (in_array($query['controller'], $this->replyControllers))
+			{
+				// we have a reply controller:
+				$isReply = true;
+				$segments[] = $query['controller'];
+				unset($query['controller']);
+
+				// if 'task' and a reply controller:
+				if (!empty($query['task']))
+				{
+					// is it an expected reply task?
+					if (in_array($query['task'], $replyTasks))
+					{
+						$segments[] = $query['task'];
+						unset($query['task']);
+					}
+				}
+				// if 'id' and a reply controller:
+				if (!empty($query['id']))
+				{
+					$segments[] = $query['id'];
+					unset($query['id']);
+				}
+			}
+		}
+
+		// straight com_newsletter logic:
+		// here we need to fetch the alias from the database, using the query id:
 		if (!empty($query['id']))
 		{
 			$database = \App::get('db');
@@ -34,6 +75,7 @@ class Router extends Base
 			unset($query['id']);
 		}
 
+		// com_newsletter tasks:
 		if (!empty($query['task']))
 		{
 			if (in_array($query['task'], array('subscribe', 'unsubscribe', 'resendconfirmation')))
@@ -56,6 +98,11 @@ class Router extends Base
 	{
 		$vars = array();
 
+		// Accommodate specifics from com_reply
+		// so is there a dash or not?
+		//$replyControllers = ['email-subscriptions', 'emailsubscriptions', 'pages', 'replies'];
+		$isReply = false;
+
 		if (empty($segments))
 		{
 			return $vars;
@@ -63,36 +110,65 @@ class Router extends Base
 
 		if (isset($segments[0]))
 		{
-			$database = \App::get('db');
-			$sql = "SELECT `id` FROM `#__newsletters` WHERE `alias`=" . $database->quote($segments[0]);
-			$database->setQuery($sql);
-			$campaignId = $database->loadResult();
+			// is it a reply controller?
+			if (in_array($segments[0], $this->replyControllers))
+			{
+				// Yes, it's a reply controller:
+				$vars['controller'] = $segments[0];
+				$isReply = true;
 
-			if ($campaignId)
-			{
-				$vars['id'] = $campaignId;
-			}
-			else
-			{
-				switch ($segments[0])
+				// obtain the reply task or id:
+				if (isset($segments[1]))
 				{
-					case 'track':
-						$vars['task'] = 'track';
-						$vars['type'] = $segments[1];
-						$vars['controller'] = 'mailings';
-						break;
-					case 'confirm':
-					case 'remove':
-					case 'subscribe':
-					case 'dosubscribe':
-					case 'unsubscribe':
-					case 'dounsubscribe':
-					case 'resendconfirmation':
-						$vars['task'] = $segments[0];
-						$vars['controller'] = 'mailinglists';
-						break;
-					default:
-						$vars['task'] = $segments[0];
+					if (is_numeric($segments[1]))
+					{
+						$vars['id'] = $segments[1];
+					}
+					else
+					{
+						$vars['task'] = $segments[1];
+					}
+				}
+				// obtain the reply id:
+				if (isset($segments[2]))
+				{
+					$vars['id'] = $segments[2];
+				}
+
+			} else {
+				// handle as com_newsletter
+				// Determine the alias from passed id, if possible:
+				$database = \App::get('db');
+				$sql = "SELECT `id` FROM `#__newsletters` WHERE `alias`=" . $database->quote($segments[0]);
+				$database->setQuery($sql);
+				$campaignId = $database->loadResult();
+
+				if ($campaignId)
+				{
+					$vars['id'] = $campaignId;
+				}
+				else
+				{
+					switch ($segments[0])
+					{
+						case 'track':
+							$vars['task'] = 'track';
+							$vars['type'] = $segments[1];
+							$vars['controller'] = 'mailings';
+							break;
+						case 'confirm':
+						case 'remove':
+						case 'subscribe':
+						case 'dosubscribe':
+						case 'unsubscribe':
+						case 'dounsubscribe':
+						case 'resendconfirmation':
+							$vars['task'] = $segments[0];
+							$vars['controller'] = 'mailinglists';
+							break;
+						default:
+							$vars['task'] = $segments[0];
+					}
 				}
 			}
 		}

--- a/core/components/com_newsletter/site/views/emailsubscriptions/_email_subscriptions_selects.php
+++ b/core/components/com_newsletter/site/views/emailsubscriptions/_email_subscriptions_selects.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$subs = $this->subs;
+$userId = $this->userId;
+?>
+
+<?php
+foreach($subs as $s):
+	$sKey = $s['foreign_key'];
+?>
+	<div class="sub">
+		<label><?php echo $s['label']; ?></label>
+
+		<?php
+			if ($subView = $s['view']):
+				$this->view($subView)
+				     ->set('userId', $userId)
+				     ->display();
+			endif;
+		?>
+
+		<select	name="<?php echo "subscriptions[$sKey][preference]"; ?>">
+			<?php
+				foreach($s['options'] as $o):
+				$selected = ($o == $s['preference']);
+			?>
+				<option <?php if ($selected) echo 'selected'; ?>>
+					<?php echo $o; ?>
+				</option>
+			<?php	endforeach; ?>
+		</select>
+		<input type="hidden" name="<?php echo "subscriptions[$sKey][foreign_key]"; ?>"
+		       value="<?php echo $sKey; ?>">
+	</div>
+<?php endforeach; ?>

--- a/core/components/com_newsletter/site/views/emailsubscriptions/_personalized_communications_by_interest.php
+++ b/core/components/com_newsletter/site/views/emailsubscriptions/_personalized_communications_by_interest.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+$userId = $this->userId;
+$profileLink = "/members/$userId/profile";
+$hubname = Config::get('sitename');
+?>
+
+<ul>
+  <li>Personalized updates based on your usage and impact on <?echo $hubname;?></li>
+  <li>Updates about resources you previously used</li>
+  <li>Specific information based on your field and interests (please review your
+<a href="<?php echo $profileLink; ?>">profile</a>)</li>
+</ul>

--- a/core/components/com_newsletter/site/views/emailsubscriptions/_updates_and_news.php
+++ b/core/components/com_newsletter/site/views/emailsubscriptions/_updates_and_news.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+$hubname = Config::get('sitename');
+?>
+
+<ul>
+  <li>news and announcements (e.g new courses, apps, and other opportunities)</li>
+  <li><?echo $hubname;?> newsletter</li>
+</ul>

--- a/core/components/com_newsletter/site/views/emailsubscriptions/display.php
+++ b/core/components/com_newsletter/site/views/emailsubscriptions/display.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$this->css('emailSubscriptionsDisplay');
+
+$code = $this->code;
+$submitText = Lang::txt('INPUT_SUBMIT');
+$breadcrumbs = ['Email Subscriptions' => ''];
+$userId = $this->userId;
+$subs = $this->subs;
+$hubname = Config::get('sitename');
+
+// Caution: this property may not exist
+if (property_exists($this, "userSubs"))
+{
+	$userSubs = $this->userSubs;
+} else {
+	$userSubs = NULL;
+}
+
+
+$this->view('_breadcrumbs', 'shared')
+	->set('breadcrumbs', $breadcrumbs)
+	->set('pageTitle', '')
+	->display();
+?>
+
+<section class="main section">
+	<div class="grid">
+		<div class="col span4 offset4">
+			<form id="hubForm" class="full" method="POST"
+						action="/newsletter/email-subscriptions/update">
+
+				<?php $this->view('_email_subscriptions_selects')
+				           ->set('userId', $userId)
+				           ->set('userSubs', $userSubs)
+				           ->set('subs', $subs)
+				           ->display(); ?>
+
+				<?php echo Html::input('token'); ?>
+				<input type="hidden" name="code" value="<?php echo $code; ?>">
+
+				<input type="submit" class="btn btn-success" value="<?php echo $submitText; ?>">
+			</form>
+		</div>
+	</div>
+
+</section>
+
+<section class="comms-notice">
+	<?echo $hubname;?> is a community-driven, grant-funded project and we continually strive
+	to improve our services. Additionally, we need to share the impact of our
+	work with our sponsors. We will periodically send you information about
+	outages, terms of usage changes, and <?echo $hubname;?> improvement surveys and
+	assessment communications. For more information regarding communications from
+	<?echo $hubname;?>, see our <a href="/legal/privacy">privacy policy</a>.
+</section>

--- a/core/components/com_newsletter/site/views/emailsubscriptions/index.html
+++ b/core/components/com_newsletter/site/views/emailsubscriptions/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/core/components/com_newsletter/site/views/mailinglists/tmpl/enter_email.php
+++ b/core/components/com_newsletter/site/views/mailinglists/tmpl/enter_email.php
@@ -50,6 +50,7 @@ $this->css()
 			<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
 			<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
 			<input type="hidden" name="task" value="subscribe" />
+			<?php echo Html::input('token'); ?>
 		</form>
 	</div>
 </section>

--- a/core/components/com_newsletter/site/views/mailinglists/tmpl/index.html
+++ b/core/components/com_newsletter/site/views/mailinglists/tmpl/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/core/components/com_newsletter/site/views/mailinglists/tmpl/subscribe.php
+++ b/core/components/com_newsletter/site/views/mailinglists/tmpl/subscribe.php
@@ -99,6 +99,7 @@ $this->css()
 			<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
 			<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
 			<input type="hidden" name="task" value="domultisubscribe" />
+			<?php echo Html::input('token'); ?>
 		</form>
 	</div>
 </section>

--- a/core/components/com_newsletter/site/views/mailinglists/tmpl/unsubscribe.php
+++ b/core/components/com_newsletter/site/views/mailinglists/tmpl/unsubscribe.php
@@ -85,6 +85,7 @@ $this->css()
 			<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
 			<input type="hidden" name="controller" value="<?php echo $this->controller; ?>" />
 			<input type="hidden" name="task" value="dounsubscribe" />
+			<?php echo Html::input('token'); ?>
 		</form>
 	</div>
 </section>

--- a/core/components/com_newsletter/site/views/pages/_page2_instructions.php
+++ b/core/components/com_newsletter/site/views/pages/_page2_instructions.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+$hubname = Config::get('sitename');
+?>
+
+<p>
+<?echo $hubname;?> is a government funded resource for the scientific community, and as
+such, we need to demonstrate <?echo $hubname;?> impact to the U.S. National Science
+Foundation, our funding agency.  One way we can assess our impact is by asking
+our users to provide us with feedback on how they use <?echo $hubname;?>.   Please help
+us in our effort to keep <?echo $hubname;?> free for a broad user base and let us know:
+<p>
+
+<div>
+
+	<p>Please let us know:</p>
+	<ul>
+		<li>
+			Are you using <?echo $hubname;?> for education? If so how?
+			<ul>
+				<li>As part of a formal course? Which course? Which educational institution? How often do you use <?echo $hubname;?> in the course per semester?</li>
+				<li>Which professor leads the class? Are you the professor?</li>
+			</ul>
+		</li>
+
+		<li>
+			Are you studying in a self-directed way?
+			<ul>
+				<li>What other resources do you use?</li>
+			</ul>
+		</li>
+
+		<li>
+			Are you using <?echo $hubname;?> for research? If so how? Please let us know some details.
+			<ul>
+				<li>Have you published research results while using <?echo $hubname;?> resources? If so, can you share your research citations with us (just copy and paste the citations below)</li>
+				<li>Do you have a Google Scholar, ResearcherID, ScopusID, ORCID, or ResearchGateID?</li>
+			</ul>
+		</li>
+
+		<li>Have your usage pattern and intent changed over time? Has it evolved from the primary usage of one set of resources to another set?</li>
+
+		<li>
+			Other web presence:
+			<ul>
+				<li>Do you have a homepage?</li>
+				<li>Do you have a LinkedIn, Twitter, or Facebook profile?</li>
+			</ul>
+		</li>
+
+		<li>
+			Are you a faculty member, a student, or a professional?
+			<ul>
+				<li>Can you share your experience?</li>
+			</ul>
+		</li>
+
+		<li>Other comments?  Anything else you want to share with us to help our mission?</li>
+	</ul>
+
+	<p>Also, if you have not returned to <?echo $hubname;?> for quite a while, can you help us understand why?</p>
+	<ul>
+		<li>Did the work you did with <?echo $hubname;?> usage finish? Were you satisfied?</li>
+		<li>Were you not able to finish your <?echo $hubname;?> work due to problems? If so, which ones?</li>
+	</ul>
+
+</div>

--- a/core/components/com_newsletter/site/views/pages/index.html
+++ b/core/components/com_newsletter/site/views/pages/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>

--- a/core/components/com_newsletter/site/views/pages/page2.php
+++ b/core/components/com_newsletter/site/views/pages/page2.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$this->css('basicForm')
+     ->css('page2');
+
+$code = $this->code;
+$pageId = $this->pageId;
+$submitText = Lang::txt('INPUT_SUBMIT');
+$breadcrumbs = ['Reply' => ''];
+
+$this->view('_breadcrumbs', 'shared')
+	->set('breadcrumbs', $breadcrumbs)
+	->set('pageTitle', '')
+	->display();
+?>
+
+<section class="main section">
+	<div class="grid">
+		<div class="col span6 offset3">
+			<?php $this->view('_page2_instructions')->display(); ?>
+		</div>
+		<div class="col span6 offset3">
+			<form id="hubForm" class="full" method="POST" action="/newsletter/replies/create">
+				<textarea name="reply[text]" rows="30"></textarea>
+
+				<?php echo Html::input('token'); ?>
+				<input type="hidden" name="code" value="<?php echo $code; ?>">
+				<input type="hidden" name="page_id" value="<?php echo $pageId; ?>">
+
+				<input type="submit" class="btn btn-success" value="<?php echo $submitText; ?>">
+			</form>
+		</div>
+	</div>
+</section>

--- a/core/components/com_newsletter/site/views/shared/_breadcrumbs.php
+++ b/core/components/com_newsletter/site/views/shared/_breadcrumbs.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$breadcrumbs = $this->breadcrumbs;
+$pageTitle = $this->pageTitle;
+
+$cumulativePath = '';
+
+foreach ($breadcrumbs as $text => $url)
+{
+	$cumulativePath .= $url;
+	Pathway::append($text, $cumulativePath);
+}
+
+Document::setTitle($pageTitle);

--- a/core/components/com_newsletter/site/views/shared/index.html
+++ b/core/components/com_newsletter/site/views/shared/index.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#FFFFFF"></body></html>


### PR DESCRIPTION
NOTE: Disregard this PR, it was an early draft.

# This is a draft

### Dependencies

This work is part of Epic [NCN-434](https://sdx-sdsc.atlassian.net/browse/NCN-434), whose PRs should all be deployed together:
- #1693, NCN-633 `plgUserHubzero` (on user login, ensure user has a secret in the DB)
- #1683 NCN-439 `com_members` (manage user secret)
- #1676  NCN-437 `com_newsletter` (manage campaign secret)
- #1675 NCN-438 `com_config` (manage hub secret)
- #1695 NCN-702, NCN-440: `com_newsletter` (update verification, after porting functionality from custom com_reply)

## Summary

This PR ports custom code from Nanohub (`com_reply`) into the core CMS component, `com_newsletter`.

It then updates access validation for one-click links to use the secrets (hub, user, and campaign) created in the Epic mentioned above, NCN-434.

## TODO

# Before you submit this pull request, please make sure:

- [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [] Include a brief summary of the issue **in your own words**
- [] Include a brief summary of the fix/changed code
- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [] Double check someone is assigned to review the ticket

**Thanks!**
