### PR TITLE
[fix] Plugin parameters were being overwritten on save

### DIFF
--- a/core/libraries/Hubzero/Plugin/Params.php
+++ b/core/libraries/Hubzero/Plugin/Params.php
@@ -66,13 +66,21 @@ class Params extends Relational
 	 * @param   string   $element  Plugin name
 	 * @return  boolean  True on success
 	 */
-	public static function oneByPlugin($oid=null, $folder=null, $element=null)
+	public static function oneByPluginOrNew($oid=null, $folder=null, $element=null)
 	{
-		return self::all()
+		$row = self::all()
 			->whereEquals('object_id', (int) $oid)
-			->whereEquals('folder', (int) $folder)
-			->whereEquals('element', (int) $element)
+			->whereEquals('folder', $folder)
+			->whereEquals('element', $element)
 			->row();
+		
+		if ($row->isNew()) {
+			$row->set('object_id', (int) $oid)
+				->set('folder', $folder)
+				->set('element', $element);
+		}
+
+		return $row;
 	}
 
 	/**
@@ -85,7 +93,7 @@ class Params extends Relational
 	 */
 	public static function getCustomParams($oid=null, $folder=null, $element=null)
 	{
-		$result = self::oneByPlugin($oid, $folder, $element);
+		$result = self::oneByPluginOrNew($oid, $folder, $element);
 
 		return new Registry($result->get('params'));
 	}

--- a/core/plugins/groups/blog/blog.php
+++ b/core/plugins/groups/blog/blog.php
@@ -1078,19 +1078,12 @@ class plgGroupsBlog extends \Hubzero\Plugin\Plugin
 			return $this->_browse();
 		}
 
-		$settings = Hubzero\Plugin\Params::oneByPlugin(
-			$this->group->gidNumber,
-			$this->_type,
-			$this->_name
-		);
-
 		// Output HTML
 		$view = $this->view('default', 'settings')
 			->set('option', $this->option)
 			->set('group', $this->group)
 			->set('task', $this->action)
 			->set('config', $this->params)
-			->set('settings', $settings)
 			->set('model', $this->model)
 			->set('authorized', $this->authorized)
 			->setErrors($this->getErrors());
@@ -1120,14 +1113,11 @@ class plgGroupsBlog extends \Hubzero\Plugin\Plugin
 		// Check for request forgeries
 		Request::checkToken();
 
-		$settings = Request::getArray('settings', array(), 'post');
-
-		$row = Hubzero\Plugin\Params::blank()->set($settings);
+		$row = \Hubzero\Plugin\Params::oneByPluginOrNew($this->group->get('gidNumber'), $this->_type, $this->_name);
 
 		// Get parameters
-		$p = new Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
-
-		$row->set('params', $p->toString());
+		$params = new \Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
+		$row->set('params', $params->toString());
 
 		// Store new content
 		if (!$row->save())

--- a/core/plugins/groups/blog/views/settings/tmpl/default.php
+++ b/core/plugins/groups/blog/views/settings/tmpl/default.php
@@ -75,11 +75,6 @@ $this->css()
 			<p class="help">
 				<?php echo Lang::txt('PLG_GROUPS_BLOG_SETTINGS_FEED_HELP'); ?>
 			</p>
-
-			<input type="hidden" name="settings[id]" value="<?php echo $this->settings->id; ?>" />
-			<input type="hidden" name="settings[object_id]" value="<?php echo $this->group->get('gidNumber'); ?>" />
-			<input type="hidden" name="settings[folder]" value="groups" />
-			<input type="hidden" name="settings[element]" value="blog" />
 		</fieldset>
 		<div class="clear"></div>
 

--- a/core/plugins/groups/collections/collections.php
+++ b/core/plugins/groups/collections/collections.php
@@ -2080,8 +2080,6 @@ class plgGroupsCollections extends \Hubzero\Plugin\Plugin
 			App::abort(403, Lang::txt('PLG_GROUPS_COLLECTIONS_NOT_AUTH'));
 		}
 
