### PR TITLE
[PURR][#2583]Replace OFR API with ROR API for organization query

### DIFF
--- a/core/components/com_members/config/config.xml
+++ b/core/components/com_members/config/config.xml
@@ -268,6 +268,7 @@
 			<option value="0">No</option>
 			<option value="1">Yes</option>
 		</field>
+		<field name="rorApiVersion" type="text" menu="hide" default="" label="Research Organization Registry API Version Number" description="The version number of Research Organization Registry API, such as 'v2'." />
 		<field name="@spacer" type="spacer" default="" label="" description="" />
 		<field name="orcid_service" type="list" default="public" label="ORCID Service" description="Select the service to use for ORCID. Sandbox is for testing and debugging purposes. The Public service only allows for searching records, new ID creation is not allowed.">
 			<option value="public">Public (search only)</option>

--- a/core/components/com_members/helpers/utility.php
+++ b/core/components/com_members/helpers/utility.php
@@ -282,4 +282,40 @@ class Utility
 
 		return ($result) ? true : false;
 	}
+	
+	/**
+	 * Escape the special characters that might exist in the organization names on Research Organization Registry 
+	 *
+	 * @param   string  $term
+	 * @return  string
+	 */
+	public static function escapeSpecialChars($term)
+	{
+		$special_chars = [
+			"+" => "\+", 
+			"-" => "\-", 
+			"=" => "\=", 
+			"&&" => "\&&", 
+			"||" => "\||", 
+			">" => "\>", 
+			"<" => "\<", 
+			"!" => "\!", 
+			"(" => "\(", 
+			")" => "\)", 
+			"{" => "\{", 
+			"}" => "\}", 
+			"[" => "\[", 
+			"]" => "\]", 
+			"^" => "\^", 
+			'"' => '\"', 
+			"~" => "\~", 
+			"*" => "\*", 
+			"?" => "\?", 
+			":" => "\:", 
+			"\\" => "\\\\", 
+			"/" => "\/"
+		];
+    
+		return str_replace(array_keys($special_chars), array_values($special_chars), $term);
+	}
 }

--- a/core/components/com_members/site/controllers/profiles.php
+++ b/core/components/com_members/site/controllers/profiles.php
@@ -1602,8 +1602,7 @@ class Profiles extends SiteController
 		// If RoR Api is turned off because of failed API or if key doesn't exist, don't retrieve list from Api.
         $useRorApi = \Component::params('com_members')->get('rorApi');
 		if (isset($profile['organization']) && !empty($profile['organization']) && $useRorApi){
-			$id = $this->getOrganizationId($profile['organization']);
-			$profile['orgid'] = $id;
+			$profile['orgid'] = $this->getOrganizationId($profile['organization']);
 		}
 
 		$old = Profile::collect($member->profiles);
@@ -1994,43 +1993,52 @@ class Profiles extends SiteController
 	 */
 	public function getOrganizationsTask() {
 		$term = trim(Request::getString('term', ''));
+		$term = \Components\Members\Helpers\Utility::escapeSpecialChars($term);
+		
+		$verNum = \Component::params('com_members')->get('rorApiVersion');
+		
+		if (!empty($verNum))
+		{
+			$queryURL = "https://api.ror.org/$verNum/organizations?query.advanced=names.value:" . urlencode($term);
+			
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $queryURL);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-		if (strpos($term, ' ') !== false){
-			$term = str_replace(' ', '+', $term);
+			$result = curl_exec($ch);
+
+			if (!$result){
+				return false;
+			}
+
+			$info = curl_getinfo($ch);
+
+			$code = $info['http_code'];
+
+			if (($code != 201) && ($code != 200)){
+				return false;
+			}
+
+			$organizations = [];
+
+			$resultObj = json_decode($result);			
+
+			foreach ($resultObj->items as $orgObj)
+			{
+				foreach ($orgObj->names as $nameObj)
+				{
+					if ($nameObj->lang == "en" && !in_array($nameObj->value, $organizations))
+					{
+						$organizations[] = $nameObj->value;
+					}
+				}
+			}
+
+			curl_close($ch);
+
+			echo json_encode($organizations);
+			exit();
 		}
-
-		$queryURL = 'https://api.ror.org/organizations?query=' . $term;
-
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $queryURL);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-		$result = curl_exec($ch);
-
-		if (!$result){
-			return false;
-		}
-
-		$info = curl_getinfo($ch);
-
-		$code = $info['http_code'];
-
-		if (($code != 201) && ($code != 200)){
-			return false;
-		}
-
-		$organizations = [];
-
-		$resultObj = json_decode($result);
-
-		foreach ($resultObj->items as $orgObj){
-			$organizations[] = $orgObj->name;
-		}
-
-		curl_close($ch);
-
-		echo json_encode($organizations);
-		exit();
 	}
 
 	/**
@@ -2041,46 +2049,48 @@ class Profiles extends SiteController
 	 */
 	public function getOrganizationId($organization){
 		$org = trim($organization);
-		$id = "none";
+		$orgQry = \Components\Members\Helpers\Utility::escapeSpecialChars($org);
+		
+		$verNum = \Component::params('com_members')->get('rorApiVersion');
+		
+		if (!empty($verNum))
+		{
+			$queryURL = "https://api.ror.org/$verNum/organizations?query.advanced=names.value:" . urlencode($orgQry);
+			
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $queryURL);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-		if (strpos($org, ' ') !== false){
-			$org = str_replace(' ', '+', $org);
-		}
+			$result = curl_exec($ch);
 
-		$queryURL = "https://api.ror.org/organizations?query=" . $org;
-
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $queryURL);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-		$result = curl_exec($ch);
-
-		if (!$result){
-			return false;
-		}
-
-		$info = curl_getinfo($ch);
-
-		$code = $info['http_code'];
-
-		if (($code != 201) && ($code != 200)){
-			return false;
-		}
-
-		$resultObj = json_decode($result);
-
-		$org = str_replace('+', ' ', $org);
-
-		foreach ($resultObj->items as $orgObj){
-			if ($org == $orgObj->name){
-				$id = $orgObj->id;
-				break;
+			if (!$result){
+				return false;
 			}
+
+			$info = curl_getinfo($ch);
+
+			$code = $info['http_code'];
+
+			if (($code != 201) && ($code != 200)){
+				return false;
+			}
+
+			$resultObj = json_decode($result);
+			
+			foreach ($resultObj->items as $orgObj)
+			{
+				foreach ($orgObj->names as $nameObj)
+				{
+					if (strcmp($nameObj->value, $org) == 0)
+					{
+						curl_close($ch);
+						return $orgObj->id;
+					}
+				}
+			}
+			
+			curl_close($ch);
+			return "";
 		}
-
-		curl_close($ch);
-
-		return $id;
 	}
