### PR TITLE
Fix getting offset of bool type

### DIFF
--- a/core/plugins/projects/files/files.php
+++ b/core/plugins/projects/files/files.php
@@ -571,7 +571,7 @@ class plgProjectsFiles extends \Hubzero\Plugin\Plugin
 
 			// Set params
 			$used = array();
-			if (!$reuse && $view->publication->_attachments['elements'])
+			if (!$reuse && $view->publication->_attachments && $view->publication->_attachments['elements'])
 			{
 				foreach ($view->publication->_attachments['elements'] as $o => $elms)
 				{


### PR DESCRIPTION
This is to deal with the case where `$results` on line 214 is an empty array. Therefore, on line 216, `$results` is falsey, so the entire function will return `false`.

Somewhere in the code, I don't recall where, tries to get an offset from the return value of this function and raises `getting offset of bool type`