### PR TITLE
[PURR][#2578]Add award number to grant management page and info page

### DIFF
--- a/core/components/com_projects/site/views/projects/tmpl/_info.php
+++ b/core/components/com_projects/site/views/projects/tmpl/_info.php
@@ -34,6 +34,7 @@ $config = $this->model->config();
 						<p>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_TITLE'); ?>:</span> <?php echo $this->model->params->get( 'grant_title'); ?></span>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_PI'); ?>:</span> <?php echo $this->model->params->get( 'grant_PI', 'N/A'); ?></span>
+							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_AWARD_NUMBER'); ?>:</span> <?php echo $this->model->params->get( 'award_number', 'N/A'); ?></span>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_AGENCY'); ?>:</span> <?php echo $this->model->params->get( 'grant_agency', 'N/A'); ?></span>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_BUDGET'); ?>:</span> <?php echo $this->model->params->get( 'grant_budget', 'N/A'); ?></span>
 							<?php if ($this->model->access('manager')) { ?>

--- a/core/components/com_projects/site/views/projects/tmpl/review.php
+++ b/core/components/com_projects/site/views/projects/tmpl/review.php
@@ -100,6 +100,13 @@ if ($this->getError()) {
 			</tr>
 			<tr>
 				<td>
+					<label><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_AWARD_NUMBER'); ?>:
+					 <input name="award_number" maxlength="250" type="text" value="<?php echo $this->params->get('award_number'); ?>"  />
+					</label>
+				</td>
+			</tr>
+			<tr>
+				<td>
 					<label for "grant_approval" class="<?php if ($approved) { echo ' spsapproved';
 } else { echo 'spsapproval'; } ?>"><?php echo $approved
 						? ucfirst(Lang::txt('COM_PROJECTS_APPROVAL_CODE_APPROVED'))

--- a/core/plugins/projects/info/views/view/tmpl/default.php
+++ b/core/plugins/projects/info/views/view/tmpl/default.php
@@ -32,6 +32,7 @@ $config  = $this->model->config();
 						<p>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_TITLE'); ?>:</span> <?php echo $this->model->params->get( 'grant_title'); ?></span>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_PI'); ?>:</span> <?php echo $this->model->params->get( 'grant_PI', 'N/A'); ?></span>
+							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_AWARD_NUMBER'); ?>:</span> <?php echo $this->model->params->get( 'award_number', 'N/A'); ?></span>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_AGENCY'); ?>:</span> <?php echo $this->model->params->get( 'grant_agency', 'N/A'); ?></span>
 							<span class="block"><span class="faded"><?php echo Lang::txt('COM_PROJECTS_SETUP_TERMS_GRANT_BUDGET'); ?>:</span> <?php echo $this->model->params->get( 'grant_budget', 'N/A'); ?></span>
 							<?php if ($this->model->access('manager')) { ?>


### PR DESCRIPTION
PURR ticket: https://purr.purdue.edu/support/ticket/2578

The award number text field is not available on project grant information management dialog, which can be accessed through project manage button on sponsored program review page (Such as https://purr.purdue.edu/projects/browse?reviewer=sponsored). The award number text field is also not available on the project info page.

The changes are to add the award number text field to both of these GUIs.

Test:
1. Access sponsored program review page, such as https://purr.purdue.edu/projects/browse?reviewer=sponsored. Click the manage button on the project card where the project is in pending status.
2. Check whether there is any award number text field on popping up dialog.
3. Login on PURR and access any info tab page of your project, check if the award number displays along with title, PI and other grant information.

They all pass test in local development environment.

Jerry