-		$settings = \Hubzero\Plugin\Params::oneByPlugin($this->group->get('gidNumber'), 'groups', $this->_name);
-
 		// Output HTML
 		$view = $this->view('default', 'settings')
 			->set('name', $this->_name)
@@ -2089,7 +2087,6 @@ class plgGroupsCollections extends \Hubzero\Plugin\Plugin
 			->set('group', $this->group)
 			->set('params', $this->params)
 			->set('action', $this->action)
-			->set('settings', $settings)
 			->set('authorized', $this->authorized);
 
 		return $view
@@ -2119,19 +2116,10 @@ class plgGroupsCollections extends \Hubzero\Plugin\Plugin
 		// Check for request forgeries
 		Request::checkToken();
 
-		$settings = Request::getArray('settings', array(), 'post');
-
-		$row = \Hubzero\Plugin\Params::oneByPlugin($this->group->get('gidNumber'), $this->_type, $this->_name);
-
-		$row->set('object_id', $this->group->get('gidNumber'));
-		$row->set('folder', $this->_type);
-		$row->set('element', $this->_name);
+		$row = \Hubzero\Plugin\Params::oneByPluginOrNew($this->group->get('gidNumber'), $this->_type, $this->_name);
 
 		// Get parameters
-		$prms = Request::getArray('params', array(), 'post');
-
-		$params = new \Hubzero\Config\Registry($prms);
-
+		$params = new \Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
 		$row->set('params', $params->toString());
 
 		// Store new content

--- a/core/plugins/groups/collections/views/settings/tmpl/default.php
+++ b/core/plugins/groups/collections/views/settings/tmpl/default.php
@@ -44,11 +44,6 @@ defined('_HZEXEC_') or die();
 			<p class="info">
 				<?php echo Lang::txt('PLG_GROUPS_COLLECTIONS_SETTINGS_CREATE_POSTS_INFO'); ?>
 			</p>
-
-			<input type="hidden" name="settings[id]" value="<?php echo $this->settings->id; ?>" />
-			<input type="hidden" name="settings[object_id]" value="<?php echo $this->group->get('gidNumber'); ?>" />
-			<input type="hidden" name="settings[folder]" value="groups" />
-			<input type="hidden" name="settings[element]" value="collections" />
 		</fieldset>
 		<div class="clear"></div>
 

--- a/core/plugins/groups/forum/forum.php
+++ b/core/plugins/groups/forum/forum.php
@@ -2112,19 +2112,12 @@ class plgGroupsForum extends \Hubzero\Plugin\Plugin
 			return $this->sections();
 		}
 
-		$settings = \Hubzero\Plugin\Params::oneByPlugin(
-			$this->group->get('gidNumber'),
-			$this->_type,
-			$this->_name
-		);
-
 		// Output HTML
 		$view = $this->view('default', 'settings')
 			->set('option', $this->option)
 			->set('group', $this->group)
 			->set('model', $this->forum)
 			->set('config', $this->params)
-			->set('settings', $settings)
 			->set('authorized', $this->authorized)
 			->setErrors($this->getErrors());
 
@@ -2153,14 +2146,11 @@ class plgGroupsForum extends \Hubzero\Plugin\Plugin
 		// Check for request forgeries
 		Request::checkToken();
 
-		$settings = Request::getArray('settings', array(), 'post');
-
-		$row = \Hubzero\Plugin\Params::blank()->set($settings);
+		$row = \Hubzero\Plugin\Params::oneByPluginOrNew($this->group->get('gidNumber'), $this->_type, $this->_name);
 
 		// Get parameters
-		$p = new \Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
-
-		$row->set('params', $p->toString());
+		$params = new \Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
+		$row->set('params', $params->toString());
 
 		// Store new content
 		if (!$row->save())

--- a/core/plugins/groups/forum/views/settings/tmpl/default.php
+++ b/core/plugins/groups/forum/views/settings/tmpl/default.php
@@ -70,11 +70,6 @@ $this->css()
 					</label>
 				</div>
 			</fieldset>
