### PR TITLE
Fix php82 deprecated comparison

### DIFF
--- a/core/plugins/groups/announcements/announcements.php
+++ b/core/plugins/groups/announcements/announcements.php
@@ -387,7 +387,7 @@ class plgGroupsAnnouncements extends \Hubzero\Plugin\Plugin
 		}
 
 		// Are we creating the announcement?
-		if (!isset($fields['id']) || $fields['id'] == 0)
+		if (!isset($fields['id']) || !$fields['id'])
 		{
 			$fields['id']         = 0;
 			$fields['scope']      = 'group';

--- a/core/plugins/groups/calendar/calendar.php
+++ b/core/plugins/groups/calendar/calendar.php
@@ -674,7 +674,7 @@ class plgGroupsCalendar extends \Hubzero\Plugin\Plugin
 		}
 
 		//if we are updating set modified time and actor
-		if (!isset($event['id']) || $event['id'] == 0)
+		if (!isset($event['id']) || !$event['id'])
 		{
 			$event['created']    = Date::toSql();
 			$event['created_by'] = $this->user->get('id');


### PR DESCRIPTION
This MR updates all deprecated comparisons between empty string and 0.

In PHP 5.6, `"" == 0` was true. This is no longer the case for PHP 8.2, which results in some behaviour errors.