### PR TITLE
Fix macro not parsed properly issue

### DIFF
--- a/core/plugins/content/formathtml/macros/group/defaulthomepages.php
+++ b/core/plugins/content/formathtml/macros/group/defaulthomepages.php
@@ -14,7 +14,7 @@ use Plugins\Content\Formathtml\Macros\GroupMacro;
 /**
  * Group events Macro
  */
-class DefaultHomePage extends GroupMacro
+class DefaultHomePages extends GroupMacro
 {
 	/**
 	 * Allow macro in partial parsing?


### PR DESCRIPTION
This MR fixes a group announcement macro not being parsed properly (It was parsed in the literal string, i.e. `[group.annoucements()]` - something similar to that). After tracing it, turns out it's just how the class was named
