### PR TITLE
[PURR][#2513]Changes to setting of DOI metadata elements

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -255,11 +255,14 @@ class Doi extends Obj
 		$pubDate = $pub->version->published_up && $pub->version->published_up != $this->_db->getNullDate()
 				? date('Y-m-d', strtotime($pub->version->published_up)) : date('Y-m-d');
 		$acceptedDate = $pub->version->accepted && $pub->version->accepted != $this->_db->getNullDate()
-				? date('Y-m-d', strtotime($pub->version->accepted)) : date('Y-m-d');
+				? date('Y-m-d', strtotime($pub->version->accepted)) : "0000-00-00";
+		$submittedDate = $pub->version->submitted && $pub->version->submitted != $this->_db->getNullDate()
+				? date('Y-m-d', strtotime($pub->version->submitted)) : "0000-00-00";
 		$this->set('pubYear', $pubYear);
 		$this->set('datePublished', $pubDate);
 		$this->set('dateAccepted', $acceptedDate);
-
+		$this->set('dateSubmitted', $submittedDate);
+		
 		// Map authors & creator
 		$this->set('authors', $pub->authors());
 		$this->mapUser($pub->version->created_by, $pub->_authors, 'creator');
@@ -508,7 +511,6 @@ class Doi extends Obj
 		$this->set('resourceType', 'Dataset');
 		$this->set('resourceTypeTitle', 'Dataset');
 		$this->set('datePublished', date('Y-m-d'));
-		$this->set('dateAccepted', date('Y-m-d'));
 	}
 
 	/**
@@ -567,7 +569,7 @@ class Doi extends Obj
 		}
 
 		// Start XML
-		$xmlfile  = '<?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4/metadata.xsd">';
+		$xmlfile  = '<?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.5/metadata.xsd">';
 		$xmlfile .='<identifier identifierType="DOI">' . $doi . '</identifier>';
 		$xmlfile .='<creators>';
 
@@ -674,11 +676,14 @@ class Doi extends Obj
 			
 			$xmlfile.='</contributors>';
 		}
-		$xmlfile.='<dates>
-			<date dateType="Available">' . $this->get('datePublished') . '</date>
-			<date dateType="Accepted">' . $this->get('dateAccepted') . '</date>
-		</dates>
-		<language>' . $this->get('language') . '</language>
+		
+		$xmlfile.='<dates>';
+		$xmlfile .= '<date dateType="Available">' . $this->get('datePublished') . '</date>';
+		$xmlfile .= '<date dateType="Submitted">' . $this->get('dateSubmitted') . '</date>';
+		$xmlfile .= '<date dateType="Accepted">' . $this->get('dateAccepted') . '</date>';
+		$xmlfile .= '</dates>';
+		
+		$xmlfile .= '<language>' . $this->get('language') . '</language>
 		<resourceType resourceTypeGeneral="' . $this->get('resourceType') . '">' . $this->get('resourceTypeTitle') . '</resourceType>';
 		
 		$doiOfPrevPub = $this->get('doiOfPrevPub');

--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -59,6 +59,28 @@ class Doi extends Obj
 	 */
 	const STATE_FROM_PUBLISHED_TO_DRAFTREADY = 0;
 	const STATE_FROM_DRAFTREADY_TO_PUBLISHED = 1;
