### PR TITLE
Fix 'Creation of dynamic property is deprecated'

### DIFF
--- a/core/libraries/Hubzero/Config/Legacy.php
+++ b/core/libraries/Hubzero/Config/Legacy.php
@@ -120,6 +120,13 @@ class Legacy extends Registry
 	);
 
 	/**
+	 * Path to the configurations.php file
+	 *
+	 * @var  string
+	 */
+	protected $file;
+
+	/**
 	 * Create a new configuration repository.
 	 *
 	 * @param   string  $path


### PR DESCRIPTION
This MR adds an attribute to a class that had that attribute dynamically created in the code