### PR TITLE
[STEMED] Revised Course Asset Duplicate Accessibility for 2.2.22

### DIFF
--- a/core/components/com_courses/admin/assets/css/duplicateAssets.css
+++ b/core/components/com_courses/admin/assets/css/duplicateAssets.css
@@ -1,0 +1,9 @@
+/* Duplicating Asset - need to override it */
+/* ICON for toolbar duplicating button: STAR */
+.toolbar-box li#toolbar-star a span:before {
+	content: "\f00b"; 
+}
+
+.toolbar-box li#toolbar-star {
+	background-color: rgb(216, 222, 98); 
+}

--- a/core/components/com_courses/admin/assets/js/duplicateAssets.js
+++ b/core/components/com_courses/admin/assets/js/duplicateAssets.js
@@ -1,0 +1,88 @@
+console.log("duplicate assets");
+
+window.addEventListener('DOMContentLoaded', (domEvent) => {
+    const coursesSelectTarget = document.querySelector('#coursesSelect')
+    const offeringsSelectTarget = document.querySelector('#offeringsSelect')
+    const unitsSelectTarget = document.querySelector('#unitsSelect')
+    const assetGroupsSelectTarget = document.querySelector('#assetGroupsSelect')
+
+    getList("/api/courses/assetgroup/getAllCourses").then((res) => {
+        const courses = res.courses;
+        for (x of courses) {
+            var opt = document.createElement('option');
+            opt.value = x["id"];
+            opt.innerHTML = x["title"];
+            coursesSelectTarget.appendChild(opt);
+        }
+    })
+    
+    coursesSelectTarget.onchange = (event) => {
+        offeringsSelectTarget.innerHTML = '<option selected disabled>Select a Course Offering</option>';
+        unitsSelectTarget.innerHTML = '<option selected disabled>Select a Course Unit</option>';
+        assetGroupsSelectTarget.innerHTML = '<option selected disabled>Select a Asset Group</option>';
+
+        const selectedCourseId = event.target.value;
+        getList(`/api/courses/assetgroup/getAllCourseOfferings?courseId=${selectedCourseId}`).then((res) => {
+            const courseOfferings = res.course_offerings;
+            for (x of courseOfferings) {
+                var opt = document.createElement('option');
+                opt.value = x["id"];
+                opt.innerHTML = x["title"];
+                offeringsSelectTarget.appendChild(opt);
+            }
+        })
+    }
+
+    offeringsSelectTarget.onchange = (event) => {
+        unitsSelectTarget.innerHTML = '<option selected disabled>Select a Course Unit</option>';
+        assetGroupsSelectTarget.innerHTML = '<option selected disabled>Select a Asset Group</option>';
+
+        const selectedOfferingId = event.target.value;
+        getList(`/api/courses/assetgroup/getAllCourseUnits?offeringId=${selectedOfferingId}`).then((res) => {
+            const courseUnits = res.course_units;
+            for (x of courseUnits) {
+                var opt = document.createElement('option');
+                opt.value = x["id"];
+                opt.innerHTML = x["title"];
+                unitsSelectTarget.appendChild(opt);
+            }
+        })
+    }
+
+    unitsSelectTarget.onchange = (event) => {
+        assetGroupsSelectTarget.innerHTML = '<option selected disabled>Select a Asset Group</option>';
+
+        const selectedUnitId = event.target.value;
+        getList(`/api/courses/assetgroup/getAllAssetGroups?unitId=${selectedUnitId}`).then((res) => {
+            const assetGroupsMap = res.asset_groups;
+
+            for (const [key, value] of Object.entries(assetGroupsMap)) {
+                // console.log(`Key: ${key}, Value: ${value['alias']}`);
+
+                var opt = document.createElement('option');
+                opt.value = key;
+                opt.innerHTML = value['title'];
+                assetGroupsSelectTarget.appendChild(opt);    
+            }
+        })
+    }
+});
+
+const getList = async (url) => {
+    try {
+        let response = await fetch(url);
+
+        if (!response.ok) {
+            window.confirm("Server Error with API");
+            console.error(`Error Code: ${response.status} / Error Message: ${response.statusText}`);
+        }
+
+        return response.json();
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            console.error('There was a SyntaxError', error);
+        } else {
+            console.error('There was an error', error);
+        }
+    }
+};

--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -529,6 +529,7 @@ class Assetgroups extends AdminController
 		$this->view->offering = \Components\Courses\Models\Offering::getInstance($this->view->unit->get('offering_id'));
 
 		$scopeId = $this->view->row->get('id');
+		// $parentId = $this->view->row->parent;
 		$courseId = $this->view->offering->get('course_id');
 		$this->view->course = \Components\Courses\Models\Course::getInstance($courseId);
 
@@ -596,7 +597,8 @@ class Assetgroups extends AdminController
 		$courseIdStart = Request::getString('courseIdToDuplicate');
 		$offeringIdStart = Request::getString('offeringIdToDuplicate');
 		$unitIdStart = Request::getString('unitIdToDuplicate');
-		$assetGroupParentIdStart = Request::getString('assetGroupIdToDuplicate');
+		$assetGroupIdStart = Request::getString('assetGroupIdToDuplicate');
+		$assetGroupParentIdStart = Request::getString('assetGroupParentIdToDuplicate');
 
 		// (END) Where the asset group will end up
 		$courseId = Request::getString('filterCourses');
@@ -604,10 +606,19 @@ class Assetgroups extends AdminController
 		$unitId = Request::getString('filterUnits');
 		$assetGroupParent = Request::getString('filterAssetGroups');
 
