### PR TITLE
[NCN-440] Update and integrate reply component: last revisions

### DIFF
--- a/core/components/com_newsletter/README.md
+++ b/core/components/com_newsletter/README.md
@@ -22,10 +22,11 @@ All management of these features is found under the Hub's administrator interfac
 ### Install
 1. Run the migrations e.g. via `muse migration run ...`
 
-### Pages
-Pages are not restricted on a by-user basis.
+### Access
 A registered user providing a URL with correct credentials (page id, campaign id, and proper code) will have access to the specified page.
+Pages are not restricted on a by-user basis.
 
+### Pages
 One survey page is provided for use with this feature.
 To use it, the Hub must have at least one Campaign defined, with a valid expiration date.
 
@@ -43,8 +44,8 @@ To add a new email subscription option page:
 1. Create or confirm name of the corresponding profile field
 1. Add a record to `jos_email_subscriptions`
 1. Create a view (content to appear beneath label) if desired 
-1. Set the email page ID in `secrets/code.php`, using `secrets/code_example.php` as a model.
-    * Manually add a record to the table `jos_reply_pages` representing the page, with `jos_reply_pages`.`id` = the email page ID.
+1. Manually add a record to the table `jos_reply_pages` representing the page.
+1. Set the email page ID in `secrets/page_code.php`, so that it is equal to the new `jos_reply_pages`.`id`. 
 
 ### Gotchas
 * `jos_email_subscriptions.profile_field_name` must correspond with a `jos_user_profile_fields.name`
@@ -62,7 +63,7 @@ To add a new email subscription option page:
 * `jos_campaign` - contains a `secret` for each campaign, with expiration date
 * `jos_config` - the `value` column for `scope`='hub' and `key`='secret' contains the overall secret for the Hub
 
-### Integrations
+### Database integrations
 The email subscription update functionality integrates with the core user profile data.
 * `jos_user_profile_fields` - profile fields
 * `jos_user_profile_options` - profile field response options
@@ -70,7 +71,8 @@ The email subscription update functionality integrates with the core user profil
 
 ### Generating Access Codes
 
-The stored procedure `hash_access_code` is used to generate and verify codes for page access. Codes are used in URLs as shown below. To obtain a code for a campaign and user, call the stored procedure from the SQL command line: 
+The stored procedure `hash_access_code` is used to generate and verify codes for page access. Codes are used in URLs as shown below. 
+To obtain a code for a campaign and user, call the stored procedure from the SQL command line: 
 
 `select hash_access_code(CAMPAIGNID, USERNAME);`
 
@@ -80,14 +82,13 @@ The example URLs shown here validate Hub user access to the provided survey page
 
 Here:
 
-* USERNAME is the user's jos_user.username
-* CAMPAIGNID is campaign.id
+* USERNAME is the user's `jos_user`.`username`
+* CAMPAIGNID is `jos_campaign`.`id`
 * HUBNAME is the name of the Hub
 * PAGEID is the integer from the name of the page view in site/views/pages. The provided view is page2.php, giving PAGEID=2.
 
-
-#### pages
+#### Pages URL format
 `https://HUBNAME.org/newsletter/pages/PAGEID?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`
 
-#### subscriptions
+#### Email subscription options URL format
 `https://HUBNAME.org/newsletter/email-subscriptions?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`

--- a/core/components/com_newsletter/README.md
+++ b/core/components/com_newsletter/README.md
@@ -3,53 +3,59 @@
 
 ### Use Case
 
-"Reply" functionality allows users to submit survey responses or update their preferences without first completing the primary hub authentication procedure.
+"Reply" functionality allows registered Hub users to submit survey responses or update their preferences without first completing the primary hub authentication procedure.
 
-This feature provides user authentication via hashes of randomly-generated codes that are associated with the user's CMS record, the campaign, and the Hub.
+This feature provides user authentication to a single specially-configured page via a hash of randomly-generated codes that are associated with the user's CMS record, the campaign, and the Hub. 
+Each user must access the page using a URL containing their unique code, the page and campaign id, and their username. Compliant URLs can be generated, then sent to users via email.
 
 This functionality is now part of the `com_newsletter` core component. It was originally found in custom component `com_reply`.
 
 Related features:
 
-All management of these features is found under the Hub's administrator interface.
+All management of these features is found under the Hub's administrator interface. 
 
 * Per-user randomly generated codes are managed under Member password management.
