### PR TITLE
Correct table name variable in the table existence check function

### DIFF
--- a/core/libraries/Hubzero/Content/Migration/Base.php
+++ b/core/libraries/Hubzero/Content/Migration/Base.php
@@ -510,7 +510,7 @@ class Base
 	 **/
 	protected function _queryIfTableExists($table, $query)
 	{
-		if ($this->db->tableExists($tableName))
+		if ($this->db->tableExists($table))
 		{
 			$this->db->setQuery($query);
 			$this->db->query();


### PR DESCRIPTION
## Summary 
This PR proposes we fix an error that prevented properly executing a Hubzero library function.  The library function is a convenience function for checking that a table exists at migration time. 

This issue was found while working on NCN-743: https://sdx-sdsc.atlassian.net/browse/NCN-743

## Error
```
PHP Notice:  Undefined variable: tableName in /var/www/jsperhac/core/libraries/Hubzero/Content/Migration/Base.php on line 513
PHP Stack trace:
PHP   1. {main}() /var/www/jsperhac/muse:0
PHP   2. Hubzero\Base\Application->run() /var/www/jsperhac/muse:99
PHP   3. Hubzero\Base\Stack->then() /var/www/jsperhac/core/libraries/Hubzero/Base/Application.php:432
PHP   4. Hubzero\Console\DispatcherServiceProvider->handle() /var/www/jsperhac/core/libraries/Hubzero/Base/Stack.php:106
PHP   5. Hubzero\Console\Command\Migration->execute() /var/www/jsperhac/core/libraries/Hubzero/Console/DispatcherServiceProvider.php:46
PHP   6. Hubzero\Console\Command\Migration->run() /var/www/jsperhac/core/libraries/Hubzero/Console/Command/Migration.php:25
PHP   7. Hubzero\Content\Migration->migrate() /var/www/jsperhac/core/libraries/Hubzero/Console/Command/Migration.php:252
PHP   8. Migration20231016000000ComMembers->up() /var/www/jsperhac/core/libraries/Hubzero/Content/Migration.php:524
PHP   9. Hubzero\Content\Migration\Base->_queryIfTableExists() /var/www/jsperhac/core/components/com_members/migrations/Migration20231016000000ComMembers.php:58
```

## Testing
Correcting the variable name by hand on my AWS dev instance prevented the stack trace from reappearing and enabled the function to execute properly.