-		// $assetgroup = new \Components\Courses\Models\Assetgroup($id);
+		$assetgroup = new \Components\Courses\Models\Assetgroup($assetGroupIdStart);
+		if (!$assetgroup->copyToSelectedAssetGroup($courseId, $offeringId, $unitId, $assetGroupParent)){
+			// Redirect back to the courses page
+			App::redirect(
+				Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&unit=' . $assetgroup->get('unit_id'), false),
+				Lang::txt('COM_COURSES_ERROR_COPY_FAILED') . ': ' . $assetgroup->getError(),
+				'error'
+			);
+			return;
+		}
 
-		$messageSTART = "Dup asset START > courseId: " . $courseIdStart . " | offeringId: " . $offeringIdStart . " | unitId: " . $unitIdStart . " | assetGroupId: " . $assetGroupParentIdStart;
-		$messageEND = "Dup asset END > courseId: " . $courseId . " | offeringId: " . $offeringId . " | unitId: " . $unitId . " | assetGroupId: " . $assetGroupParent;
+		$messageSTART = "Dup asset START > courseId: " . $courseIdStart . " | offeringId: " . $offeringIdStart . " | unitId: " . $unitIdStart . " | assetGroupId: " . $assetGroupIdStart . " | assetGroupParentId: " . $assetGroupParentIdStart;
+		$messageEND = "Dup asset END > courseId: " . $courseId . " | offeringId: " . $offeringId . " | unitId: " . $unitId . " | assetGroupParentId: " . $assetGroupParent;
 
 		$message = "Dup Asset from " . $assetGroupParentIdStart . " to " . $assetGroupParent;
 

--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -256,13 +256,7 @@ class Assetgroups extends AdminController
 
 		// Incoming
 		$fields = Request::getArray('fields', array(), 'post');
-
-		\Log::debug( var_export("---- SAVE TASK -----", true));
-		\Log::debug( var_export($fields, true));
-
 		$task = Request::getArray('task', array(), 'post');
-		\Log::debug( var_export($task, true));
-
 
 		// Instantiate a Course object
 		$model = new \Components\Courses\Models\Assetgroup($fields['id']);

--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -575,9 +575,6 @@ class Assetgroups extends AdminController
 		$this->view
 			->setLayout('duplicateassets')
 			->display();
-
-		// Get the assets - group
-		// Get all the different asset groups - dropdown
 	}
 
 	/**
@@ -595,16 +592,27 @@ class Assetgroups extends AdminController
 	public function dupassetsTask() {
 		\Log::debug( var_export("---- dupassetsTask SAVE -----", true));
 
-		// Incoming
-		$id = Request::getArray('id', array());
-		$unit_id = Request::getArray('unit_id', array());
+		// (START) Ids of asset groups that will be duplicated
+		$courseIdStart = Request::getString('courseIdToDuplicate');
+		$offeringIdStart = Request::getString('offeringIdToDuplicate');
+		$unitIdStart = Request::getString('unitIdToDuplicate');
+		$assetGroupParentIdStart = Request::getString('assetGroupIdToDuplicate');
 
-		// Grab all the select options... will utilize the specific values
-		\Log::debug( var_export(Request::getString('filterCourses'), true));
-		\Log::debug( var_export(Request::getString('filterOfferings'), true));
-		\Log::debug( var_export(Request::getString('filterUnits'), true));
-		\Log::debug( var_export(Request::getString('filterAssetGroups'), true));
+		// (END) Where the asset group will end up
+		$courseId = Request::getString('filterCourses');
+		$offeringId = Request::getString('filterOfferings');
+		$unitId = Request::getString('filterUnits');
+		$assetGroupParent = Request::getString('filterAssetGroups');
 
+		// $assetgroup = new \Components\Courses\Models\Assetgroup($id);
+
+		$messageSTART = "Dup asset START > courseId: " . $courseIdStart . " | offeringId: " . $offeringIdStart . " | unitId: " . $unitIdStart . " | assetGroupId: " . $assetGroupParentIdStart;
+		$messageEND = "Dup asset END > courseId: " . $courseId . " | offeringId: " . $offeringId . " | unitId: " . $unitId . " | assetGroupId: " . $assetGroupParent;
+
+		$message = "Dup Asset from " . $assetGroupParentIdStart . " to " . $assetGroupParent;
+
+		\Log::debug( var_export($messageSTART, true));
+		\Log::debug( var_export($messageEND, true));
 
 		// Redirect to the asset groups
 		App::redirect(

--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -591,8 +591,6 @@ class Assetgroups extends AdminController
 	 * Upon saving the duplicate asset form with button underneath the form
 	 */
 	public function dupassetsTask() {
-		\Log::debug( var_export("---- dupassetsTask SAVE -----", true));
-
 		// (START) Ids of asset groups that will be duplicated
 		$courseIdStart = Request::getString('courseIdToDuplicate');
 		$offeringIdStart = Request::getString('offeringIdToDuplicate');
@@ -617,13 +615,8 @@ class Assetgroups extends AdminController
 			return;
 		}
 
