### PR TITLE
Fix use array key exists on non array var

### DIFF
--- a/core/components/com_publications/helpers/html.php
+++ b/core/components/com_publications/helpers/html.php
@@ -1333,12 +1333,12 @@ class Html
 			self::getMIMEtypesOfPrimarySupportFiles($publication_id, $publication_version_id, $secret, 1, $attachments, $mimeTypes);
 		}
 		
-		if (array_key_exists(2, $attachments))
+		if (is_array($attachments) && array_key_exists(2, $attachments))
 		{
 			self::getMIMEtypesOfPrimarySupportFiles($publication_id, $publication_version_id, $secret, 2, $attachments, $mimeTypes);
 		}
 		
-		if (array_key_exists(3, $attachments))
+		if (is_array($attachments) && array_key_exists(3, $attachments))
 		{
 			self::getMIMEtypesOfGalleryFile($publication_id, $publication_version_id, $mimeTypes);
 		}


### PR DESCRIPTION
This is a new error that I found when running our Hubzero site in a `php:8.2-apache` container.

This PR aims to prevent using `array_key_exists` on a non-array variable