### PR TITLE
[GEOD-118] Add in new file types: AVI and PRM

### DIFF
--- a/core/components/com_courses/models/assets/file.php
+++ b/core/components/com_courses/models/assets/file.php
@@ -30,7 +30,7 @@ class File extends Handler
 			'txt', 'pdf', 'jpg', 'jpeg', 'gif', 'png', 'ppt',
 			'pptx', 'pps', 'ppsx', 'doc', 'docx', 'xls', 'xlsx',
 			'zip', 'tgz', 'tar', 'mp3', 'm', 'cpp', 'c', 'r', 'rmd',
-			'wm2d', 'slx', 'srt', 'ipynb', 'aedt', 'csv', 'xyz'
+			'wm2d', 'slx', 'srt', 'ipynb', 'aedt', 'csv', 'xyz', 'prm', 'avi'
 		),
 	);
 


### PR DESCRIPTION
# Source JIRA card(s) and hubzero ticket(s)
https://geodynamics.org/support/ticket/316
https://sdx-sdsc.atlassian.net/browse/GEOD-118

# Brief summary of the issue
Client unable to upload a .prm and .avi file to Courses. They were getting an error message of "file type not recognized". Client tried to add it as a file type in Media Manager, but it is still not being recognized.  

# Brief summary of the fix
Looking at the POST API that gets called during the drop of a file - '/api/courses/asset/handlers', the developer looked at several files: 
- core/components/com_courses/api/controllers/assetv1_0.php > looked at the handlersTask() method which initiated the file handler object - new Handler($database, $ext)
- core/components/com_courses/models/assets/handler.php > looked at the getExtensions() function, then found 'responds_to' captures what file types are allowed
- core/components/com_courses/models/assets/file.php > saw that there were many other different types of file types, added in avi and prm file. 

Once the developer added those files type, files were able to be added to the server and it showed on the table 'jos_courses_assets'

# Brief summary of your testing
Tried it on https://woo.aws.hubzero.org/courses/calculus101/calculus101-indv/outline after creating new course, new unit, new offering. Was able to edit outline and add in media files. 

# Do the change needs to be hotfixed to any production hubs before a normal core rollout
Yes, it needs to be released because client needs it for production level courses. Sooner that we can cherry pick, the better

# Double check someone is assigned to review the ticket
Yes - Nick and David