-
 }

--- a/core/components/com_projects/site/controllers/setup.php
+++ b/core/components/com_projects/site/controllers/setup.php
@@ -23,6 +23,7 @@ use App;
 require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'orm' . DS . 'description' . DS . 'field.php';
 require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'orm' . DS . 'description.php';
 require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'orm' . DS . 'project.php';
+require_once dirname(dirname(dirname(__DIR__))) . DS . 'com_members' . DS . 'helpers' . DS . 'utility.php';
 
 /**
  * Projects setup controller class
@@ -1214,52 +1215,54 @@ class Setup extends Base
 	public function getGrantAgencyTask()
 	{
 		$term = trim(Request::getString('term', ''));
+		$term = \Components\Members\Helpers\Utility::escapeSpecialChars($term);
 		
-		if (strpos($term, ' ') !== false)
+		$verNum = \Component::params('com_members')->get('rorApiVersion');
+		
+		if (!empty($verNum))
 		{
-			$term = str_replace(' ', '+', $term);
+			$queryURL = "https://api.ror.org/$verNum/organizations?filter=types:funder&query.advanced=names.value:" . urlencode($term);
+			
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $queryURL);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			
+			$result = curl_exec($ch);
+			
+			if (!$result)
+			{
+				return false;
+			}
+			
+			$info = curl_getinfo($ch);
+			
+			$code = $info['http_code'];
+			
+			if (($code != 201) && ($code != 200))
+			{
+				return false;
+			}
+			
+			$agencies = [];
+			
+			$resultObj = json_decode($result);
+			
+			foreach ($resultObj->items as $orgObj)
+			{
+				foreach ($orgObj->names as $nameObj)
+				{
+					if ($nameObj->lang == "en" && !in_array($nameObj->value, $agencies))
+					{
+						$agencies[] = $nameObj->value;
+					}
+				}
+			}
+			
+			curl_close($ch);
+			
+			echo json_encode($agencies);
+			exit();
 		}
-		
-		$queryURL = "https://api.crossref.org/funders?query=" . $term . "&rows=1000";
-		
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $queryURL);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		
-		$result = curl_exec($ch);
-		
-		if (!$result)
-		{
-			return false;
-		}
-		
-		$info = curl_getinfo($ch);
-		
-		$code = $info['http_code'];
-		
-		if (($code != 201) && ($code != 200))
-		{
-			return false;
-		}
-		
-		$agencies = [];
-		
-		$resultObj = json_decode($result);
-		
-		if ($resultObj->status != "ok")
-		{
-			return false;
-		}
-		
-		foreach ($resultObj->message->items as $agencyObj)
-		{
-			$agencies[] = $agencyObj->name;
-		}
-		
-		curl_close($ch);
-		
-		echo json_encode($agencies);
-		exit();
 	}
 	
 	/**
@@ -1271,51 +1274,50 @@ class Setup extends Base
 	public function getGrantAgencyId($grantAgency)
 	{
 		$agency = trim($grantAgency);
+		$agencyQry = \Components\Members\Helpers\Utility::escapeSpecialChars($agency);
 		
-		if (strpos($agency, ' ') !== false)
+		$verNum = \Component::params('com_members')->get('rorApiVersion');
+		
+		if (!empty($verNum))
 		{
-			$agency = str_replace(' ', '+', $agency);
-		}
-		
-		$queryURL = "https://api.crossref.org/funders?query=" . $agency . "&rows=1000";
-		
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL, $queryURL);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		
-		$result = curl_exec($ch);
-		
-		if (!$result)
-		{
-			return false;
-		}
-		
-		$info = curl_getinfo($ch);
-		
-		$code = $info['http_code'];
-		
-		if (($code != 201) && ($code != 200))
-		{
-			return false;
-		}
-		
-		$resultObj = json_decode($result);
-		
-		$agency = str_replace('+', ' ', $agency);
-		
-		$uri = "";
-		
-		foreach ($resultObj->message->items as $agencyObj)
-		{
-			if ($agency == $agencyObj->name)
+			$queryURL = "https://api.ror.org/$verNum/organizations?filter=types:funder&query.advanced=names.value:" . urlencode($agencyQry);
+			
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $queryURL);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			
+			$result = curl_exec($ch);
+			
+			if (!$result)
 			{
-				$uri = $agencyObj->uri;
-				break;
+				return false;
 			}
+			
+			$info = curl_getinfo($ch);
+			
+			$code = $info['http_code'];
+			
+			if (($code != 201) && ($code != 200))
+			{
+				return false;
+			}
+			
+			$resultObj = json_decode($result);
+			
+			foreach ($resultObj->items as $orgObj)
+			{
+				foreach ($orgObj->names as $nameObj)
+				{
+					if (strcmp($nameObj->value, $agency) == 0)
+					{
+						curl_close($ch);
+						return $orgObj->id;
+					}
+				}
+			}
+			
+			curl_close($ch);
+			return "";
 		}
-		
-		curl_close($ch);
-		
-		return $uri;
 	}
 }


### PR DESCRIPTION
PURR Ticket: https://purr.purdue.edu/support/ticket/2583

Currently when project manger types the funding agency name in funding agency text filed in project setting, Hub/PURR utilizes the Crossref Unified Resource API(https://api.crossref.org/swagger-ui/index.html) to query the funding agency names on Open Funder Registry, then display the matched names in a list for manager to choose and save. However, Crossref that manages the Open Funder Registry has announced that they are going to deprecate the OFR and merge it with Research Organization Registry (https://ror.readme.io/docs/funder-registry). In this case, we are going to replace the Crossref Unified Resource API with ROR REST API on PURR/Hub, so that project manager can look up and save the funding agency names that come from Research Organization Registry.

The code changes include:
1. Create an ROR API version number text filed in members component configuration options, so that the ROR API version is configurable. If there is a ROR API version update in the future, we can set the right version number through the member component admin interface. By November 2024, the ROR API version 2 is recommended (https://ror.readme.io/v2/docs/rest-api) and we need set "v2" in the ROR API version number text field on member component through admin interface.
2. Replace the CrossRef API for querying funding agency name with the ROR API in project component. A filter to funder is added in the query.
3. According to ROR API V2 document, use the ROR API version 2 endpoint for advanced query. 
4. Modify the output process according to data structure in ROR API version 2 query result.

Test for organization setting in user profile:
0. Set "v2" in the ROR API Version number text field in member component configurable options on admin interface.
1. Login on PURR and access the profile page.
2. Click on the organization section and enter the organization you are affiliated with in organization text field. It should pop up a list of organization names that match what you enter. You choose the exact one and save the entry.
3. Revisit the organization section and check what you selected in step 2 is displaying in organization text field or not. Check the organization and organization id(orgid)  in user profile table, where the organization id(orgid)  is the ROR id for the organization.
4. Login on admin interface, click on menu users->members, click one user name in the list to edit the user profile, enter an organization name or change the organization name and save the changes. The new organization name should appear in user profile on user profile page. The organization name and organization id(orgid) should be the exact name and id in user profile table.
5. Initiate a publication,  add an author to the publication, set the organization and save the changes. Check the publication author table to see if there are organization and organization id for the newly-added author.

Funding agency setting test:
1. Access settings in your project. Select "Yes" for question "Is this project supported by a research grant?".
2. Enter the funding agency name such as "national science foundation" in funding agency text field. It is going to display a list of names in dropdown. Choose the "National Science Foundation" and click the save changes button.
3. Check the params column in projects table to see if grant_agency is set to "National Science Foundation" and whether the grant_agency_id is set to "https://ror.org/021nxhr62".

Test is done in local environment and functions work as expected.

Jerry
