### PR TITLE
Update MimeType.php

### DIFF
--- a/core/libraries/Hubzero/Filesystem/Util/MimeType.php
+++ b/core/libraries/Hubzero/Filesystem/Util/MimeType.php
@@ -201,6 +201,8 @@ class MimeType
 			'cdr'   => 'application/cdr',
 			'wma'   => 'audio/x-ms-wma',
 			'jar'   => 'application/java-archive',
+			'mbz'   => 'application/x-zip',
+                        'imscc' => 'application/x-zip'
 		);
 	}
 }


### PR DESCRIPTION
Hubicl needed file extensions .mbz and .imscc to be recognized.

https://hubicl.org/support/ticket/313

The change was hotfixed on hubicl.org.
