### PR TITLE
[CMKC] Original Group Invite Issue

### DIFF
--- a/core/components/com_groups/site/controllers/membership.php
+++ b/core/components/com_groups/site/controllers/membership.php
@@ -407,7 +407,8 @@ class Membership extends Base
 			// build message object and send
 			$message->setSubject($subject)
 					->addFrom($from['email'], $from['name'])
-					->setTo($groupInvitees)
+					->setTo($from['email'])
+					->setBcc($groupInvitees)
 					->addHeader('X-Mailer', 'PHP/' . phpversion())
 					->addHeader('X-Component', 'com_groups')
 					->addHeader('X-Component-Object', 'group_invite')
@@ -495,7 +496,8 @@ class Membership extends Base
 			// build message object and send
 			$message->setSubject($subject)
 					->addFrom($from['email'], $from['name'])
-					->setTo(array($mbr['email']))
+					->setTo($from['email'])
+					->setBcc(array($mbr['email']))
 					->addHeader('X-Mailer', 'PHP/' . phpversion())
 					->addHeader('X-Component', 'com_groups')
 					->addHeader('X-Component-Object', 'group_inviteemail')


### PR DESCRIPTION
# Source JIRA card(s) and hubzero ticket(s)
https://sdx-sdsc.atlassian.net/browse/USP-193

# Brief summary of the issue
PART 1 of 2: When sending invites to multiple emails, the emails are populated into the To field, rather than Bcc. So everyone sees everyone else. This was addressed as a 'data breach' from client. Need to change this to Bcc to fix issue. 
PART 2: https://github.com/hubzero/hubzero-cms/pull/1724

# Brief summary of the fix
In the Email object, set the list of email to be sent Bcc (blind carbon copy) instead of To or Cc. 

# Screenshots showing fix
Before the change
<img width="1027" alt="screenshot of email received in to field" src="https://github.com/hubzero/hubzero-cms/assets/12104578/3396458a-93d0-4a47-93ba-dc016bfc6107">

After the change
<img width="1023" alt="screenshot of email received in bcc" src="https://github.com/hubzero/hubzero-cms/assets/12104578/0d39988b-1175-46d9-8cd2-67e0a8216d1a">

# Brief summary of your testing
Tried it on https://woo.aws.hubzero.org and once accepted, can push to stage.cmkc then production, bundle with other changes to push it out. Will need help from @nkissebe to do some grep's to find other instances of this. 

# Do the change needs to be hotfixed to any production hubs before a normal core rollout
Yes, it needs to be released because of client urgency. 

# Double check someone is assigned to review the ticket
Yes - Nick and David