### PR TITLE
Fix use statement with non compound has no effect

### DIFF
--- a/core/plugins/groups/calendar/helpers/userLocalizer.php
+++ b/core/plugins/groups/calendar/helpers/userLocalizer.php
@@ -9,9 +9,6 @@
 defined('_HZEXEC_') or die();
 
 use Hubzero\Utility\Arr;
-use App;
-use Config;
-use User;
 
 class UserLocalizer
 {


### PR DESCRIPTION
This PR fixes "using the `use` statement with non-compound name has no effect" PHP error, which is thrown when using `php:8.2-apache` base container