### PR TITLE
[PURR][#2597]Fix issue with relationType attribute in DOI XML metadata

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -697,7 +697,7 @@ class Doi extends Obj
 						$citation->resourceTypeGeneral = substr(trim($citation->resourceTypeGeneral), $pos + strlen(self::DATACITE));
 					}
 					
-					if (!empty($citation->relationType))
+					if (!empty($citation->relationType) && (preg_match("/" . self::REFERENCES . "/i", $citation->relationType) || preg_match("/" . self::REFERENCEDBY . "/i", $citation->relationType)))
 					{
 						if (preg_match("/" . self::REFERENCES . "/i", $citation->relationType))
 						{
@@ -707,51 +707,51 @@ class Doi extends Obj
 						{
 							$citation->relationType = self::ISREFERENCEDBY;
 						}
-					}
-					
-					if (!empty($citation->relationType) && !empty($citation->resourceTypeGeneral))
-					{
-						if (!empty($citation->relatedIdentifier))
+						
+						if (!empty($citation->resourceTypeGeneral))
 						{
-							$xmlfile .= '<relatedIdentifier relatedIdentifierType="DOI" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . trim($citation->relatedIdentifier) . '</relatedIdentifier>';
-						}
-						else
-						{
-							if (!empty($citation->url))
+							if (!empty($citation->relatedIdentifier))
 							{
-								if (preg_match("/purl/i", $citation->url))
+								$xmlfile .= '<relatedIdentifier relatedIdentifierType="DOI" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . trim($citation->relatedIdentifier) . '</relatedIdentifier>';
+							}
+							else
+							{
+								if (!empty($citation->url))
 								{
-									$xmlfile .= '<relatedIdentifier relatedIdentifierType="PURL" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . trim($citation->url) . '</relatedIdentifier>';
-								}
-								elseif (preg_match("/handle/i", $citation->url))
-								{
-									if (preg_match("/hdl\.handle\.net/i", $citation->url))
+									if (preg_match("/purl/i", $citation->url))
 									{
-										$pos = strpos($citation->url, self::HANDLE_DOMAIN_NAME);
-										$val = substr($citation->url, $pos + strlen(self::HANDLE_DOMAIN_NAME) + 1);
+										$xmlfile .= '<relatedIdentifier relatedIdentifierType="PURL" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . trim($citation->url) . '</relatedIdentifier>';
+									}
+									elseif (preg_match("/handle/i", $citation->url))
+									{
+										if (preg_match("/hdl\.handle\.net/i", $citation->url))
+										{
+											$pos = strpos($citation->url, self::HANDLE_DOMAIN_NAME);
+											$val = substr($citation->url, $pos + strlen(self::HANDLE_DOMAIN_NAME) + 1);
+										}
+										else
+										{
+											$pos = strpos($citation->url, self::HANDLE);
+											$val = substr($citation->url, $pos + strlen(self::HANDLE) + 1);
+										}
+										$xmlfile .= '<relatedIdentifier relatedIdentifierType="Handle" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $val . '</relatedIdentifier>';
+									}
+									elseif (preg_match("/ark:/i", $citation->url) && !empty($citation->eprint))
+									{
+										$xmlfile .= '<relatedIdentifier relatedIdentifierType="ARK" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
+									}
+									elseif (preg_match("/arxiv/i", $citation->url) && !empty($citation->eprint))
+									{
+										$xmlfile .= '<relatedIdentifier relatedIdentifierType="arXiv" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
+									}
+									elseif (preg_match("/urn:/i", $citation->url) && !empty($citation->eprint))
+									{
+										$xmlfile .= '<relatedIdentifier relatedIdentifierType="URN" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
 									}
 									else
 									{
-										$pos = strpos($citation->url, self::HANDLE);
-										$val = substr($citation->url, $pos + strlen(self::HANDLE) + 1);
+										$xmlfile .= '<relatedIdentifier relatedIdentifierType="URL" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->url . '</relatedIdentifier>';
 									}
-									$xmlfile .= '<relatedIdentifier relatedIdentifierType="Handle" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $val . '</relatedIdentifier>';
-								}
-								elseif (preg_match("/ark:/i", $citation->url) && !empty($citation->eprint))
-								{
-									$xmlfile .= '<relatedIdentifier relatedIdentifierType="ARK" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
-								}
-								elseif (preg_match("/arxiv/i", $citation->url) && !empty($citation->eprint))
-								{
-									$xmlfile .= '<relatedIdentifier relatedIdentifierType="arXiv" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
-								}
-								elseif (preg_match("/urn:/i", $citation->url) && !empty($citation->eprint))
-								{
-									$xmlfile .= '<relatedIdentifier relatedIdentifierType="URN" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->eprint . '</relatedIdentifier>';
-								}
-								else
-								{
-									$xmlfile .= '<relatedIdentifier relatedIdentifierType="URL" relationType="' . $citation->relationType . '" resourceTypeGeneral="' . $citation->resourceTypeGeneral . '">' . $citation->url . '</relatedIdentifier>';
 								}
 							}
 						}


### PR DESCRIPTION
Wrong attribute value was found in DOI's XML metadata

PURR Ticket: https://purr.purdue.edu/support/ticket/2597

We found that the relationType attribute value is owner in DOI 10.4231/TDT6-YV13's XML metadata on DataCite, however, it is not a valid option for relationType attribute according to DataCite medata schema(https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/relatedidentifier/#b). This causes the error "Failed to update the DataCite DOI metadata" occur when updating the publication through admin interface.

When the submitter provides the citation information for a dataset in publication submission workflow, the relation type between the citation and the dataset is set to owner by default on Hubzero/PURR. In this case, we should not create and insert the relatedIdentifier element into the DOI's XML metadata. 

The code change is that the relationType for relatedIdentifier element in DOI's XML metadata has to be either "references" or "isReferencedBy", then the relatedIdentifier element for citation can be created in DOI's XML metadata.

Test.
1. Create a file publication and provide citation information for the publication in the submission workflow, and then submit the publication.
2. A DOI is created in step 1. Check such DOI's XML metadata on DataCite, you are expected not to see the relatedIdentifier element of citation information in it.
3. Login on admin interface, access the citation menu, and open the citation that you added in the publication submission workflow. Select "References this citation" or "Referenced by this citation" from the Context dropdown list and save the changes.
4. Approve the publication and check the DOI's XML metadata on DataCite again. You are expected to see that the relatedIdentifier element of citation appears in the XML metadata.

Local test passes.

Jerry
