### PR TITLE
[CMKC] Fix for Forum Reply Post not showing ckeditor Controls

### DIFF
--- a/core/plugins/groups/forum/assets/css/forum.css
+++ b/core/plugins/groups/forum/assets/css/forum.css
@@ -210,7 +210,7 @@
 	.comment-add label {
 		display: block;
 	}
-	.comment-add label span {
+	.comment-add label span.label-text {
 		display: none;
 	}
 	.comment-add .cancelreply {


### PR DESCRIPTION
# Source JIRA card(s) and hubzero ticket(s)
https://sdx-sdsc.atlassian.net/browse/USP-182

# Brief summary of the issue
Replying to a forum post doesn't show the ckeditor controls

# Brief summary of the fix
CSS was hiding elements. Hidden elements didn't allow ckeditor JS to select the specific element it was looking for and wrap the editor controls. Even though the php code showed the method $this->editor(), without the span element, the JS couldn't wrap around any ckeditor code. 

Fix was to specific what span element to hide, which I think the original intent was to hide the input labels. In the css, I added in specific class that the span label had. 

# Screenshots showing fix
Before showcasing the issue
![image](https://github.com/hubzero/hubzero-cms/assets/12104578/3e1181d5-9dfb-44c1-99e2-4b130724ad30)

After the change
![image](https://github.com/hubzero/hubzero-cms/assets/12104578/baa6227f-acf3-46c1-9fb1-d3724ef45f51)
![image](https://github.com/hubzero/hubzero-cms/assets/12104578/83368484-6fcb-4076-b45e-8329182a5fed)

# Brief summary of your testing
Tried it on https://woo.aws.hubzero.org and once accepted, can push to stage.cmkc then production, bundle with the members page. 

# Do the change needs to be hotfixed to any production hubs before a normal core rollout
Yes, it needs to be released because the client urgency wants it for the advisory board to do more edits. Sooner that we can cherry pick, the better. 

# Double check someone is assigned to review the ticket
Yes - Nick and David