-* Per-campaign randomly generated codes are managed under the Newsletter component's Campaign tab, on the administrative interface.
-* The Hub's randomly generated code is managed under Global Configuration on the administrative interface.
+* Per-campaign randomly generated codes are managed under the Newsletter component's Campaign tab.
+    In order to use the feature, administrators must create at least one Campaign.
+* The Hub's randomly generated code is managed under Global Configuration. 
 
 ### Install
 1. Run the migrations e.g. via `muse migration run ...`
 
 ### Pages
-It is assumed that all users providing correct credentials will have access to all pages.
+Pages are not restricted on a by-user basis.
+A registered user providing a URL with correct credentials (page id, campaign id, and proper code) will have access to the specified page.
 
-One page view is provided for use.
+One survey page is provided for use with this feature.
+To use it, the Hub must have at least one Campaign defined, with a valid expiration date.
 
 To add a new form-based page:
 1. Create a view for the page in `site/views/pages`, using the provided view, `page2.php`, as an example.
 1. The name of the view should be page<PAGEID>.php
+1. Create a record in the table `jos_reply_pages` representing the page, with `jos_reply_pages`.`id` = PAGEID.
 
 ### Email Subscription Options
 
-One email subscription option page is provided for use.
+One email subscription option page is provided for use with this feature.
+The Hub must also have at least one Campaign configured, with a valid expiration date.
 
-To add a new email subscription option:
+To add a new email subscription option page:
 1. Create or confirm name of the corresponding profile field
 1. Add a record to `jos_email_subscriptions`
 1. Create a view (content to appear beneath label) if desired 
 1. Set the email page ID in `secrets/code.php`, using `secrets/code_example.php` as a model.
-    * The page ID key is referenced in CodeHelper.php `validateEmailSubscriptionsCode()`.
+    * Manually add a record to the table `jos_reply_pages` representing the page, with `jos_reply_pages`.`id` = the email page ID.
 
 ### Gotchas
 * `jos_email_subscriptions.profile_field_name` must correspond with a `jos_user_profile_fields.name`
 * `jos_user_profile_options` must be populated for the user profile fields. `jos_user_profile_options.field_id` must correspond with id from `jos_user_profile_fields.id`
-* `jos_users` user codes are provided at login time by the core Hubzero members plugin.
-* Hashed access codes are provided by the stored procedure, which can be accessed from the database.
-    It takes two arguments, `jos_campaign`.`id` and `jos_users`.`username`
+* `jos_users` user codes are created automatically by the core Hubzero members plugin when users log in.
+* Individual access codes are provided by the stored procedure `hash_access_code()`. It takes two arguments, `jos_campaign`.`id` and `jos_users`.`username`
 
 ### Component-Specific Tables
-* `jos_reply_replies` - user-submitted responses
-* `jos_email_subscriptions` - email subscription options
+* `jos_reply_pages` - specifies the pages which provide prompts for user entry
+* `jos_reply_replies` - stores user-submitted responses
+* `jos_email_subscriptions` - specifies the email subscription options
 
 ### Access-Related Tables
 * `jos_users` - contains a `secret` for each user
@@ -70,15 +76,18 @@ The stored procedure `hash_access_code` is used to generate and verify codes for
 
 ### Example URLs
 
+The example URLs shown here validate Hub user access to the provided survey page and email-subscription option page.
+
 Here:
 
 * USERNAME is the user's jos_user.username
 * CAMPAIGNID is campaign.id
+* HUBNAME is the name of the Hub
 * PAGEID is the integer from the name of the page view in site/views/pages. The provided view is page2.php, giving PAGEID=2.
 
 
 #### pages
-`https://jsperhac.aws.hubzero.org/newsletter/pages/PAGEID?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`
+`https://HUBNAME.org/newsletter/pages/PAGEID?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`
 
 #### subscriptions
-`https://jsperhac.aws.hubzero.org/newsletter/email-subscriptions?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`
+`https://HUBNAME.org/newsletter/email-subscriptions?campaign=CAMPAIGNID&user=USERNAME&code=CODE_FROM_hash_access_code`

