### PR TITLE
[PURR][#2561]Fix issue that doi is created when submitting a publication that has been reverted before

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -927,7 +927,8 @@ class Doi extends Obj
 	}
 
 	/**
-	 * Run cURL to register metadata. When input $doi is null, it is going to create DOI on DataCite.
+	 * Run cURL to register metadata. When input $doi is null as well as only DOI shoulder is set in $url, 
+	 * it is going to create DOI on DataCite.
 	 *
 	 * @param	string	$url
 	 * @param	array	$postVals
@@ -941,9 +942,9 @@ class Doi extends Obj
 		curl_setopt($ch, CURLOPT_USERPWD, $this->_configs->dataciteUserPW);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $postvals);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:text/plain;charset=UTF-8', 'Content-Length: ' . strlen($postvals)));
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/xml;charset=UTF-8'));
 		curl_setopt($ch, CURLOPT_FAILONERROR, true);
-		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
 
 		$response = curl_exec($ch);
 
@@ -992,7 +993,7 @@ class Doi extends Obj
 		curl_setopt($ch, CURLOPT_USERPWD, $this->_configs->dataciteUserPW);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $postvals);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:text/plain;charset=UTF-8', 'Content-Length: ' . strlen($postvals)));
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:text/plain;charset=UTF-8'));
 		curl_setopt($ch, CURLOPT_FAILONERROR, true);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
 
@@ -1020,7 +1021,7 @@ class Doi extends Obj
 	/**
 	 * Register DOI metadata. This is the first step to create DOI name and register metadata on DataCite.
 	 *
-	 * @param  string  $doi  - It is null when the function is used for DOI registration. Otherwise, the function is used for updating DOI state on DataCite.
+	 * @param  string  $doi
 	 *
 	 * @return string $doi
 	 */
@@ -1083,7 +1084,7 @@ class Doi extends Obj
 	}
 
 	/**
-	 * Update DOI metadata
+	 * Update DOI metadata on DataCite
 	 *
 	 * @param   string   $doi
 	 *
@@ -1105,16 +1106,16 @@ class Doi extends Obj
 			return false;
 		}
 
-		$metadataURL = $this->_configs->dataciteServiceURL . DS . 'metadata';
+		$metadataURL = $this->_configs->dataciteServiceURL . DS . 'metadata' . DS . $doi;
 		$xml = $this->buildXml($doi);
 
 		$ch = curl_init($metadataURL);
 		curl_setopt($ch, CURLOPT_USERPWD, $this->_configs->dataciteUserPW);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:text/plain;charset=UTF-8', 'Content-Length: ' . strlen($xml)));
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/xml;charset=UTF-8'));
 		curl_setopt($ch, CURLOPT_FAILONERROR, true);
-		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
 
 		$response = curl_exec($ch);
 
@@ -1124,6 +1125,7 @@ class Doi extends Obj
 		}
 
 		$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
 
 		curl_close($ch);
 
@@ -1426,7 +1428,7 @@ class Doi extends Obj
 			$ch = curl_init($url);
 			curl_setopt($ch, CURLOPT_USERPWD, $this->_configs->dataciteUserPW);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:text/plain;charset=UTF-8'));
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/plain;charset=UTF-8'));
 			curl_setopt($ch, CURLOPT_FAILONERROR, true);
 			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
 
@@ -1445,10 +1447,8 @@ class Doi extends Obj
 				return false;
 			}
 		}
-		elseif ($stateSwitch == self::STATE_FROM_DRAFTREADY_TO_PUBLISHED)
-		{
-			return $this->registerMetadata($doi);
-		}
+		
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
https://purr.purdue.edu/support/ticket/2561

A new DOI is created when submitting a publication that has been reverted before.

A publication can be reverted by submitter when it is published and is still within 30-day grace period. However, we found an issue that a new DOI is going to be created on DataCite when user submits the publication, which was reverted from published to draft. (The submitter reverted the publication to draft because a few changes to the datasets are needed). This is a bug that need to be fixed because a DOI has been created when the publication was submitted for the first time. The same DOI should go with the publication all the time no matter what actions has been taken by users through PURR web user interface.

The code change is to remove the operation of registering dataset on DataCite which leads to new DOI created, when submitting a dataset that is in draft ready status (The dataset has been reverted from published to draft).

Test:
1. User submits a publication and administrator approves it.
2. In the project->publications, user reverts the publication to draft, makes changes, then submits it again.
3. Login on doi.test.datacite.org to see there isn't any new DOI created for the publication. The expected result is that you don't find any new DOI created for the dataset, and only see the DOI that was created in step 1 process.


