### PR TITLE
Remove quotename method call

### DIFF
--- a/core/components/com_languages/helpers/multilangstatus.php
+++ b/core/components/com_languages/helpers/multilangstatus.php
@@ -25,7 +25,7 @@ abstract class Multilangstatus
 		$db = App::get('db');
 		$query = $db->getQuery();
 		$query->select('COUNT(*)');
-		$query->from($db->quoteName('#__menu'));
+		$query->from('#__menu');
 		$query->where('home = 1');
 		$query->where('published = 1');
 		$query->where('client_id = 0');
@@ -44,7 +44,7 @@ abstract class Multilangstatus
 		$db = App::get('db');
 		$query = $db->getQuery();
 		$query->select('COUNT(*)');
-		$query->from($db->quoteName('#__modules'));
+		$query->from('#__modules');
 		$query->where('module = ' . $db->quote('mod_languages'));
 		$query->where('published = 1');
 		$query->where('client_id = 0');
@@ -99,7 +99,7 @@ abstract class Multilangstatus
 		$query = $db->getQuery();
 		$query->select('language');
 		$query->select('id');
-		$query->from($db->quoteName('#__menu'));
+		$query->from('#__menu');
 		$query->where('home = 1');
 		$query->where('published = 1');
 		$query->where('client_id = 0');

--- a/core/modules/mod_login/helper.php
+++ b/core/modules/mod_login/helper.php
@@ -36,7 +36,7 @@ class Helper extends Module
 			$query = $db->getQuery();
 
 			$query->select($db->quoteName('link'));
-			$query->from($db->quoteName('#__menu'));
+			$query->from('#__menu');
 			$query->where($db->quoteName('published') . '=1');
 			$query->where($db->quoteName('id') . '=' . $db->quote($itemid));
 


### PR DESCRIPTION
Using the `$db-quoteName` method results in an empty table name in the final query