--- a/core/components/com_newsletter/helpers/codeHelper.php
+++ b/core/components/com_newsletter/helpers/codeHelper.php
@@ -10,9 +10,11 @@ namespace Components\Newsletter\Helpers;
 $componentPath = Component::path('com_newsletter');
 
 require_once  "$componentPath/models/campaign.php";
+require_once  "$componentPath/models/page.php";
 require_once  "$componentPath/secrets/code.php";
 
 use Components\Newsletter\Models\Campaign;
+use Components\Newsletter\Models\Page;
 
 class CodeHelper
 {
@@ -28,6 +30,9 @@ class CodeHelper
 		// and ran a cron job that populated a db table to ensure this was the case.
 		// Here rather than maintaining the table we instead just assume that all users have access.
 
+		// check for existence of page
+		$pageExists = (1 == Page::all()->whereEquals('id', $pageId)->total());
+
 		// Calculate and compare hash of hub, user, and campaign secrets to passed code:
 		$database = \App::get('db');
 		$vars = array(
@@ -41,7 +46,7 @@ class CodeHelper
 		$hashMatches = ($code == $database->loadResult());
 
 		// Is this access valid?
-		return ($hashMatches && $campNotExpired);
+		return ($hashMatches && $campNotExpired && $pageExists);
 	}
 
 	// Validate code obtained from user's URL, using email subscription page id

--- a/core/components/com_newsletter/helpers/codeHelper.php
+++ b/core/components/com_newsletter/helpers/codeHelper.php
@@ -11,7 +11,7 @@ $componentPath = Component::path('com_newsletter');
 
 require_once  "$componentPath/models/campaign.php";
 require_once  "$componentPath/models/page.php";
-require_once  "$componentPath/secrets/code.php";
+require_once  "$componentPath/secrets/page_code.php";
 
 use Components\Newsletter\Models\Campaign;
 use Components\Newsletter\Models\Page;
@@ -22,7 +22,7 @@ class CodeHelper
 	// Validate that the user-supplied URL and code are valid:
 	public static function validateCode($username, $campaignId, $pageId, $code)
 	{
-		// acquire campaign info
+		// acquire campaign info from database:
 		$campModel = Campaign::all()->whereEquals('id', $campaignId)->row();
 		$campNotExpired = !$campModel->isExpired();
 
@@ -30,7 +30,7 @@ class CodeHelper
 		// and ran a cron job that populated a db table to ensure this was the case.
 		// Here rather than maintaining the table we instead just assume that all users have access.
 
-		// check for existence of page
+		// check for existence of page in database:
 		$pageExists = (1 == Page::all()->whereEquals('id', $pageId)->total());
 
 		// Calculate and compare hash of hub, user, and campaign secrets to passed code:
@@ -53,7 +53,7 @@ class CodeHelper
 	public static function validateEmailSubscriptionsCode($username, $campaignId, $code)
 	{
 		// Acquire page Id for email subscription:
-		$emailSubsPageId = CODE_SECRETS['email_subscriptions_page_id'];
+		$emailSubsPageId = PAGE_CODE['email_subscriptions_page_id'];
 
 		// Validate user-supplied URL and code for this page:
 		return self::validateCode($username, $campaignId, $emailSubsPageId, $code);

--- a/core/components/com_newsletter/migrations/Migration20240202000000CreatePagesTable.php
+++ b/core/components/com_newsletter/migrations/Migration20240202000000CreatePagesTable.php
@@ -1,0 +1,44 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20240202000000CreatePagesTable extends Base
+{
+
+	static $tableName = '#__reply_pages';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`description` varchar(255) NOT NULL,
+			`created` timestamp NULL DEFAULT NULL,
+			PRIMARY KEY (`id`)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		$tableName = self::$tableName;
+
+		$dropTable = "DROP TABLE $tableName";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($dropTable);
+			$this->db->query();
+		}
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20240207000000AlterEmailSubscriptionsTable.php
+++ b/core/components/com_newsletter/migrations/Migration20240207000000AlterEmailSubscriptionsTable.php
@@ -22,11 +22,19 @@ class Migration20240207000000AlterEmailSubscriptionsTable extends Base
 
 		if ($this->db->tableExists($tableName))
 		{
-			$this->db->setQuery($renameDescription);
-			$this->db->query();
+			if ($this->db->tableHasField($tableName, 'description')) 
+			{
+				$this->log('Column `description` found in table, renaming...');
+				$this->db->setQuery($renameDescription);
+				$this->db->query();
+			}
 
-			$this->db->setQuery($dropRequired);
-			$this->db->query();
+			if ($this->db->tableHasField($tableName, 'required')) 
+			{
+				$this->log('Column `required` found in table, dropping...');
+				$this->db->setQuery($dropRequired);
+				$this->db->query();
+			}
 
 		}
 	}
@@ -43,11 +51,19 @@ class Migration20240207000000AlterEmailSubscriptionsTable extends Base
 
 		if ($this->db->tableExists($tableName))
 		{
-			$this->db->setQuery($renameDescription);
-			$this->db->query();
+			if ($this->db->tableHasField($tableName, 'profile_field_name')) 
+			{
+				$this->log('Column `profile_field_name` found in table, renaming...');
+				$this->db->setQuery($renameDescription);
+				$this->db->query();
+			}
 
-			$this->db->setQuery($dropRequired);
-			$this->db->query();
+			if (!$this->db->tableHasField($tableName, 'required')) 
+			{
+				$this->log('Column `required` not found in table, creating...');
+				$this->db->setQuery($addRequired);
+				$this->db->query();
+			}
 		}
 	}
 

--- a/core/components/com_newsletter/migrations/Migration20240209000000RemovePageExpirationCol.php
+++ b/core/components/com_newsletter/migrations/Migration20240209000000RemovePageExpirationCol.php
@@ -14,6 +14,7 @@ class Migration20240209000000RemovePageExpirationCol extends Base
 
 	static $tableName = '#__reply_pages';
 
+	// next_expiration column should not be present in core implementation of table
 	public function up()
 	{
 		$tableName = self::$tableName;
@@ -31,8 +32,21 @@ class Migration20240209000000RemovePageExpirationCol extends Base
 		}
 	}
 
