### PR TITLE
Fix a missing deprecated regex

### DIFF
--- a/core/plugins/projects/links/helpers/simple_html_dom.php
+++ b/core/plugins/projects/links/helpers/simple_html_dom.php
@@ -730,8 +730,8 @@ class simple_html_dom
 			return true;
 		}
 
-	   // text
-		if (!preg_match("/^[\w-:]+$/", $tag)) {
+		// text
+		if (!preg_match("/^[\w:-]+$/", $tag)) {
 			$node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
 			if ($this->char==='<') {
 				$this->link_nodes($node, false);


### PR DESCRIPTION
Fix a missing deprecated regex in `core/plugins/projects/links/helpers/simple_html_dom.php`