### PR TITLE
[PURR][#2572]Fix the issue that additional doc link hidden behind download button

### DIFF
--- a/core/components/com_publications/site/assets/css/publications.css
+++ b/core/components/com_publications/site/assets/css/publications.css
@@ -434,7 +434,6 @@ p.doi {
 	padding-bottom: 0.5em;
 }
 .viewalldocs {
-	margin-top: -1em;
 	font-size: 85%;
 	padding: 0 0 0.8em 30px;
 	background: url("../img/childlink.gif") 10px 0 no-repeat;


### PR DESCRIPTION
PURR ticket: https://purr.purdue.edu/support/ticket/2572

The link to additional docs of publication is hidden behind the download button. Please see screenshot in ticket. We expect the link display under the download button. 

The issue is caused by a margin setting for viewalldocs class in publication.css. The link displays properly under the download button after the margin setting is removed.

Test:
1. Access a file publication page such as https://purr.purdue.edu/publications/4245/1 to see if the link to additional doc shows behind the download button or under the download button.

Jerry