+	// next_expiration column was previously present in custom implementation of table
+	// this is for consistency with the com_reply implementation only. Column is unused.
 	public function down()
 	{
-		// no-op
+		$tableName = self::$tableName;
+
+		$alterTable = "ALTER TABLE $tableName ADD COLUMN next_expiration timestamp;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			if (!$this->db->tableHasField($tableName, 'next_expiration')) 
+			{
+				$this->db->setQuery($alterTable);
+				$this->db->query();
+			}
+		}
 	}
 }

--- a/core/components/com_newsletter/migrations/Migration20240209000000RemovePageExpirationCol.php
+++ b/core/components/com_newsletter/migrations/Migration20240209000000RemovePageExpirationCol.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+defined('_HZEXEC_') or die();
+
+use Hubzero\Content\Migration\Base;
+
+class Migration20240209000000RemovePageExpirationCol extends Base
+{
+
+	static $tableName = '#__reply_pages';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$alterTable = "ALTER TABLE $tableName DROP COLUMN next_expiration;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			if ($this->db->tableHasField($tableName, 'next_expiration')) 
+			{
+				$this->log('Column `next_expiration` found in table, dropping...');
+				$this->db->setQuery($alterTable);
+				$this->db->query();
+			}
+		}
+	}
+
+	public function down()
+	{
+		// no-op
+	}
+}

--- a/core/components/com_newsletter/migrations/Migration20240210000000DropTableReplyAccessCode.php
+++ b/core/components/com_newsletter/migrations/Migration20240210000000DropTableReplyAccessCode.php
@@ -14,6 +14,7 @@ class Migration20240210000000DropTableReplyAccessCode  extends Base
 
 	static $tableName = '#__reply_access_codes';
 
+	// jos_reply_access_codes table should not be present in core implementation 
 	public function up()
 	{
 		$tableName = self::$tableName;
@@ -28,9 +29,28 @@ class Migration20240210000000DropTableReplyAccessCode  extends Base
 		}
 	}
 
+	// jos_reply_access_codes table was previously present in custom com_reply implementation 
+	// This is for consistency with the com_reply implementation only. Table is unused.
 	public function down()
 	{
-		// No-op
-	}
+		$tableName = self::$tableName;
 