-		$messageSTART = "Dup asset START > courseId: " . $courseIdStart . " | offeringId: " . $offeringIdStart . " | unitId: " . $unitIdStart . " | assetGroupId: " . $assetGroupIdStart . " | assetGroupParentId: " . $assetGroupParentIdStart;
-		$messageEND = "Dup asset END > courseId: " . $courseId . " | offeringId: " . $offeringId . " | unitId: " . $unitId . " | assetGroupParentId: " . $assetGroupParent;
-
-		$message = "Dup Asset from " . $assetGroupParentIdStart . " to " . $assetGroupParent;
-
-		\Log::debug( var_export($messageSTART, true));
-		\Log::debug( var_export($messageEND, true));
+		$message = "Duplicated Asset from Asset Group " . $assetGroupIdStart . 
+			" to Asset Group Parent" . $assetGroupParent;
 
 		// Redirect to the asset groups
 		App::redirect(

--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -257,6 +257,13 @@ class Assetgroups extends AdminController
 		// Incoming
 		$fields = Request::getArray('fields', array(), 'post');
 
+		\Log::debug( var_export("---- SAVE TASK -----", true));
+		\Log::debug( var_export($fields, true));
+
+		$task = Request::getArray('task', array(), 'post');
+		\Log::debug( var_export($task, true));
+
+
 		// Instantiate a Course object
 		$model = new \Components\Courses\Models\Assetgroup($fields['id']);
 
@@ -480,5 +487,121 @@ class Assetgroups extends AdminController
 		App::redirect(
 			Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&unit=' . Request::getInt('unit', 0), false)
 		);
+	}
+
+
+
+	/**
+	 * Duplicate Asset data / files
+	 *
+	 * @return	void
+	 */
+	public function assetdupTask() {
+
+		Request::setVar('hidemainmenu', 1);
+
+		// Incoming Id
+		$id = Request::getArray('id', array());
+
+		// Get the single ID we're working with
+		if (is_array($id)){
+			$id = (!empty($id)) ? $id[0] : 0;
+		}
+
+		if (!$id){
+			App::redirect(
+				Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller . '&unit=' . Request::getInt('unit', 0), false),
+				Lang::txt('COM_COURSES_ERROR_NO_ID'),
+				'error'
+			);
+			return;
+		}
+
+		// ------------- ASSET GROUPS BASED ON ID -------------
+		$assetGroup = new \Components\Courses\Models\Assetgroup($id);
+		$this->view->row = $assetGroup;
+
+		if (!$this->view->row->get('unit_id')){
+			$this->view->row->set('unit_id', Request::getInt('unit', 0));
+		}
+
+		$this->view->unit = \Components\Courses\Models\Unit::getInstance($this->view->row->get('unit_id'));
+		$this->view->offering = \Components\Courses\Models\Offering::getInstance($this->view->unit->get('offering_id'));
+
+		$scopeId = $this->view->row->get('id');
+		$courseId = $this->view->offering->get('course_id');
+		$this->view->course = \Components\Courses\Models\Course::getInstance($courseId);
+
+		// ------------- ASSETS -------------
+		$this->view->filters = array(
+			'tmpl' => 'component',
+			'asset_scope' => 'asset_group',
+			'asset_scope_id' => $scopeId,
+			'course_id' => $courseId,
+			'limit' => Config::get('list_limit'),
+			'start' => 0
+		);
+
+		$tbl = new Tables\Asset($this->database);
+		$assetRows = $tbl->find(array(
+			'w' => $this->view->filters
+		));
+
+		$this->view->assetrows = $assetRows;
+		$this->view->assetsCount = count($assetRows);
+
+		// NEED TO GET HIERARCHY OF ALL ASSET GROUPS ---------------
+		// RECURSION FROM THE TOP OF THE CHAIN - all asset groups
+
+		$rows = $this->view->unit->assetgroups();
+
+		// Establish the hierarchy of the menu
+		$children = array(
+			0 => array()
+		);
+
+		$levellimit = 500;
+
+		// 1st pass - collect children
+		foreach ($rows as $v) {
+			$children[0][] = $v;
+			$children[$v->get('id')] = $v->children();
+		}
+
+		// 2nd pass - get an indent list of the items
+		$this->view->assetgroups = $this->treeRecurse(0, '', array(), $children, max(0, $levellimit-1));
+
+		// ------------- OUTPUT TO HTML -------------
+		$this->view
+			->setLayout('duplicateassets')
+			->display();
+
+		// Get the assets - group
+		// Get all the different asset groups - dropdown
+	}
+
+	/**
+	 * Upon saving the duplicate asset form
+	 * Task is ran through the toolbar
+	 */
+	public function duplicateassetsTask() {
+		\Log::debug( var_export("---- duplicateassetsTask -----", true));
+		Notify::success("duplicate asset now");
+	}
+
+	/**
+	 * Upon saving the duplicate asset form
+	 * Task is ran through the toolbar
+	 */
+	public function dupassetsTask() {
+		\Log::debug( var_export("---- dupassetsTask SAVE -----", true));
+
+
+		// Redirect back to the courses page
+		App::redirect(
+			Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller, false),
+			Lang::txt('COM_COURSES_ITEM_COPIED')
+		);
+
 	}
 }

--- a/core/components/com_courses/admin/controllers/assetgroups.php
+++ b/core/components/com_courses/admin/controllers/assetgroups.php
@@ -590,17 +590,26 @@ class Assetgroups extends AdminController
 	}
 
 	/**
-	 * Upon saving the duplicate asset form
-	 * Task is ran through the toolbar
+	 * Upon saving the duplicate asset form with button underneath the form
 	 */
 	public function dupassetsTask() {
 		\Log::debug( var_export("---- dupassetsTask SAVE -----", true));
 
+		// Incoming
+		$id = Request::getArray('id', array());
+		$unit_id = Request::getArray('unit_id', array());
 
-		// Redirect back to the courses page
+		// Grab all the select options... will utilize the specific values
+		\Log::debug( var_export(Request::getString('filterCourses'), true));
+		\Log::debug( var_export(Request::getString('filterOfferings'), true));
+		\Log::debug( var_export(Request::getString('filterUnits'), true));
+		\Log::debug( var_export(Request::getString('filterAssetGroups'), true));
+
+
+		// Redirect to the asset groups
 		App::redirect(
 			Route::url('index.php?option=' . $this->_option . '&controller=' . $this->_controller, false),
-			Lang::txt('COM_COURSES_ITEM_COPIED')
+			$message
 		);
 
 	}

