### PR TITLE
[PURR][#2568]Keep the organization as what it enters by publication submitter

### DIFF
--- a/core/components/com_publications/tables/author.php
+++ b/core/components/com_publications/tables/author.php
@@ -317,12 +317,12 @@ class Author extends Table
 						$res->orcid = $user->get('orcid');
 					}
 					
-					if (!empty($user->get('organization')))
+					if (empty($res->organization) && !empty($user->get('organization')))
 					{
 						$res->organization = $user->get('organization');
 					}
 					
-					if (!empty($user->get('orgid')))
+					if (empty($res->orgid) && !empty($user->get('orgid')))
 					{
 						$res->orgid = $user->get('orgid');
 					}


### PR DESCRIPTION
PURR Ticket: https://purr.purdue.edu/support/ticket/2568

Keep the changes that dataset submitter makes to the author's organization in publication submitting workflow

Currently, the author's organization is set to what it is in the user profile when the author is a PURR/Hub user, even if the publication submitter has edited and saved the organization for such author through author editing user interface in publication submission workflow. However, we want to keep what the submitter enters in the organization text field rather than setting to the organization value in PURR/Hub user's profile.

The code changes includes setting the organization value of an author, as well as hub user, to what it is in the hub user's profile, if the author's organization is empty. 

Test:
1. Initiate a publication. In author section, choose a PURR user as author.
2. Click the edit button on right of the author. Set the organization to "Purdue University West Lafayette" if it is empty. If it is not empty, set the organization to a different organization name, such as "Indiana University". Then save the changes.
3. Publish the dataset and check the organization on the publication page to see if the organization for such author that you edited is what you have set.

The test result meets the expectation in local development environment.

Jerry