+		$createTable = "CREATE TABLE $tableName (
+			`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`user_id` int(11) unsigned NOT NULL,
+			`page_id` int(11) unsigned NOT NULL,
+			`code` char(64) NOT NULL,
+			`expiration` timestamp NULL DEFAULT NULL,
+			`created` timestamp NULL DEFAULT NULL,
+			PRIMARY KEY (`id`),
+			UNIQUE KEY(code),
+			INDEX(user_id)
+		) ENGINE=MYISAM DEFAULT CHARSET=utf8;";
+
+		if (!$this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($createTable);
+			$this->db->query();
+		}
+	}
 }

--- a/core/components/com_newsletter/migrations/Migration20240210000000DropTableReplyAccessCode.php
+++ b/core/components/com_newsletter/migrations/Migration20240210000000DropTableReplyAccessCode.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+defined('_HZEXEC_') or die();
+
+use Hubzero\Content\Migration\Base;
+
+class Migration20240210000000DropTableReplyAccessCode  extends Base
+{
+
+	static $tableName = '#__reply_access_codes';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+
+		$alterTable = "DROP TABLE $tableName;";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->log('Table `jos_reply_access_codes` found in db, dropping...');
+			$this->db->setQuery($alterTable);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		// No-op
+	}
+
+}

--- a/core/components/com_newsletter/migrations/Migration20240211000000PopulatePagesTable.php
+++ b/core/components/com_newsletter/migrations/Migration20240211000000PopulatePagesTable.php
@@ -1,0 +1,36 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+// no direct access
+defined('_HZEXEC_') or die();
+
+class Migration20240211000000PopulatePagesTable extends Base
+{
+
+	static $tableName = '#__reply_pages';
+
+	public function up()
+	{
+		$tableName = self::$tableName;
+		$now = Date::toSql();
+
+		$insertRecords = "INSERT INTO $tableName
+			(`description`, `created`)
+			VALUES
+			('email subscriptions', '$now'),
+			('how do you use the Hub?', '$now');";
+
+		if ($this->db->tableExists($tableName))
+		{
+			$this->db->setQuery($insertRecords);
+			$this->db->query();
+		}
+	}
+
+	public function down()
+	{
+		// manually delete records
+	}
+
+}

--- a/core/components/com_newsletter/models/page.php
+++ b/core/components/com_newsletter/models/page.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * @package   hubzero-cms
+ * @copyright Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Components\Newsletter\Models;
+
+use Hubzero\Database\Relational;
+
+class Page extends Relational
+{
+	protected $table = '#__reply_pages';
+
+}

--- a/core/components/com_newsletter/secrets/code_example.php
+++ b/core/components/com_newsletter/secrets/code_example.php
@@ -1,6 +1,0 @@
-<?php
-
-const CODE_SECRETS = [
-	'email_subscriptions_page_id' => 0 //<email_subscriptions_page_id>
-];
-?>

--- a/core/components/com_newsletter/secrets/page_code.php
+++ b/core/components/com_newsletter/secrets/page_code.php
@@ -1,0 +1,7 @@
+<?php
+
+const PAGE_CODE = [
+	// reference jos_reply_pages.id for the email subscriptions page
+	'email_subscriptions_page_id' => 1
+];
+?>


### PR DESCRIPTION
These are some last (:crossed_fingers:) changes to the salesforce one-click work for core. See also https://github.com/hubzero/hubzero-cms/pull/1704.

Don't panic, it's mostly the README and the migrations!

## Verify requested page exists

Here we restore the table jos_reply_pages so that we can verify that the user is requesting a real page. Randomly chosen page ids will now fail. At migration time, the table's expiration column is removed if it is found, and the table is populated with records that match the page and email subscription provided.

A very simple ORM model is also provided for the table.

## Explicitly drop unused table

I've added an explicit migration that drops the jos_reply_access_codes table. It was used
by the prior implementation, jos_reply, but is not used any longer, since I have removed validation from the
page level, and user level validation is on the jos_users record.

## Clean up unclear language

I've renamed the file that provides the email subscription page id, for clarity, and added it to the codebase. Previously we had an "example" file that had to be edited at install time. Since we provide the email subscription options page and the user survey page, let's just supply the correct page id too.

## Motivation
Jira NCN-440 and friends. 

## Testing
Performed on AWS instance of jsperhac, checked valid and invalid page accesses. Ran debugger to verify.

## Checklist

- [X] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [X] Include a brief summary of the issue **in your own words**
- [X] Include a brief summary of the fix/changed code
- [X] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [X] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [X] Double check someone is assigned to review the ticket