+	
+	/**
+	 * DataCite
+	 *
+	 * @const
+	 */
+	const DATACITE = "datacite::";
+	
+	/**
+	 * Relation type
+	 *
+	 * @const
+	 */
+	const REFERENCES = "references";
+	const REFERENCEDBY = "referencedby";
+	const ISREFERENCEDBY = "IsReferencedBy";
+	
+	/*
+	* Handle
+	*/
+	const HANDLE = "handle";
+	const HANDLE_DOMAIN_NAME = "hdl.handle.net";
 
 	/**
 	 * Constructor
@@ -232,8 +254,11 @@ class Doi extends Obj
 				? date('Y', strtotime($pub->version->published_up)) : date('Y');
 		$pubDate = $pub->version->published_up && $pub->version->published_up != $this->_db->getNullDate()
 				? date('Y-m-d', strtotime($pub->version->published_up)) : date('Y-m-d');
+		$acceptedDate = $pub->version->accepted && $pub->version->accepted != $this->_db->getNullDate()
+				? date('Y-m-d', strtotime($pub->version->accepted)) : date('Y-m-d');
 		$this->set('pubYear', $pubYear);
 		$this->set('datePublished', $pubDate);
+		$this->set('dateAccepted', $acceptedDate);
 
 		// Map authors & creator
 		$this->set('authors', $pub->authors());
@@ -269,10 +294,22 @@ class Doi extends Obj
 		}
 
 		// Map related identifier
-		$lastPub = $pub->lastPublicRelease();
-		if ($lastPub && $lastPub->doi && $pub->version->version_number > 1)
+		$prevPub = $pub->prevPublication();
+		if ($prevPub && $prevPub->doi)
 		{
-			$this->set('relatedDoi', $lastPub->doi);
+			$this->set('doiOfPrevPub', $prevPub->doi);
+		}
+		
+		$nextPub = $pub->nextPublication();
+		if ($nextPub && $nextPub->doi)
+		{
+			$this->set('doiOfNextPub', $nextPub->doi);
+		}
+		
+		$citations = $pub->getCitationsForMetadataSet();
+		if ($citations)
+		{
+			$this->set('citations', $citations);
 		}
 		
 		// Format
@@ -395,7 +432,6 @@ class Doi extends Obj
 							$fosTags[] = $fosTag;
 						}
 					}
-					
 				}
 			}
 			
@@ -630,7 +666,7 @@ class Doi extends Obj
 				if ($contactPerson->organization)
 				{
 					$orgidAtr = (isset($contactPerson->orgid) && !empty($contactPerson->orgid)) ? ' affiliationIdentifier="' . $contactPerson->orgid . '"' . ' affiliationIdentifierScheme="ROR" schemeURI="https://ror.org"' : "";
-					$xmlfile .= '		<affiliation' .  $orgidAtr . '>' . $author->organization . '</affiliation>';
+					$xmlfile .= '		<affiliation' .  $orgidAtr . '>' . $contactPerson->organization . '</affiliation>';
 				}
 				
 				$xmlfile.='	</contributor>';
@@ -639,25 +675,113 @@ class Doi extends Obj
 			$xmlfile.='</contributors>';
 		}
 		$xmlfile.='<dates>
-			<date dateType="Valid">' . $this->get('datePublished') . '</date>
+			<date dateType="Available">' . $this->get('datePublished') . '</date>
 			<date dateType="Accepted">' . $this->get('dateAccepted') . '</date>
 		</dates>
 		<language>' . $this->get('language') . '</language>
 		<resourceType resourceTypeGeneral="' . $this->get('resourceType') . '">' . $this->get('resourceTypeTitle') . '</resourceType>';
-		if ($this->get('relatedDoi'))
+		
+		$doiOfPrevPub = $this->get('doiOfPrevPub');
+		$doiOfNextPub = $this->get('doiOfNextPub');
+		$citations = $this->get('citations');
+		if ($doiOfPrevPub || $doiOfNextPub || $citations)
 		{
-			$xmlfile.='<relatedIdentifiers>
-				<relatedIdentifier relatedIdentifierType="DOI" relationType="IsNewVersionOf">' . $this->get('relatedDoi') . '</relatedIdentifier>
-			</relatedIdentifiers>';
+			$xmlfile .= '<relatedIdentifiers>';
+			
+			if ($doiOfPrevPub)
+			{
+				$xmlfile .= '	<relatedIdentifier relatedIdentifierType="DOI" relationType="IsNewVersionOf">' . $doiOfPrevPub . '</relatedIdentifier>';
+			}
+			
+			if ($doiOfNextPub)
+			{
+				$xmlfile .= '	<relatedIdentifier relatedIdentifierType="DOI" relationType="IsPreviousVersionOf">' . $doiOfNextPub . '</relatedIdentifier>';
+			}
+			
+			if ($citations)
+			{
+				foreach ($citations as $citation)
+				{
+					$pos = strpos(trim($citation->resourceTypeGeneral), self::DATACITE);
+					
+					if ($pos == 0)
+					{
+						$citation->resourceTypeGeneral = substr(trim($citation->resourceTypeGeneral), $pos + strlen(self::DATACITE));
+					}
+					
+					if (!empty($citation->relationType))
+					{
+						if (preg_match("/" . self::REFERENCES . "/i", $citation->relationType))
+						{
+							$citation->relationType = ucfirst(self::REFERENCES);
+						}
+						else if (preg_match("/" . self::REFERENCEDBY . "/i", $citation->relationType))
+						{
+							$citation->relationType = self::ISREFERENCEDBY;
+						}
+					}
+					
+					if (!empty($citation->relationType) && !empty($citation->resourceTypeGeneral))
+					{
+						if (!empty($citation->relatedIdentifier))
+						{
+							$xmlfile .= '<relatedIdentifier relatedIdentifierType="DOI" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . trim($citation->relatedIdentifier) . '</relatedIdentifier>';
+						}
+						else
+						{
+							if (!empty($citation->url))
+							{
+								if (preg_match("/purl/i", $citation->url))
+								{
+									$xmlfile .= '<relatedIdentifier relatedIdentifierType="PURL" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . trim($citation->url) . '</relatedIdentifier>';
+								}
+								elseif (preg_match("/handle/i", $citation->url))
+								{
+									if (preg_match("/hdl\.handle\.net/i", $citation->url))
+									{
+										$pos = strpos($citation->url, self::HANDLE_DOMAIN_NAME);
+										$val = substr($citation->url, $pos + strlen(self::HANDLE_DOMAIN_NAME) + 1);
+									}
+									else
+									{
+										$pos = strpos($citation->url, self::HANDLE);
+										$val = substr($citation->url, $pos + strlen(self::HANDLE) + 1);
+									}
+									$xmlfile .= '<relatedIdentifier relatedIdentifierType="Handle" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $val . '</relatedIdentifier>';
+								}
+								elseif (preg_match("/ark:/i", $citation->url) && !empty($citation->eprint))
+								{
+									$xmlfile .= '<relatedIdentifier relatedIdentifierType="ARK" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
+								}
+								elseif (preg_match("/arxiv/i", $citation->url) && !empty($citation->eprint))
+								{
+									$xmlfile .= '<relatedIdentifier relatedIdentifierType="arXiv" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
+								}
+								elseif (preg_match("/urn:/i", $citation->url) && !empty($citation->eprint))
+								{
+									$xmlfile .= '<relatedIdentifier relatedIdentifierType="URN" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
+								}
+								else
+								{
+									$xmlfile .= '<relatedIdentifier relatedIdentifierType="URL" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->url . '</relatedIdentifier>';
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			$xmlfile .= '</relatedIdentifiers>';
 		}
+		
 		if ($this->get('version'))
 		{
 			$xmlfile.= '<version>' . $this->get('version') . '</version>';
 		}
 		if ($this->get('license'))
 		{
-			$rightsURI = $this->get('licenseURI') ? ' rightsURI="' . $this->get('licenseURI') . '"' : "";
-			$xmlfile.='<rightsList><rights xml:lang="en-US" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC0 1.0"' . $rightsURI . '>' . htmlspecialchars($this->get('license')) . '</rights></rightsList>';
+			$rightsURI = $this->get('licenseURI') ? 'rightsURI="' . $this->get('licenseURI') . '"' : "";
+			$xmlfile.='<rightsList><rights ' . $rightsURI . '>' . htmlspecialchars($this->get('license')) . '</rights></rightsList>';
 		}
 		if ($this->get('grantInfo'))
 		{
@@ -772,7 +896,6 @@ class Doi extends Obj
 		$xmlfile .= '
 			</descriptions>
 		</resource>';
-		
 		return $xmlfile;
 	}
 

--- a/core/components/com_publications/tables/version.php
+++ b/core/components/com_publications/tables/version.php
@@ -393,6 +393,42 @@ class Version extends Table
 		$result = $this->_db->loadObjectList();
 		return $result ? $result[0] : false;
 	}
+	
+	/**
+	 * Get previous version publication
+	 *
+	 * @param   integer	$pid	Pub ID
+	 * @param	integer	$verNum	version number
+	 * @return  object
+	 */
+	public function getPrevPublication($pid = null, $version_number)
+	{
+		if ($pid === null || $version_number == 1)
+		{
+			return false;
+		}
+		$query = "SELECT * FROM $this->_tbl WHERE publication_id=" . $this->_db->quote($pid) . " AND version_number=" . $this->_db->quote(--$version_number) . " AND state = 1";
+		$this->_db->setQuery($query);
+		return $this->_db->loadObject();
+	}
+	
+	/**
+	 * Get next version publication
+	 *
+	 * @param	integer	$pid	Pub ID
+	 * @param	integer	$verNum	version number
+	 * @return  object
+	 */
+	public function getNextPublication($pid = null, $version_number)
+	{
+		if ($pid === null)
+		{
+			return false;
+		}
+		$query = "SELECT * FROM $this->_tbl WHERE publication_id=" . $this->_db->quote($pid) . " AND version_number=" . $this->_db->quote(++$version_number) . " AND state = 1";
+		$this->_db->setQuery($query);
+		return $this->_db->loadObject();
+	}
 
 	/**
 	 * Remove main flag


### PR DESCRIPTION
Support ticket: https://purr.purdue.edu/support/ticket/2513
Summary of Issue: We see that a few metadata elements' values in the Datacite DOI metadata set are not set properly and also want to include citation in DOI metadata set. 
Summary of Fix/Changes: 
1. Change the attribute value of "type" from "Valid" to "Available" for the date element that maps to the "published_up" column in table #__publication_versions.
2. Remove the attributes: 'xml:lang="en-US" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC0 1.0"' from the rights element.
3. Fix issue that relatedIdentifer element with relationType "IsNewVersionOf" is set to wrong doi value, where the DOI of the previous version dataset is the correct. Add relatedIdentifer element with relationType "IsPreviousVersionOf", where the value is set to the DOI of the next version dataset.
4. Set citations to relatedIdentifer element.
Summary of Testing: 
1. Create, submit and approve three file publications, where their versions are in ascending order, such as version 1, version 2 and version 3. 
2. Login on doi.datacite.org and check the metadata set for the three DOIs of the datasets. 
(1) All three DOI metadata sets should include date element and rights element with correct attribute and value as specified in Summary of Fix/Changes. 
(2) The DOI metadata set of the second version publication and third verion publication should have relatedIdentifier with relationType "IsNewVersionOf", where the value of the relatedIdentifier element is the doi of the previous version publication.
3. Open the first version publication and second version publication separately in publication component on admin interface, then click the save button on top right, then go back to check metadata set on DataCite, where you should see that they all include relatedIdentifier with relationType "IsPreviousVersionOf", where the value of the element is the doi of the next version publication.
4. Citation test. Follow the steps below to test that citation is included in DOI metadata record on DataCite.
(1) Login on admin interface and click the menu components->citation to open the citation component admin interface.
(2) Click on the “+” icon on upper right to open the citation editing form, and enter citation information in each field, such as choose the Type, set the Title/Chapter, and set at least either DOI or other identifier URL of the citation. To test different identfier that is associated with the citation, try each way below in a single test.
a. Set DOI of the citation in DOI field.
b. Leave the DOI field empty, and set URL field to "https://purl.utwente.nl/essays/96565".
c. Leave the DOI field empty, and set URL field to "https://scholarworks.montana.edu/xmlui/handle/1/9567".
d. Leave the DOI field empty, and set URL field to "https://n2t.net/ark:/12148/btv1b8449691v/f29", and set E-print field to "ark/1237772".
e. Leave the DOI field empty, and set URL field to "https://arxiv.org/abs/1210.5802", and set E-print field to "1210.5802v2".
f. Leave the DOI field empty, and set URL field to "http://urn.fi/URN:NBN:fi:hulib-202112144262", and set E-print field to "URN:NBN:fi:hulib-202112144262".
g. Leave the DOI field empty, and set URL field to "https://url.utwente.nl/essays/96565".
(3) In the “CITATION FOR” section, set the type to “Publication”, enter the dataset’s publication version ID, and choose the context option.
(5) Click “Save and Close” button on upper right, the citation will be pushed to the DOI’s metadata record on DataCite when it shows "citation successfully saved". Login on doi.datacite.org, open the corresponding doi metadata record and check whether the expected relatedIdentifier element with the proper relatedIdentifierType is set.
Hotfix needed? No.
