### PR TITLE
Improve tag search prioritization

### DIFF
--- a/core/components/com_tags/site/controllers/tags.php
+++ b/core/components/com_tags/site/controllers/tags.php
@@ -356,11 +356,11 @@ class Tags extends SiteController
 				);
 
 				// Find the exact match
-				if ($row->get('tag') == $filters['search'])
+				if (strtolower($row->get('tag')) == strtolower($filters['search']) || strtolower($name) == strtolower($filters['search']))
 				{
 					$exactMatches[] = $item;
 				}
-				if (stripos($row->get('tag'), $filters['search'] . ' ') === 0 || stripos($name, $filters['search'] . ' ') === 0)
+				elseif (stripos($row->get('tag'), $filters['search'] . ' ') === 0 || stripos($name, $filters['search'] . ' ') === 0)
 				{
 					$beginsWithWord[] = $item;
 				}

--- a/core/components/com_tags/site/controllers/tags.php
+++ b/core/components/com_tags/site/controllers/tags.php
@@ -322,7 +322,6 @@ class Tags extends SiteController
 	public function autocompleteTask()
 	{
 		$filters = array(
-			'limit'  => 20,
 			'start'  => 0,
 			'search' => trim(Request::getString('value', ''))
 		);
@@ -341,6 +340,8 @@ class Tags extends SiteController
 		// Output search results in JSON format
 		$json = array();
 		$exactMatches = array();
+		$beginsWithWord =array();
+		$beginWith = array();
 
 		if (count($rows) > 0)
 		{
@@ -359,15 +360,45 @@ class Tags extends SiteController
 				{
 					$exactMatches[] = $item;
 				}
-				// Prioritize beginning of the string
-				elseif (strpos($row->get('tag'), $filters['search']) === 0)
+				if (stripos($row->get('tag'), $filters['search'] . ' ') === 0 || stripos($name, $filters['search'] . ' ') === 0)
 				{
-					array_unshift($json, $item);
+					$beginsWithWord[] = $item;
+				}
+				// Prioritize beginning of the string
+				elseif (stripos($row->get('tag'), $filters['search']) === 0 || stripos($name, $filters['search']) === 0)
+				{
+					$beginWith[] = $item;
 				}
 				else
 				{
 					$json[] = $item;
 				}
+			}
+		}
+
+		// Push matches that start with the search to the front
+		if (sizeof($beginWith))
+		{
+			// Sort the array
+			$name = array_column($beginWith, 'name');
+			array_multisort($name, SORT_DESC, SORT_NATURAL|SORT_FLAG_CASE , $beginWith);
+
+			foreach ($beginWith as $match)
+			{
+				array_unshift($json, $match);
+			}
+		}
+
+		// Push matches that begin with a word to the front
+		if (sizeof($beginsWithWord))
+		{
+			// Sort the array
+			$name = array_column($beginsWithWord, 'name');
+			array_multisort($name, SORT_DESC, SORT_NATURAL|SORT_FLAG_CASE, $beginsWithWord);
+
+			foreach ($beginsWithWord as $match)
+			{
+				array_unshift($json, $match);
 			}
 		}
 


### PR DESCRIPTION
Fixes https://nanohub.org/support/ticket/451985
JIRA Card: https://sdx-sdsc.atlassian.net/browse/NCN-922?atlOrigin=eyJpIjoiNmQwZTM3OTFmNzAyNDgyNTllN2RjYzk2OTYxZGYxYTIiLCJwIjoiaiJ9

The issue was that the SCALE tag was not showing in the autocomplete field. Apparently this was happening because there are many other tags starting with SCALE.

The new code update prioritizes matches in the following order (when searching for "scale:):
1. Exact matches ("Scale", "SCALE")
2. Separate word matches in the beginning of the tag name (search + space after, e.g. "Scale tool" "SCALE bar", "scale stuff"), ordered alphabetically, case insensitive.
3. String matches in the beginning of the tag name ("Scaleable", "Scale@purdue", etc.), ordered alphabetically, case insensitive.