### PR TITLE
[NCN-811] Fix total resources contributed query

### DIFF
--- a/core/plugins/members/usage/usage.php
+++ b/core/plugins/members/usage/usage.php
@@ -164,7 +164,7 @@ class plgMembersUsage extends \Hubzero\Plugin\Plugin
 
 		$sql = "SELECT COUNT(DISTINCT aa.subid) as contribs, DATE_FORMAT(MIN(res.publish_up), '%d %b %Y') AS first_contrib, DATE_FORMAT(MAX(res.publish_up), '%d %b %Y') AS last_contrib
 				FROM `#__resources` AS res, `#__author_assoc` AS aa, `#__resource_types` AS restypes
-				WHERE res.id = aa.subid AND res.type = restypes.id AND aa.authorid = " . $database->quote($authorid) . " AND aa.role!='submitter'
+				WHERE res.id = aa.subid AND res.type = restypes.id AND aa.authorid = " . $database->quote($authorid) . " AND ((aa.role!='submitter' and res.type!=7) OR res.type=7)
 				AND res.standalone = 1
 				AND res.published = 1
 				AND (res.access=0 OR res.access=3)


### PR DESCRIPTION
## Summary

The “total” count of resources+tools created by some users is not reported correctly in the members usage plugin. The resource count and tools count are shown and the sum should be correct. 

## Motivation

Jira card: https://sdx-sdsc.atlassian.net/browse/NCN-811

Gerhard noticed this discrepancy in contributing users' resource counts while we were collecting resource contribution stats per user and asked that it be fixed.

The screenshot shows the members usage plugin for user "NEEDS". Notice that the "Contributions" line in Table 1 shows the value 1, whereas there are two contributions evident in Tables 2 and 3, one Tool and one Resource.

![NCN-811-needs-user-screenshot](https://github.com/hubzero/hubzero-cms/assets/3996484/eb61b279-4f0b-40e7-8b0b-130c4e415bc1)

## Changes Made

Query in the function first_last_contribution($authorid) was changed to ensure that author contributions were counted either if:
- resource is a tool (type==7)
- or, resource is not a tool and the author's role is NOT 'submitter'

The problem is that the “total” count of resources+tools created by some users are not reported correctly. The resource count and tools count are shown and the sum should be correct. 

To fix this, need to correct the query in public function first_last_contribution($authorid) in the plugin: core/plugins/members/usage/usage.php

## Testing

The check for this is found in the script nanohub.org:/home/su-jsperhac/contributor-report/bugfix/bugfix.php which compares the existing and fixed query. The output indicates that 12 users show incorrect contribution counts when the old query is used:

```$ php bugfix.php 
contribs total 538 is wrong (correct: 539) for user gekco, with id 3482
contribs total 20 is wrong (correct: 23) for user clarksm, with id 8971
contribs total 184 is wrong (correct: 185) for user strachan, with id 13594
contribs total 38 is wrong (correct: 39) for user wang159, with id 14002
contribs total 87 is wrong (correct: 88) for user redwing, with id 14395
contribs total 26 is wrong (correct: 34) for user mmh, with id 29230
contribs total 50 is wrong (correct: 52) for user faltens, with id 29294
contribs total 0 is wrong (correct: 1) for user yao14, with id 46868
contribs total 12 is wrong (correct: 13) for user sunxingshu, with id 50809
contribs total 1 is wrong (correct: 2) for user needs, with id 83851
contribs total 17 is wrong (correct: 18) for user jferrari, with id 199067
contribs total 14 is wrong (correct: 15) for user tjsego, with id 258745
wrongTotal is: 12 
```

## PR checklist

No hotfix should be necessary.

- [X] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [X] Include a brief summary of the issue **in your own words**
- [X] Include a brief summary of the fix/changed code
- [X] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [X] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [X] Double check someone is assigned to review the ticket