### PR TITLE
Remove unused left join from jos_resources display query

### DIFF
--- a/core/components/com_resources/site/views/create/tmpl/display.php
+++ b/core/components/com_resources/site/views/create/tmpl/display.php
@@ -17,7 +17,6 @@ if (!User::isGuest())
 						AA.subtable, R.created, R.created_by, R.published, R.publish_up, R.standalone,
 						R.rating, R.times_rated, R.alias, R.ranking, rt.type AS typetitle ";
 	$query .= "FROM #__author_assoc AS AA, #__resource_types AS rt, #__resources AS R ";
-	$query .= "LEFT JOIN #__resource_types AS t ON R.logical_type=t.id ";
 	$query .= "WHERE AA.authorid = ". User::get('id') ." ";
 	$query .= "AND R.id = AA.subid ";
 	$query .= "AND AA.subtable = 'resources' ";


### PR DESCRIPTION
There's no ticket or Jira card associated with this. It's just an obvious error I saw that is easily fixed.

The following query is found in the 'display.php' script for com_resources views:

`	$query  = "SELECT DISTINCT R.id, R.title, R.type, R.logical_type AS logicaltype,
						AA.subtable, R.created, R.created_by, R.published, R.publish_up, R.standalone,
						R.rating, R.times_rated, R.alias, R.ranking, rt.type AS typetitle ";
	$query .= "FROM #__author_assoc AS AA, #__resource_types AS rt, #__resources AS R ";
	$query .= "LEFT JOIN #__resource_types AS t ON R.logical_type=t.id ";
	$query .= "WHERE AA.authorid = ". User::get('id') ." ";
	$query .= "AND R.id = AA.subid ";
	$query .= "AND AA.subtable = 'resources' ";
	$query .= "AND R.standalone=1 AND R.type=rt.id AND (R.published=2 OR R.published=3) AND R.type!=7 ";
	$query .= "ORDER BY published ASC, title ASC";
`

On inspection, the LEFT JOIN to jos_resource_types joins on the wrong column. The resulting table alias, `t`, is entirely unused in the query; the incorrect left join ensures that there's no effect on the result set.

Elsewhere in the query, `jos_resource_types` is specified with alias `rt` and is correctly joined to `jos_resources R` in the WHERE clause, on `R.type = rt.id`

So this is a one-line correction, and removes an unused table alias with an incorrect join condition.  The proposed correction looks like this (only the LEFT JOIN is removed):

`
	$query  = "SELECT DISTINCT R.id, R.title, R.type, R.logical_type AS logicaltype,
						AA.subtable, R.created, R.created_by, R.published, R.publish_up, R.standalone,
						R.rating, R.times_rated, R.alias, R.ranking, rt.type AS typetitle ";
	$query .= "FROM #__author_assoc AS AA, #__resource_types AS rt, #__resources AS R ";
	$query .= "WHERE AA.authorid = ". User::get('id') ." ";
	$query .= "AND R.id = AA.subid ";
	$query .= "AND AA.subtable = 'resources' ";
	$query .= "AND R.standalone=1 AND R.type=rt.id AND (R.published=2 OR R.published=3) AND R.type!=7 ";
	$query .= "ORDER BY published ASC, title ASC";
`


