### PR TITLE
Fix php82 deprecated date functions

### DIFF
--- a/core/components/com_support/site/controllers/tickets.php
+++ b/core/components/com_support/site/controllers/tickets.php
@@ -175,7 +175,7 @@ class Tickets extends SiteController
 		$date = new \Hubzero\Utility\Date();
 
 		$year  = Request::getInt('year', $date->toLocal('Y'));
-		$month = strftime("%m", $date->toLocal('m'));
+		$month = $date->toLocal('m');
 
 		$this->view->year = $year;
 		$this->view->opened = array();


### PR DESCRIPTION
Replace the deprecated function `strftime`
