### PR TITLE
[PURR][#2564]Fix the misalignment issue in adding new author user interface

### DIFF
--- a/core/plugins/projects/team/assets/css/selector.css
+++ b/core/plugins/projects/team/assets/css/selector.css
@@ -152,7 +152,7 @@
 		display: inline-block;
 		width: 48%;
 		margin: 0;
-		text-align: right;
+		text-align: left;
 	}
 	#abox-content form.add-author label {
 		width: 100%;
@@ -164,14 +164,14 @@
 		margin: 0.5em 0;
 	}
 	.block-liner {
-		margin-right: 1.5em;
-		text-align: right;
+		margin: 0.5em 0;
+		text-align: left;
 	}
 	.block-liner input {
 		width: 76%;
 	}
 	.invite-question {
-		padding: 1em 3em;
+		padding: 1em 0 0 0;
 		font-weight: bold;
 	}
 	.add-author .token-input-list-acm {
@@ -292,4 +292,10 @@
 	.ui-autocomplete .ui-menu-item:hover {
 		background: #f1f1f1;
 		cursor: pointer;
+	}
+	.quick-add label{
+		text-transform: none;
+	}
+	ul.token-input-list-acm li input {
+		width:auto !important; 
 	}

--- a/core/plugins/projects/team/views/selector/tmpl/newauthor.php
+++ b/core/plugins/projects/team/views/selector/tmpl/newauthor.php
@@ -40,10 +40,9 @@ if (count($this->authors) > 0)
 				<input type="hidden" name="id" value="<?php echo $this->model->get('id'); ?>" />
 			<?php } ?>
 		</fieldset>
-		<p class="requirement"><?php echo Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_ADD_NEW'); ?></p>
 		<div id="quick-add" class="quick-add">
 			<?php // if ($this->model->isProvisioned()) { ?>
-				<div class="autoc">
+				<div class="block">
 					<label>
 						<span class="formlabel"><?php echo ucfirst(Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_LOOK_UP_BY_ID')); ?>:</span>
 						<?php
@@ -100,16 +99,16 @@ if (count($this->authors) > 0)
 				</div>
 			<?php //} ?>
 			<div class="block">
-				<div class="inlineblock">
+				<div class="block-liner">
 					<label for="firstName">
 						<span class="formlabel"><?php echo ucfirst(Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_FIRST_NAME')); ?>*:</span>
-						<input type="text" name="firstName" id="firstName" class="inputrequired" value="" maxlength="255" />
+						<input type="text" name="firstName" id="firstName" class="long" value="" maxlength="255" />
 					</label>
 				</div>
-				<div class="inlineblock">
+				<div class="block-liner">
 					<label for="lastName">
 						<span class="formlabel"><?php echo ucfirst(Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_LAST_NAME')); ?>*:</span>
-						<input type="text" name="lastName" id="lastName" class="inputrequired" value="" maxlength="255" />
+						<input type="text" name="lastName" id="lastName" class="long" value="" maxlength="255" />
 					</label>
 				</div>
 			</div>
@@ -117,7 +116,7 @@ if (count($this->authors) > 0)
 				<div class="block-liner">
 					<label for="organization">
 						<span class="formlabel"><?php echo ucfirst(Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_ORGANIZATION')); ?>*:</span>
-						<input type="text" class="inputrequired" name="organization" id="organization" value="" maxlength="255" />
+						<input type="text" class="long" name="organization" id="organization" value="" maxlength="255" />
 						<?php
                             // Add in class for JS selector to conditionally retrieve data from RoR Api
                             if (\Component::params('com_members')->get('rorApi')) {
@@ -132,7 +131,7 @@ if (count($this->authors) > 0)
 				<div class="block-liner">
 					<label for="orcid">
 						<span class="formlabel"><?php echo Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_ORCID'); ?></span>
-						<input type="text" name="orcid" id="orcid" value="" maxlength="255" /><span class="optional"><?php echo Lang::txt('OPTIONAL'); ?></span>
+						<input type="text" class="long" name="orcid" id="orcid" value="" maxlength="255" /><span class="optional"><?php echo Lang::txt('OPTIONAL'); ?></span>
 					</label>
 				</div>
 			</div>
@@ -142,7 +141,7 @@ if (count($this->authors) > 0)
 					<div class="block-liner">
 					<label for="email">
 						<span class="formlabel"><?php echo ucfirst(Lang::txt('PLG_PROJECTS_TEAM_SELECTOR_EMAIL')); ?>:</span>
-						<input type="text"  name="email" value="" maxlength="255" />
+						<input type="text" class="long" name="email" value="" maxlength="255" />
 					</label>
 					</div>
 				</div>


### PR DESCRIPTION
https://purr.purdue.edu/support/ticket/2564

The text fields on GUI of the adding new author are not aligned to the left as 
![add_new_author_disorder](https://github.com/user-attachments/assets/28320a98-018a-471c-add0-eb929c1a01a1)
shown. 

The changes are aligning all the labels and text fields to the left.

1. Create a file publication.
2. In Authors section, click "Select author(s)" -> "Add an author" to see if the GUI looks as expected 
![new_GUI_for_adding_new_author](https://github.com/user-attachments/assets/9c0e7aa7-6534-4342-81be-21eaaad7ca79)

Jerry
