### PR TITLE
[NCN-789] Remove conversions from db calls

### DIFF
--- a/core/components/com_tools/helpers/utils.php
+++ b/core/components/com_tools/helpers/utils.php
@@ -486,7 +486,7 @@ class Utils
 		}
 
 		//if the user is in an E1 nation
-		if (\Hubzero\Geocode\Geocode::is_e1nation(\Hubzero\Geocode\Geocode::ipcountry($ip)))
+		if (\Hubzero\Geocode\Geocode::is_e1nation($country))
 		{
 			$export_access->valid = 0;
 			$export_access->error->message = Lang::txt('COM_TOOLS_ERROR_ACCESS_DENIED_EXPORT_E1');
@@ -498,7 +498,7 @@ class Utils
 		switch ($export_control)
 		{
 			case 'us':
-				if (\Hubzero\Geocode\Geocode::ipcountry($ip) != 'us')
+				if ($country != 'us')
 				{
 					$export_access->valid = 0;
 					$export_access->error->message = Lang::txt('COM_TOOLS_ERROR_ACCESS_DENIED_EXPORT_USA_ONLY');
@@ -508,7 +508,7 @@ class Utils
 			break;
 
 			case 'd1':
-				if (\Hubzero\Geocode\Geocode::is_d1nation(\Hubzero\Geocode\Geocode::ipcountry($ip)))
+				if (\Hubzero\Geocode\Geocode::is_d1nation($country))
 				{
 					$export_access->valid = 0;
 					$export_access->error->message = Lang::txt('COM_TOOLS_ERROR_ACCESS_DENIED_EXPORT_LICENSE');

--- a/core/components/com_tools/site/controllers/sessions.php
+++ b/core/components/com_tools/site/controllers/sessions.php
@@ -1840,7 +1840,7 @@ class Sessions extends SiteController
 			return false;
 		}
 
-		if (\Hubzero\Geocode\Geocode::is_e1nation(\Hubzero\Geocode\Geocode::ipcountry($ip)))
+		if (\Hubzero\Geocode\Geocode::is_e1nation($country))
 		{
 			$this->setError(Lang::txt('COM_TOOLS_ERROR_ACCESS_DENIED_EXPORT_E1'));
 			Log::debug("mw::_getToolExportControl($exportcontrol) FAILED E1 export control check");
@@ -1850,7 +1850,7 @@ class Sessions extends SiteController
 		switch ($exportcontrol)
 		{
 			case 'us':
-				if (\Hubzero\Geocode\Geocode::ipcountry($ip) != 'us')
+				if ($country != 'us')
 				{
 					$this->setError(Lang::txt('COM_TOOLS_ERROR_ACCESS_DENIED_EXPORT_USA_ONLY'));
 					Log::debug("mw::_getToolExportControl($exportcontrol) FAILED US export control check");
@@ -1859,7 +1859,7 @@ class Sessions extends SiteController
 			break;
 
 			case 'd1':
-				if (\Hubzero\Geocode\Geocode::is_d1nation(\Hubzero\Geocode\Geocode::ipcountry($ip)))
+				if (\Hubzero\Geocode\Geocode::is_d1nation($country))
 				{
 					$this->setError(Lang::txt('COM_TOOLS_ERROR_ACCESS_DENIED_EXPORT_LICENSE'));
 					Log::debug("mw::_getToolExportControl($exportcontrol) FAILED D1 export control check");

--- a/core/libraries/Hubzero/Geocode/Geocode.php
+++ b/core/libraries/Hubzero/Geocode/Geocode.php
@@ -420,7 +420,10 @@ class Geocode
 				return $country;
 			}
 
-			$sql = "SELECT LOWER(countrySHORT) FROM ipcountry WHERE ipFROM <= INET_ATON(" . $gdb->quote($ip) . ") AND ipTO >= INET_ATON(" . $gdb->quote($ip) . ")";
+			// Convert the dotted quad IP address to long:
+			$n_ip = ip2long($ip);
+
+			$sql = "SELECT LOWER(countrySHORT) FROM ipcountry WHERE ipFROM <= " .  $gdb->quote($n_ip) . " AND ipTO >= " . $gdb->quote($n_ip);
 			$gdb->setQuery($sql);
 			$country = stripslashes($gdb->loadResult());
 		}
@@ -443,7 +446,7 @@ class Geocode
 				return $d1nation;
 			}
 
-			$gdb->setQuery("SELECT COUNT(*) FROM countrygroup WHERE LOWER(countrycode) = LOWER(" . $gdb->quote($country) . ") AND countrygroup = 'D1'");
+			$gdb->setQuery("SELECT COUNT(*) FROM countrygroup WHERE LOWER(countrycode) = " . $gdb->quote(strtolower($country)) . " AND countrygroup = 'D1'");
 			$c = $gdb->loadResult();
 			if ($c > 0)
 			{
@@ -469,7 +472,7 @@ class Geocode
 				return $e1nation;
 			}
 
-			$gdb->setQuery("SELECT COUNT(*) FROM countrygroup WHERE LOWER(countrycode) = LOWER(" . $gdb->quote($country) . ") AND countrygroup = 'E1'");
+			$gdb->setQuery("SELECT COUNT(*) FROM countrygroup WHERE LOWER(countrycode) = " . $gdb->quote(strtolower($country)) . " AND countrygroup = 'E1'");
 			$c = $gdb->loadResult();
 			if ($c > 0)
 			{
@@ -496,7 +499,10 @@ class Geocode
 				return $iplocation;
 			}
 
-			$sql = "SELECT COUNT(*) FROM iplocation WHERE ipfrom <= INET_ATON(" . $gdb->quote($ip) . ") AND ipto >= INET_ATON(" . $gdb->quote($ip) . ") AND LOWER(location) = LOWER(" . $gdb->quote($location) . ")";
+			// Convert the dotted quad IP address to long:
+			$n_ip = ip2long($ip);
+
+			$sql = "SELECT COUNT(*) FROM iplocation WHERE ipfrom <= " .  $gdb->quote($n_ip) . " AND ipto >= " . $gdb->quote($n_ip) . " AND LOWER(location) = " .  $gdb->quote(strtolower($location));
 			$gdb->setQuery($sql);
 			$c = $gdb->loadResult();
 			if ($c > 0)


### PR DESCRIPTION
## Summary

Tool session starts rely on checks of tool export controls and on the tool user's country and location. These checks are based on lookup of the user's IP address. There are inefficiencies in how these lookups are performed that may help expedite tool starts, if improved. 

I propose improvements to these lookups based on common entries in the slow query log.

## Motivation

Jira card: https://sdx-sdsc.atlassian.net/browse/NCN-789

Nanohub has recently had queries in the slow query log (from 40 to several hundred per day) that look like this:

`SELECT LOWER(countrySHORT) FROM ipcountry WHERE ipFROM <= INET_ATON('193.x.y.z') AND ipTO >= INET_ATON('193.x.y.z');`

(where 193.x.y.z represents a real IP address in dotted quad format) These logged queries were taking 5-6 sec to execute.

It is inefficient to use INET_ATON() calls in the database to convert a dotted-quad IP to a long (especially in the WHERE clause, as this invalidates use of the index). This conversion could be done in the PHP instead. Quick query benchmarking indicated we can save about a factor of 2 in time by making the conversion in the PHP and making this change to the query:

`SELECT LOWER(countrySHORT) FROM ipcountry WHERE ipFROM <= <IP-as-LONG> AND ipTO >= <IP-as-LONG>;`

I tracked the query down to `libraries/Hubzero/Geocode/Geocode.php` and found a couple of other places in the Geocode library code where we are relying on the database to do string conversions and/or IP conversions. 

Places where the INET_ATON heavy library code was called include the com_tools controller that handles session management (`core/components/com_tools/site/controllers/sessions.php`) and the utility code that validates user permissions to run export controlled tools. Since nanohub has been experiencing slow tool starts, improving efficiencies there seems like a good move.

## Changes made

- Relocated formatting (strings, IPs) from database to PHP in Geocode library code
- Removed redundant calls to library function \Hubzero\Geocode\Geocode::ipcountry() from `com_tools` helper class
- Removed redundant calls to library function \Hubzero\Geocode\Geocode::ipcountry() from `com_tools` session controller

## PR Checklist

- [X] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [X] Include a brief summary of the issue **in your own words**
- [X] Include a brief summary of the fix/changed code
- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [X] Double check someone is assigned to review the ticket
