### PR TITLE
Fix a deprecated regex

### DIFF
--- a/core/plugins/projects/links/helpers/simple_html_dom.php
+++ b/core/plugins/projects/links/helpers/simple_html_dom.php
@@ -364,7 +364,7 @@ class simple_html_dom_node
 	protected function parse_selector($selector_string)
 	{
 		// pattern of CSS selectors, modified from mootools
-		$pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([, ]+)/is";
+		$pattern = "/([\w:\-*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([, ]+)/is";
 		preg_match_all($pattern, trim($selector_string).' ', $matches, PREG_SET_ORDER);
 		$selectors = array();
 		$result = array();


### PR DESCRIPTION
'-' had a different meaning for PHP 5.6 from PHP 8.2.

This MR makes change to the regex so they behave the same way as before 