--- a/core/components/com_courses/admin/controllers/assets.php
+++ b/core/components/com_courses/admin/controllers/assets.php
@@ -84,10 +84,14 @@ class Assets extends AdminController
 		);
 
 		$tbl = new Tables\Asset($this->database);
+		// print_r($this->view->filters);
 
 		$rows = $tbl->find(array(
 			'w' => $this->view->filters
 		));
+
+		// print_r($rows);
+
 		$r = array();
 		if ($rows)
 		{
@@ -110,6 +114,8 @@ class Assets extends AdminController
 			}
 		}
 		$this->view->assets = $a;
+
+		// print_r($a);
 
 		$this->view->total = count($this->view->rows);
 

--- a/core/components/com_courses/admin/language/en-GB/en-GB.com_courses.ini
+++ b/core/components/com_courses/admin/language/en-GB/en-GB.com_courses.ini
@@ -12,6 +12,8 @@ COM_COURSES_STUDENTS="Students"
 COM_COURSES_ROLES="Roles"
 COM_COURSES_PLUGINS="Plugins"
 
+COM_COURSES_ASSET_DUPLICATE="Duplicate Assets to Existing Groups"
+
 ; Misc.
 COM_COURSES_TYPE="Type"
 COM_COURSES_SUBMIT="Submit"
@@ -297,6 +299,7 @@ COM_COURSES_ENTRY_MUST_BE_SAVED_BEFORE_ASSETS="Entry must be saved before assets
 
 ; Asset groups
 COM_COURSES_ASSET_GROUPS="Asset groups"
+COM_COURSES_ASSETGROUP_SAVED="Asset groups Saved"
 
 ; Assets
 COM_COURSES_ATTACH_ASSET="Attach asset"

