### PR TITLE
Avoid passing null to trim

### DIFF
--- a/core/components/com_templates/admin/views/styles/tmpl/edit.php
+++ b/core/components/com_templates/admin/views/styles/tmpl/edit.php
@@ -103,7 +103,7 @@ $this->js();
 						</tr>
 					<?php endif; ?>
 					<?php if ($this->item->parent->xml) : ?>
-						<?php if ($text = trim($this->item->parent->xml->get('description'))) : ?>
+						<?php if ($text = trim($this->item->parent->xml->get('description', ''))) : ?>
 							<tr>
 								<th scope="row"><?php echo Lang::txt('COM_TEMPLATES_TEMPLATE_DESCRIPTION'); ?></th>
 								<td><?php echo Lang::txt($text); ?></td>


### PR DESCRIPTION
Fix a new null param mistake that I found for selecting the default template