### PR TITLE
Print deleted status in admin console

### DIFF
--- a/core/components/com_publications/models/publication.php
+++ b/core/components/com_publications/models/publication.php
@@ -2376,6 +2376,10 @@ class Publication extends Obj
 				$name = Lang::txt('COM_PUBLICATIONS_VERSION_WIP');
 				break;
 
+			case self::STATE_DELETED:
+				$name = Lang::txt('COM_PUBLICATIONS_VERSION_DELETED');
+				break;
+			
 			case self::STATE_DRAFT:
 			default:
 				$name = Lang::txt('COM_PUBLICATIONS_VERSION_DRAFT');
@@ -2420,6 +2424,10 @@ class Publication extends Obj
 				$name = 'wip';
 				break;
 
+			case self::STATE_DELETED:
+				$name = 'deleted';
+				break;
+			
 			case self::STATE_DRAFT:
 			default:
 				$name = 'draft';


### PR DESCRIPTION
This PR addresses the issue of icons for deleted publications not being displayed correctly in the admin console. Currently, the function responsible for returning styles and names does not account for this case.