### PR TITLE
Fix import path

### DIFF
--- a/core/modules/mod_languages/helper.php
+++ b/core/modules/mod_languages/helper.php
@@ -49,7 +49,7 @@ class Helper extends Module
 	 */
 	public static function getList(&$params)
 	{
-		require_once \Component::path('com_menus') . '/admin/helpers/menus.php';
+		require_once \Component::path('com_menus') . '/helpers/menus.php';
 
 		$lang = Lang::getRoot();
 		$menu = App::get('menu');

--- a/core/plugins/system/languagefilter/languagefilter.php
+++ b/core/plugins/system/languagefilter/languagefilter.php
@@ -8,7 +8,7 @@
 // no direct access
 defined('_HZEXEC_') or die;
 
-require_once Component::path('com_menus') . '/admin/helpers/menus.php';
+require_once Component::path('com_menus') . '/helpers/menus.php';
 require_once Component::path('com_languages') . '/helpers/multilangstatus.php';
 
 /**


### PR DESCRIPTION
This MR has commits broken from MR #1740. These commits aim to fix wrong import paths found in a language module and plugin
