### PR TITLE
Optimize the code for accessing ORCID and organization id in JSON+LD

### DIFF
--- a/core/plugins/publications/jsonld/jsonld.php
+++ b/core/plugins/publications/jsonld/jsonld.php
@@ -104,8 +104,6 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 
 			$givenName = $contributor->givenName;
 			$familyName = $contributor->surname;
-			$orcid = $contributor->orcid;
-			$orgid = $contributor->orgid;
 
 			if (!$givenName)
 			{
@@ -139,9 +137,9 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 				'familyName' => $familyName
 			);
 			
-			if ($orcid)
+			if ($contributor->orcid)
 			{
-				$author['@id'] = "https://orcid.org/" . $orcid;
+				$author['@id'] = "https://orcid.org/" . $contributor->orcid;
 			}
 
 			if ($contributor->organization)
@@ -151,9 +149,9 @@ class plgPublicationsJsonld extends \Hubzero\Plugin\Plugin
 					'name'  => $contributor->organization
 				);
 				
-				if ($orgid)
+				if ($contributor->orgid)
 				{
-					$org['@id'] = $orgid;
+					$org['@id'] = $contributor->orgid;
 				}
 
 				$author['affiliation'] = $org;


### PR DESCRIPTION
PURR Ticket: https://purr.purdue.edu/support/ticket/2557

The ORCID and organization (organization id) for the author in publication are all optional, so the publication submitter might not enter them when submitting a publication. So, it's better to check whether ORCID and organization id (it is acquired by quering organization name on Research Organization Registry) are all available before adding them to JSON+LD metadata set. 

In JSON+LD plugin, add ORCID and organization id to metadata set only when each of them is available.

Accessing a publication page, so the page is accessible. Check head in the source of the page to see if ORCID and organization id is available, they should appear in JSON+LD metadata set.