--- a/core/components/com_courses/admin/views/assetgroups/tmpl/display.php
+++ b/core/components/com_courses/admin/views/assetgroups/tmpl/display.php
@@ -20,6 +20,10 @@ $canDo = \Components\Courses\Helpers\Permissions::getActions();
 Toolbar::title(Lang::txt('COM_COURSES') . ': ' . Lang::txt('COM_COURSES_ASSET_GROUPS'), 'courses');
 if ($canDo->get('core.create'))
 {
+	// NEW FEATURE - [Asset Duplicate] - Pop open a modal window with form
+	Toolbar::custom('assetdup', 'star', '', 'COM_COURSES_ASSET_DUPLICATE', true);
+	Toolbar::spacer();
+
 	Toolbar::custom('copy', 'copy.png', 'copy_f2.png', 'JTOOLBAR_DUPLICATE', true);
 	Toolbar::spacer();
 	Toolbar::addNew();
@@ -35,7 +39,8 @@ if ($canDo->get('core.delete'))
 Toolbar::spacer();
 Toolbar::help('assetgroups');
 
-$this->css();
+$this->css()
+	->css('duplicateAssets');
 
 Html::behavior('tooltip');
 ?>
@@ -63,7 +68,7 @@ Html::behavior('tooltip');
 		</div>
 	</fieldset>
 
-	<table class="adminlist">
+	<table class="adminlist" id="assetgroups">
 		<caption>
 			(<a href="<?php echo Route::url('index.php?option=' . $this->option  . '&controller=offerings&course=' . $this->course->get('id')); ?>">
 				<?php echo $this->escape(stripslashes($this->course->get('alias'))); ?>

--- a/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
+++ b/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
@@ -35,9 +35,11 @@ $this->css('duplicateAssets')
 			<fieldset class="adminform">
 				<legend><span>Assets to Duplicate</span></legend>
 				
-				<input type="hidden" name="fields[id]" value="<?php echo $this->row->get('id'); ?>" />
-				<input type="hidden" name="fields[unit_id]" value="<?php echo $this->row->get('unit_id'); ?>" />
-				<input type="hidden" name="unit" value="<?php echo $this->row->get('unit_id'); ?>" />
+				<!-- Ids that will be passed to form -->
+				<input type="hidden" name="assetGroupIdToDuplicate" value="<?php echo $this->row->get('id'); ?>" />
+				<input type="hidden" name="unitIdToDuplicate" value="<?php echo $this->unit->get('id'); ?>" />
+				<input type="hidden" name="offeringIdToDuplicate" value="<?php echo $this->offering->get('id'); ?>" />
+				<input type="hidden" name="courseIdToDuplicate" value="<?php echo $this->course->get('id'); ?>" />
 
 				<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
 				<input type="hidden" name="controller" value="<?php echo $this->controller; ?>">

--- a/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
+++ b/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
@@ -37,6 +37,7 @@ $this->css('duplicateAssets')
 				
 				<!-- Ids that will be passed to form -->
 				<input type="hidden" name="assetGroupIdToDuplicate" value="<?php echo $this->row->get('id'); ?>" />
+				<input type="hidden" name="assetGroupParentIdToDuplicate" value="<?php echo $this->row->get('parent'); ?>" />
 				<input type="hidden" name="unitIdToDuplicate" value="<?php echo $this->unit->get('id'); ?>" />
 				<input type="hidden" name="offeringIdToDuplicate" value="<?php echo $this->offering->get('id'); ?>" />
 				<input type="hidden" name="courseIdToDuplicate" value="<?php echo $this->course->get('id'); ?>" />
@@ -202,6 +203,11 @@ $this->css('duplicateAssets')
 					<tr>
 						<th scope="row">Asset Group Title</th>
 						<td><?php echo $this->escape($this->row->get('title')); ?></td>
+					</tr>
+					</tr>
+					<tr>
+						<th scope="row">Asset Group PARENT</th>
+						<td><?php echo $this->escape($this->row->get('parent')); ?></td>
 					</tr>
 					<tr>
 						<th scope="row">Asset Group Alias</th>

--- a/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
+++ b/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2024 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+$text = "Duplicate Assets For Existing Asset Groups";
+
+$canDo = \Components\Courses\Helpers\Permissions::getActions();
+
+Toolbar::title(Lang::txt('COM_COURSES') . ': ' . $text, 'courses.png');
+
+// SAVE and CANCEL
+// Toolbar::save();
+Toolbar::cancel();
+
+Html::behavior('framework', true);
+
+// Remove datapicker error
+$this->css('duplicateAssets')
+	 ->js('duplicateAssets');
+?>
+
+<form action="<?php echo Route::url('index.php?option=' . $this->option  . '&controller=' . $this->controller); ?>&amp;task=dupassets" 
+	method="post" name="adminForm" id="item-form" class="editform form-validate" 
+	data-invalid-msg="<?php echo $this->escape(Lang::txt('JGLOBAL_VALIDATION_FORM_FAILED'));?>">
+	
+	<div class="grid">
+		
+		<div class="col span7">
+			<fieldset class="adminform">
+				<legend><span>Assets to Duplicate</span></legend>
+				
+				<input type="hidden" name="fields[id]" value="<?php echo $this->row->get('id'); ?>" />
+				<input type="hidden" name="fields[unit_id]" value="<?php echo $this->row->get('unit_id'); ?>" />
+				<input type="hidden" name="unit" value="<?php echo $this->row->get('unit_id'); ?>" />
+
+				<input type="hidden" name="option" value="<?php echo $this->option; ?>" />
+				<input type="hidden" name="controller" value="<?php echo $this->controller; ?>">
+				<input type="hidden" name="task" value="dupassets" />
+				<input type="hidden" name="action" value="dupassets" />
+
+				<div class="input-wrap" id="selectDropdownForAssetGroups">
+					<label for="field-parent">Save to which Asset Group?</label><br />
+					<select id="coursesSelect">
+						<option selected disabled>Select a Course</option>
+					</select>
+					<br><br>
+					<select id="offeringsSelect">
+						<option selected disabled>Select a Course Offering</option>
+					</select>
+					<br><br>
+					<select id="unitsSelect">
+						<option selected disabled>Select a Course Unit</option>
+					</select>
+					<br><br>
+					<select id="assetGroupsSelect">
+						<option selected disabled>Select a Asset Group</option>
+					</select>
+				</div>
+
+				<!-- https://stage.stemedhub.org/administrator/index.php?option=com_courses&controller=assets&tmpl=component&scope=asset_group&scope_id=92&course_id=8 -->
+				<!-- SQL: select * from jos_courses_assets; -->
+				<p><strong><?php echo $this->escape($this->assetsCount); ?></strong> Assets That Will Be Copied from Current Asset Group <strong><?php echo $this->escape($this->row->get('id')); ?></strong> --> Asset Group Selected ABOVE.</p>
+				<table class="adminlist">
+					<thead style="background: black">
+						<tr>
+							<th scope="col">Asset Id</th>
+							<th scope="col">Asset Title</th>
+							<th scope="col">Type</th>
+							<th scope="col">State</th>
+							<th scope="col">Ordering</th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php
+							$i = 0; $k = 0; $n = count($this->assetrows);
+							foreach ($this->assetrows as $row) {
+						?>
+							<tr class="<?php echo "row$k"; ?>">
+								<td><?php echo $this->escape($row->id); ?></td>
+								<td><?php echo $this->escape(stripslashes($row->title)); ?></td>
+								<td><?php echo $this->escape(stripslashes($row->type)); ?></td>
+								<td>
+									<?php if ($row->state == 2) { ?>
+										Trashed
+									<?php } else if ($row->state == 1) { ?>
+										Published
+									<?php } else { ?>
+										Unpublished 
+									<?php } ?>
+								</td>
+								<td><?php echo $this->escape(stripslashes($row->ordering)); ?></td>
+							</tr>
+						<?php 
+							$i++; $k = 1 - $k;
+						} ?>
+					</tbody>
+				</table>
+			</fieldset>
+			<input type="submit" class="btn" value="DUPLICATE ASSETS" />
+		</div>
+		
+
+		<div class="col span5">
+			<table class="meta">
+				<thead style="background: black">
+					<tr>
+						<th colspan="2" style="font-weight: bolder">Course Meta Data</td>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">Course Id (<a href='/administrator/index.php?option=com_courses&controller=courses'>All</a>)</th>
+						<td>
+							<a href='/administrator/index.php?option=com_courses&controller=courses&task=edit&id=<?php echo $this->escape($this->course->get('id')); ?>'>
+								<?php echo $this->escape($this->course->get('id')); ?>
+							</a>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">Course Title</th>
+						<td><?php echo $this->escape($this->course->get('title')); ?></td>
+					</tr>
+					<tr>
+						<th scope="row">Course Alias</th>
+						<td><?php echo $this->escape($this->course->get('alias')); ?></td>
+					</tr>
+				</tbody>
+			</table>
+			<table class="meta">
+				<thead style="background: black">
+					<tr>
+						<th colspan="2" style="font-weight: bolder">Offering Meta Data</td>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">Offering Id</th>
+						<td>
+							<a href='/administrator/index.php?option=com_courses&controller=offerings&course=<?php echo $this->escape($this->course->get('id')); ?>'>
+								<?php echo $this->escape($this->offering->get('id')); ?>
+							</a>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">Offering Title</th>
+						<td><?php echo $this->escape($this->offering->get('title')); ?></td>
+					</tr>
+					<tr>
+						<th scope="row">Offering Alias</th>
+						<td><?php echo $this->escape($this->offering->get('alias')); ?></td>
+					</tr>
+				</tbody>
+			</table>
+			<table class="meta">
+				<thead style="background: black">
+					<tr>
+						<th colspan="2" style="font-weight: bolder">Unit Meta Data</td>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">Unit Id</th>
+						<td>
+							<a href='/administrator/index.php?option=com_courses&controller=units&offering=<?php echo $this->escape($this->offering->get('id')); ?>'>
+								<?php echo $this->escape($this->unit->get('id')); ?>
+							</a>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">Unit Title</th>
+						<td><?php echo $this->escape($this->unit->get('title')); ?></td>
+					</tr>
+					<tr>
+						<th scope="row">Unit Alias</th>
+						<td><?php echo $this->escape($this->unit->get('alias')); ?></td>
+					</tr>
+				</tbody>
+			</table>
+			<table class="meta">
+				<thead style="background: black">
+					<tr>
+						<th colspan="2" style="font-weight: bolder">Asset Group Meta Data</td>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">Asset Group Id</th>
+						<td>
+							<a href='/administrator/index.php?option=com_courses&controller=assetgroups&unit=<?php echo $this->escape($this->unit->get('id')); ?>'>
+								<?php echo $this->escape($this->row->get('id')); ?>
+							</a>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">Asset Group Title</th>
+						<td><?php echo $this->escape($this->row->get('title')); ?></td>
+					</tr>
+					<tr>
+						<th scope="row">Asset Group Alias</th>
+						<td><?php echo $this->escape($this->row->get('alias')); ?></td>
+					</tr>
+					<?php if ($this->row->get('created')) { ?>
+						<tr>
+							<th scope="row">Created On</th>
+							<td><time datetime="<?php echo $this->escape($this->row->get('created')); ?>"><?php echo $this->escape(Date::of($this->row->get('created'))->toLocal()); ?></time></td>
+						</tr>
+					<?php } ?>
+					<?php if ($this->row->get('created_by')) { ?>
+						<tr>
+							<th scope="row">Created By</th>
+							<td><?php
+								$creator = User::getInstance($this->row->get('created_by'));
+								echo $this->escape(stripslashes($creator->get('name'))); ?>
+							</td>
+						</tr>
+					<?php } ?>
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<?php echo Html::input('token'); ?>
+</form>

--- a/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
+++ b/core/components/com_courses/admin/views/assetgroups/tmpl/duplicateassets.php
@@ -46,19 +46,19 @@ $this->css('duplicateAssets')
 
 				<div class="input-wrap" id="selectDropdownForAssetGroups">
 					<label for="field-parent">Save to which Asset Group?</label><br />
-					<select id="coursesSelect">
+					<select id="coursesSelect" name="filterCourses">
 						<option selected disabled>Select a Course</option>
 					</select>
 					<br><br>
-					<select id="offeringsSelect">
+					<select id="offeringsSelect" name="filterOfferings">
 						<option selected disabled>Select a Course Offering</option>
 					</select>
 					<br><br>
-					<select id="unitsSelect">
+					<select id="unitsSelect" name="filterUnits">
 						<option selected disabled>Select a Course Unit</option>
 					</select>
 					<br><br>
-					<select id="assetGroupsSelect">
+					<select id="assetGroupsSelect" name="filterAssetGroups">
 						<option selected disabled>Select a Asset Group</option>
 					</select>
 				</div>

--- a/core/components/com_courses/api/controllers/assetgroupv1_0.php
+++ b/core/components/com_courses/api/controllers/assetgroupv1_0.php
@@ -14,10 +14,16 @@ use Components\Courses\Models\Assets\Tool;
 use App;
 use Request;
 use Date;
+use stdClass;
 
 require_once __DIR__ . DS . 'base.php';
 require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'assetgroup.php';
 require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'assets' . DS . 'tool.php';
+
+require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'assetgroup.php';
+require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'unit.php';
+require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'offering.php';
+require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'course.php';
 
 /**
  * API controller for the course asset groups
@@ -228,4 +234,112 @@ class Assetgroupv1_0 extends base
 		// Return message
 		$this->send('New order saved');
 	}
+
+
+	// Creating that hierachy with an API
+	// https://stage.stemedhub.org/api/courses/assetgroup/getAllCourses
+	// COURSES - LEVEL 1
+	public function getAllCoursesTask(){
+		$database = \App::get('db');
+		$query = "SELECT * FROM `#__courses`";
+
+        $database->setQuery($query);
+        $rows = $database->loadObjectList();
+
+        $object = new stdClass();
+        $object->courses = $rows;
+
+        $this->send($object);
+	}
+
+	// COURSE OFFERING - LEVEL 2
+	// https://stage.stemedhub.org/api/courses/assetgroup/getAllCourseOfferings?courseId=8
+	public function getAllCourseOfferingsTask(){
+		$courseId = Request::getInt('courseId', false);
+
+		// Conditional Checks
+		if (!$courseId) {
+			throw new Exception("Course Id is required");
+		}
+
+		$database = \App::get('db');
+		$query = "SELECT * FROM `#__courses_offerings` WHERE `course_id` = " . $courseId;
+
+        $database->setQuery($query);
+        $rows = $database->loadObjectList();
+
+        $object = new stdClass();
+        $object->course_offerings = $rows;
+
+        $this->send($object);
+	}
+
+	// COURSE UNITS - LEVEL 3
+	// https://stage.stemedhub.org/api/courses/assetgroup/getAllCourseUnits?offeringId=8
+	public function getAllCourseUnitsTask(){
+		$offeringId = Request::getInt('offeringId', false);
+
+		// Conditional Checks
+		if (!$offeringId) {
+			throw new Exception("Offering Id is required");
+		}
+
+		$database = \App::get('db');
+		$query = "SELECT * FROM `#__courses_units` WHERE `offering_id` = " . $offeringId;
+
+        $database->setQuery($query);
+        $rows = $database->loadObjectList();
+
+        $object = new stdClass();
+        $object->course_units = $rows;
+
+        $this->send($object);
+	}
+
+	// ASSET GROUPS - LEVEL 4
+	// https://stage.stemedhub.org/api/courses/assetgroup/getAllAssetGroups?unitId=18
+	// https://stackoverflow.com/questions/21021863/creating-a-nested-array-form-a-flat-array-trough-parent-id
+	public function getAllAssetGroupsTask(){
+		$unitId = Request::getInt('unitId', false);
+
+		// Conditional Checks
+		if (!$unitId) {
+			throw new Exception("Unit Id is required");
+		}
+
+		$database = \App::get('db');
+		$query = "SELECT * FROM `#__courses_asset_groups` WHERE `unit_id` = " . $unitId;
+
+		// Recursive
+        $database->setQuery($query);
+        $rows = $database->loadObjectList();
+
+		$jsonArray = array();
+        foreach ($rows as $v) {
+			// Solve Error "Cannot use object of type stdClass as array"
+            $assetGroupArray = (array) json_decode(json_encode($v),true);
+            $jsonArray[] = $assetGroupArray;
+        }
+
+		$tree = $this->convertToTree($jsonArray);
+
+		$object = new stdClass();
+        $object->asset_groups = $tree;
+
+        $this->send($object);
+	}
+
+	// This is a recursive function, needed to happen because levels can vary with depth and location of nodes, it's a tree.
+    public function convertToTree($flat, $idField = 'id', $parentIdField = 'parent', $childNodesField = 'child', $curIdx = 0) {
+        $indexed = array();
+
+        foreach($flat as $row) {
+            if ($row[$parentIdField] == $curIdx) {
+                $indexed[$row[$idField]] = $row;
+                $indexed[$row[$idField]]["child"] = $this->convertToTree($flat, $idField, $parentIdField, $childNodesField, $row[$idField]);
+            }
+        }
+
+        return $indexed;
+    }
 }

--- a/core/components/com_courses/config/access.xml
+++ b/core/components/com_courses/config/access.xml
@@ -24,5 +24,6 @@
 		<action name="core.edit" title="JACTION_EDIT" description="COM_CATEGORIES_ACCESS_EDIT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="COM_CATEGORIES_ACCESS_EDITSTATE_DESC" />
 		<action name="core.edit.own" title="JACTION_EDITOWN" description="COM_CATEGORIES_ACCESS_EDITOWN_DESC" />
+		<action name="core.duplicateassets" title="Duplicate Assets" description="Duplicate Assets by Asset Groups" />
 	</section>
 </access>

--- a/core/components/com_courses/models/asset.php
+++ b/core/components/com_courses/models/asset.php
@@ -503,9 +503,6 @@ class Asset extends Base
 		// Keep track of the original id
 		$originalId = $this->get('id');
 
-		\Log::debug( var_export("---- asset->copy() ----", true));
-		\Log::debug( var_export($originalId, true));
-
 		// Reset the ID. This will force store() to create a new record.
 		$this->set('id', 0);
 
@@ -548,24 +545,21 @@ class Asset extends Base
 
 		// Reset the ID. This will force store() to create a new record.
 		$this->set('id', 0);
-
-		// TODO: FIX -------- NOT the RIGHT WAY TO SET PATH
-		// This path is probably the path to the folder
-		$pathNew = $courseId . '/' . $this->get('id');
 		$this->set('course_id', $courseId);
-		$this->set('path', $pathNew);
 
-		\Log::debug( var_export("---- asset->duplicate() ----", true));
-		\Log::debug( var_export($originalId, true));
-		\Log::debug( var_export($courseId, true));
-		\Log::debug( var_export($pathNew, true));
-
+		// Initial storage
 		if (!$this->store()){
 			return false;
 		}
 
+		// Update the path with new asset id, additional store
+		// TODO: how does it create a directory, it's probably from models/assets/url.php
 		// This needs to be a deep copy for type: video, subtype: video
-		// Also file
+		$pathNew = $courseId . '/' . $this->get('id');
+		$this->set('path', $pathNew);
+		if (!$this->store()){
+			return false;
+		}
 
 		return true;
 	}

--- a/core/components/com_courses/models/asset.php
+++ b/core/components/com_courses/models/asset.php
@@ -503,6 +503,9 @@ class Asset extends Base
 		// Keep track of the original id
 		$originalId = $this->get('id');
 
+		\Log::debug( var_export("---- asset->copy() ----", true));
+		\Log::debug( var_export($originalId, true));
+
 		// Reset the ID. This will force store() to create a new record.
 		$this->set('id', 0);
 
@@ -529,6 +532,40 @@ class Asset extends Base
 				$this->store();
 			}
 		}
+
+		return true;
+	}
+
+	/**
+	 * Duplicate an asset and it's associated data
+	 *
+	 * @param  bool $forms whether or not to duplicate forms as well
+	 * @return bool
+	 */
+	public function duplicate($courseId){
+		// Keep track of the original id
+		$originalId = $this->get('id');
+
+		// Reset the ID. This will force store() to create a new record.
+		$this->set('id', 0);
+
+		// TODO: FIX -------- NOT the RIGHT WAY TO SET PATH
+		// This path is probably the path to the folder
+		$pathNew = $courseId . '/' . $this->get('id');
+		$this->set('course_id', $courseId);
+		$this->set('path', $pathNew);
+
+		\Log::debug( var_export("---- asset->duplicate() ----", true));
+		\Log::debug( var_export($originalId, true));
+		\Log::debug( var_export($courseId, true));
+		\Log::debug( var_export($pathNew, true));
+
+		if (!$this->store()){
+			return false;
+		}
+
+		// This needs to be a deep copy for type: video, subtype: video
+		// Also file
 
 		return true;
 	}

--- a/core/components/com_courses/models/asset.php
+++ b/core/components/com_courses/models/asset.php
@@ -542,6 +542,7 @@ class Asset extends Base
 	public function duplicate($courseId){
 		// Keep track of the original asset ID, for original directory
 		$originalId = $this->get('id');
+		$originalCourseId = $this->get('course_id');
 
 		// Reset the ID. This will force store() to create a new record.
 		$this->set('id', 0);
@@ -566,17 +567,25 @@ class Asset extends Base
 			$cconfig = Component::params('com_courses');
 
 			// Build the upload path if it doesn't exist
-			$originalDirectory = PATH_APP . DS . trim($cconfig->get('uploadpath', '/site/courses'), DS) . DS . $courseId . DS . $originalId . DS;
+			// Need to be the original course Id, NOT the next one
+			$originalDirectory = PATH_APP . DS . trim($cconfig->get('uploadpath', '/site/courses'), DS) . DS . $originalCourseId . DS . $originalId . DS;
 			$uploadDirectory = PATH_APP . DS . trim($cconfig->get('uploadpath', '/site/courses'), DS) . DS . $courseId . DS . $assetId . DS;
+
+			// Figuring out ERROR handling	
+			\Log::debug( var_export($originalDirectory, true) );
+			\Log::debug( var_export($uploadDirectory, true) );
+			\Log::debug( var_export(is_dir($uploadDirectory), true) );
 
 			// Make sure upload directory exists and is writable
 			if (!is_dir($uploadDirectory)){
 				if (!Filesystem::makeDirectory($uploadDirectory, 0755, true)){
+					\Log::debug( var_export('Server error. Unable to create upload directory', true) );
 					return array('error' => 'Server error. Unable to create upload directory');
 				}
 			}
 
 			if (!is_writable($uploadDirectory)){
+				\Log::debug( var_export('Server error. Upload directory is not writable', true) );
 				return array('error' => 'Server error. Upload directory isn\'t writable');
 			}
 

--- a/core/components/com_courses/models/assetgroup.php
+++ b/core/components/com_courses/models/assetgroup.php
@@ -498,9 +498,6 @@ class Assetgroup extends Base
 				{
 					$oldAssetId = $asset->get('id');
 
-					\Log::debug( var_export("---- BEFORE asset->copy() ----", true));
-					\Log::debug( var_export($oldAssetId, true));
-
 					if (!$asset->copy())
 					{
 						$this->setError($asset->getError());
@@ -514,10 +511,6 @@ class Assetgroup extends Base
 							'scope' => 'asset_group', 
 							'asset_id' => $oldAssetId)) as $aa)
 						{
-							\Log::debug( var_export("---- assetgroup AssetAssociation for COPY() ----", true));
-							\Log::debug( var_export($oldAssetGroupId, true));
-							
-							
 							$tbl->bind($aa);
 							$tbl->id = 0;
 							$tbl->scope_id = $this->get('id');
@@ -561,6 +554,7 @@ class Assetgroup extends Base
 	public function copyToSelectedAssetGroup(
 		$courseId=null, $offeringId=null, 
 		$unitId=null, $assetGroupParent=null, $deep=true) {
+			
 
 		// Keep a copy of the original asset group for later
 		$startingAssetGroupId     = $this->get('id');

--- a/core/components/com_courses/site/views/assets/tmpl/video.php
+++ b/core/components/com_courses/site/views/assets/tmpl/video.php
@@ -45,6 +45,10 @@ else
 
 Html::behavior('framework', true);
 
+// Default width and height
+$width  = 'auto';
+$height = 'auto';
+
 // If the video type is 'hubpresenter', perform next steps
 if ($type == 'hubpresenter')
 {


### PR DESCRIPTION
# Source JIRA card(s) and hubzero ticket(s)
https://sdx-sdsc.atlassian.net/browse/STEMED-21
https://stemedhub.org/support/ticket/1051

# Brief summary of the issue
Inside a course offering asset group, you can duplicate an asset. This is working fine, but you can only access this asset inside the same course offering unit it resides in. It seems like it should be accessible to add to another course offering unit by it's asset ID, but it's not. This feature will give an admin the ability to duplicate an asset group into any other course offering. 

# Brief summary of the fix
Had to create an entirely new form, new API with javascript to grab updated course data, and had to create new methods to duplicate assets. This new feature was created from branching off of 2.2.22, which is currently the old CMS version that stemedhub is running. 

# Screenshots showing the featured solution
![image](https://github.com/user-attachments/assets/cedcd46e-476c-4f38-a4e8-af7c06caed55)
![image](https://github.com/user-attachments/assets/6802ce41-3816-4b05-b34f-1682de07c7cf)
![image](https://github.com/user-attachments/assets/9f80a4da-3e6f-437f-8410-9d569cb1ecce)
![image](https://github.com/user-attachments/assets/b5ce3de1-fcfd-4546-8f7a-cf7b67765bf1)
![image](https://github.com/user-attachments/assets/3095f413-2591-402b-b3e5-8e4c981d5caf)
![image](https://github.com/user-attachments/assets/de7938fd-4105-4a7b-a202-257a922fcb65)

# Brief summary of your testing
Tried it on https://stage.stemedhub.org/. Will ask client to test on stage when it is ready. We want the client to try it out on stage before it is released. 

# Do the change needs to be hotfixed to any production hubs before a normal core rollout
No, not at this moment. But we can ask client whether she wants it out sooner than later. 

# Double check someone is assigned to review the ticket
Yes - Nick and David