### PR TITLE
add ORCID page link after the author's name on publication page

### DIFF
--- a/core/components/com_publications/site/assets/css/publications.css
+++ b/core/components/com_publications/site/assets/css/publications.css
@@ -298,6 +298,12 @@ body #introduction:after {
 	color: #000;
 	font-style: italic;
 }
+#authorslist p > a[href^="https://orcid.org/"] {
+	background-image: none;
+}
+#authorslist p > a > img {
+	margin-bottom: 0.25rem;
+}
 
 /* Launch area content */
 p.curversion,

--- a/core/components/com_publications/site/views/view/tmpl/_contributors.php
+++ b/core/components/com_publications/site/views/view/tmpl/_contributors.php
@@ -85,6 +85,12 @@ if ($this->contributors)
 		{
 			$link .= '<sup>' . $k . '</sup>';
 		}
+		if ($contributor->orcid)
+		{
+			$orcid = '<a href="https://orcid.org/' . $contributor->orcid . '" target="blank" title="' . $name . '\'s ORCID page"><img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></a>';
+			$link_s .= $orcid;
+			$link .= $orcid;
+		}
 		$names_s[] = $link_s;
 		$names[] = $link;
 	}


### PR DESCRIPTION
PURR ticket #2540 Add ORCID page link after author's name on publication page

The author names are displaying on the publication page. If an author of the publication is an PURR user and the ORCID ID is in the profile, we want to display the ORCID icon after the author's name, where the icon is set to the link to the author's ORCID page.  This helps promotes the ORCID on hubs.

The code changes include setting a link for the ORCID logo image for the authors who have ORCID id in the profile. 

To test the feature, access a publication page which you know that the author has ORCID in the profile. On the page, you will see the ORCID logo icon displaying after the author's name. When you click the ORCID logo icon, it is going to take you to the author's ORCID page. 

Test passed in both local and dev PURR.