-
-			<input type="hidden" name="settings[id]" value="<?php echo $this->settings->get('id'); ?>" />
-			<input type="hidden" name="settings[object_id]" value="<?php echo $this->group->get('gidNumber'); ?>" />
-			<input type="hidden" name="settings[folder]" value="groups" />
-			<input type="hidden" name="settings[element]" value="forum" />
 		</fieldset>
 		<div class="clear"></div>
 

--- a/core/plugins/members/blog/blog.php
+++ b/core/plugins/members/blog/blog.php
@@ -855,19 +855,12 @@ class plgMembersBlog extends \Hubzero\Plugin\Plugin
 			return $this->_browse();
 		}
 
-		$settings = \Hubzero\Plugin\Params::oneByPlugin(
-			$this->member->get('id'),
-			'members',
-			$this->_name
-		);
-
 		// Output HTML
 		$view = $this->view('default', 'settings')
 			->set('option', $this->option)
 			->set('member', $this->member)
 			->set('task', $this->task)
 			->set('config', $this->params)
-			->set('settings', $settings)
 			->setErrors($this->getErrors());
 
 		return $view->loadTemplate();
@@ -895,14 +888,10 @@ class plgMembersBlog extends \Hubzero\Plugin\Plugin
 		// Check for request forgeries
 		Request::checkToken();
 
-		// Incoming
-		$settings = Request::getArray('settings', array(), 'post');
+		$row = \Hubzero\Plugin\Params::oneByPluginOrNew($this->member->get('id'), $this->_type, $this->_name);
 
-		$row = \Hubzero\Plugin\Params::blank()->set($settings);
-
-		$p = new \Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
-
-		$row->set('params', $p->toString());
+		$params = new \Hubzero\Config\Registry(Request::getArray('params', array(), 'post'));
+		$row->set('params', $params->toString());
 
 		// Store new content
 		if (!$row->save())

--- a/core/plugins/members/blog/views/settings/tmpl/default.php
+++ b/core/plugins/members/blog/views/settings/tmpl/default.php
@@ -50,11 +50,6 @@ $this->css()
 		<p class="help">
 			<?php echo Lang::txt('PLG_MEMBERS_BLOG_SETTINGS_FEED_HELP'); ?>
 		</p>
-
-		<input type="hidden" name="settings[id]" value="<?php echo $this->settings->id; ?>" />
-		<input type="hidden" name="settings[object_id]" value="<?php echo $this->member->get('id'); ?>" />
-		<input type="hidden" name="settings[folder]" value="members" />
-		<input type="hidden" name="settings[element]" value="blog" />
 	</fieldset>
 	<div class="clear"></div>
 


### PR DESCRIPTION
### JIRA card or HubZero ticket reference

I have not submitted a ticket on this.

### Brief summary of the issue

Plugin parameters are being overwritten on save. Casting of `jos_plugin_params` database table fields in the `\Hubzero\Plugin\Params::oneByPlugin` method was causing the issue. Effect was to only allow for one row per object id, causing for example all group plugins to share the same row in the database, leading to lost parameter settings.

### Brief summary of fixed code

Changed the oneByPlugin method to NOT cast the two string fields to integer. Also made it a `oneByPluginOrNew` to account for first-time save of settings. I refactored a bit by removing the sending of the settings to the view, which seemed unnecessary. Another goal of the refactor was a reduction in code redundancy.

### Testing

Doing a search on "oneByPlugin," it appeared to me that only four plugins were affected by this: the blog, collections, and forum group plugins, and the member blog plugin. I tested the changes by starting from scratch on a new group and initializing settings for the three group plugins. They each got their own row in the `jos_plugin_params` table, and their settings were not overwritten on other plugin setting saves (i.e. they persisted). I also changed the settings in multiple plugins, with the changes persisting as well. Finally, I set the settings on a member's blog, which persisted. There was no other member plugin to test to make sure it didn't share the same row in the table.

### Hotfixing??

Well, that might be up to you all, but any loss of data (even if it is just settings) seems to be somewhat problematic, but mostly for usability I think.

# Before you submit this pull request, please make sure:

- [x] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [x] Include a brief summary of the issue **in your own words**
- [x] Include a brief summary of the fix/changed code
- [x] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [x] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [x] Double check someone is assigned to review the ticket

**Thanks!**
