### PR TITLE
Avoid passing null to count

### DIFF
--- a/core/components/com_publications/models/attachments/file.php
+++ b/core/components/com_publications/models/attachments/file.php
@@ -527,7 +527,7 @@ class File extends Base
 		{
 			$options = array();
 
-			if (count($attachments) > 1)
+			if (count($attachments ? $attachments : []) > 1)
 			{
 				$fpath = $this->bundle($attachments, $configs, false);
 				$title = $configs->bundleTitle;
@@ -1430,7 +1430,7 @@ class File extends Base
 		$role     = $element->role;
 		$params   = $element->typeParams;
 		$required = $element->required;
-		$counter  = count($attachments);
+		$counter  = count($attachments ? $attachments : []);
 
 		// Check for correct number of files
 		if ($min > 0 && $counter < $min)


### PR DESCRIPTION
Avoid passing null to `count`
