### PR TITLE
Updates Forum likes and mentions

### DIFF
--- a/core/components/com_forum/api/controllers/likesv1_0.php
+++ b/core/components/com_forum/api/controllers/likesv1_0.php
@@ -52,6 +52,11 @@ class Likesv1_0 extends ApiController
 		$userId = Request::getString('userId');
 		$created = Date::of('now')->toSql();
 
+		if (!userId || (userId === 0))
+		{
+			throw new Exception("Please sign into post a Like", 404);
+		}
+
 		$db = \App::get('db');
 		$insertQuery = "INSERT INTO `#__forum_posts_like` (`threadId`, `postId`, `userId`, `created`)
 		  VALUES (?,?,?,?)";

--- a/core/components/com_forum/site/controllers/threads.php
+++ b/core/components/com_forum/site/controllers/threads.php
@@ -355,10 +355,11 @@ class Threads extends SiteController
 		$domComment->loadHTML($fields['comment']);
 		$mentionEmailList = array();
 		foreach ($domComment->getElementsByTagName('a') as $item) {
-			$hrefLink = $item->getAttribute('href');
-			if (strpos($hrefLink, 'mailto:') !== false) {
-				$mentionEmailList[] = str_replace('mailto:', "", $hrefLink);
-			}
+			$userId = $item->getAttribute('data-user-id');
+            $user = User::getInstance($userId);
+            $email = $user->get('email');
+
+            $mentionEmailList[] = $email;
 		}
 
 		// Authorization check

--- a/core/components/com_forum/site/views/threads/tmpl/_comment.php
+++ b/core/components/com_forum/site/views/threads/tmpl/_comment.php
@@ -78,41 +78,44 @@ defined('_HZEXEC_') or die();
 				<?php echo $comment; ?>
 
                 <!-- Heart and "Like" link Button -->
-                <div class="elementInline likeContainer">
-                    <a class="icon-heart like <?php if ($userLikesComment) { echo "userLiked"; } ?>" href="#"
-                       data-thread="<?php echo $this->thread->get('id'); ?>"
-                       data-post="<?php echo $this->comment->get('id'); ?>"
-                       data-user="<?php echo User::get('id'); ?>"
-                       data-user-name="<?php echo User::get('name'); ?>"
-                       data-likes-list="<?php echo $userNameLikesArray; ?>"
-                       data-count="<?php echo $countLike; ?>"
-                    ></a>
-                    <span class="likesStat <?php if ($countLike==0) { echo "noLikes"; } ?>">
-                        <?php echo ($countLike>0) ? "View Likes (" . $countLike . ")" : "No Likes"; ?>
-                    </span>
-                </div>
-                <div class="clear"></div>
+                <!-- Only show if people is logged in -->
+				<?php if (!User::isGuest()) { ?>
+					<div class="elementInline likeContainer">
+						<a class="icon-heart like <?php if ($userLikesComment) { echo "userLiked"; } ?>" href="#"
+						data-thread="<?php echo $this->thread->get('id'); ?>"
+						data-post="<?php echo $this->comment->get('id'); ?>"
+						data-user="<?php echo User::get('id'); ?>"
+						data-user-name="<?php echo User::get('name'); ?>"
+						data-likes-list="<?php echo $userNameLikesArray; ?>"
+						data-count="<?php echo $countLike; ?>"
+						></a>
+						<span class="likesStat <?php if ($countLike==0) { echo "noLikes"; } ?>">
+							<?php echo ($countLike>0) ? "View Likes (" . $countLike . ")" : "No Likes"; ?>
+						</span>
+					</div>
+					<div class="clear"></div>
 
-                <div class="whoLikedPost">
-                    <?php if (strlen($userNameLikesArray) > 0) { ?>
-                        <div class="names">
-                            <?php
-                                $nameArray = preg_split("#/#", $userNameLikesArray);
-                                $links = array();
-				foreach ($nameArray as $nameString) 
-				{
-                                    $nameArray = explode("#", $nameString);
-                                    $userName = $nameArray[0];
-                                    $userId =  $nameArray[1];
-                                    $userProfileUrl = "/members/$userId/profile";
+					<div class="whoLikedPost">
+						<?php if (strlen($userNameLikesArray) > 0) { ?>
+							<div class="names">
+								<?php
+									$nameArray = preg_split("#/#", $userNameLikesArray);
+									$links = array();
+									foreach ($nameArray as $nameString) 
+									{
+										$nameArray = explode("#", $nameString);
+										$userName = $nameArray[0];
+										$userId =  $nameArray[1];
+										$userProfileUrl = "/members/$userId/profile";
 
-                                    $links[] = "<a href=$userProfileUrl target='_blank'>$userName</a>";
-                                }
-                                echo join(", ", $links) . " liked this";
-                            ?>
-                        </div>
-                    <?php } ?>
-                </div>
+										$links[] = "<a href=$userProfileUrl target='_blank'>$userName</a>";
+									}
+									echo join(", ", $links) . " liked this";
+								?>
+							</div>
+						<?php } ?>
+					</div>
+				<?php } ?>
 
 			</div>
 

--- a/core/components/com_forum/site/views/threads/tmpl/display.php
+++ b/core/components/com_forum/site/views/threads/tmpl/display.php
@@ -119,7 +119,10 @@ $now = Date::of('now')->toSql();
 							</p>
 
 							<label for="fieldcomment" id="addNewPostArea">
-								<?php echo Lang::txt('COM_FORUM_FIELD_COMMENTS'); ?>
+								<div>
+									<?php echo Lang::txt('COM_FORUM_FIELD_COMMENTS'); ?>
+									<span class="note" style='float:right'>Use an @ sign to mention users to the post</span>
+								</div>
 								<?php echo $this->editor('fields[comment]', '', 35, 15, 'fieldcomment',
 										array(
 											'class' => 'minimal no-footer',

--- a/core/components/com_forum/site/views/threads/tmpl/display.php
+++ b/core/components/com_forum/site/views/threads/tmpl/display.php
@@ -128,7 +128,7 @@ $now = Date::of('now')->toSql();
 													'minChars' => 0,
 													'feed' =>  '/api/members/mentions/list?search={encodedQuery}',
 													'itemTemplate' => '<li data-id="{id}"><img class="photo" src="{picture}" /><strong class="username">{username}</strong><span class="fullname">{name}</span></li>',
-													'outputTemplate' => '<a href="mailto:{email}">@{username}</a><span>&nbsp;</span>',
+													'outputTemplate' => '<a href="/members/{id}" data-user-id="{id}" target="_blank">@{username}</a>&nbsp;&nbsp;',
 												)
 											)
 										)); ?>

--- a/core/components/com_members/api/controllers/mentionsv1_0.php
+++ b/core/components/com_members/api/controllers/mentionsv1_0.php
@@ -33,6 +33,7 @@ class Mentionsv1_0 extends ApiController {
         $entries = Member::all()
 			->whereEquals('block', 0)
 			->whereEquals('activation', 1)
+            ->where('email', '!=', 'noone@example.com')
 			->where('approved', '>', 0);
 
         if ($search) {

--- a/core/components/com_members/api/controllers/mentionsv1_0.php
+++ b/core/components/com_members/api/controllers/mentionsv1_0.php
@@ -33,7 +33,7 @@ class Mentionsv1_0 extends ApiController {
         $entries = Member::all()
 			->whereEquals('block', 0)
 			->whereEquals('activation', 1)
-            ->where('username', 'NOT LIKE', '-%')
+			->where('username', 'NOT LIKE', '-%')
 			->where('approved', '>', 0);
 
         if ($search) {

--- a/core/components/com_members/api/controllers/mentionsv1_0.php
+++ b/core/components/com_members/api/controllers/mentionsv1_0.php
@@ -33,7 +33,7 @@ class Mentionsv1_0 extends ApiController {
         $entries = Member::all()
 			->whereEquals('block', 0)
 			->whereEquals('activation', 1)
-            ->where('email', '!=', 'noone@example.com')
+            ->where('username', 'NOT LIKE', '-%')
 			->where('approved', '>', 0);
 
         if ($search) {

--- a/core/plugins/groups/forum/forum.php
+++ b/core/plugins/groups/forum/forum.php
@@ -1439,10 +1439,11 @@ class plgGroupsForum extends \Hubzero\Plugin\Plugin
 		$domComment->loadHTML($fields['comment']);
 		$mentionEmailList = array();
 		foreach ($domComment->getElementsByTagName('a') as $item) {
-			$hrefLink = $item->getAttribute('href');
-			if (strpos($hrefLink, 'mailto:') !== false) {
-				$mentionEmailList[] = str_replace('mailto:', "", $hrefLink);
-			}
+			$userId = $item->getAttribute('data-user-id');
+            $user = User::getInstance($userId);
+            $email = $user->get('email');
+
+            $mentionEmailList[] = $email;
 		}
 
 		if (!$this->params->get('access-edit-thread')

--- a/core/plugins/groups/forum/views/threads/tmpl/_comment.php
+++ b/core/plugins/groups/forum/views/threads/tmpl/_comment.php
@@ -84,43 +84,48 @@ defined('_HZEXEC_') or die();
 				<?php echo $comment; ?>
 
 				<!-- Heart and "Like" link Button -->
-				<div class="elementInline likeContainer">
-					<a class="icon-heart like <?php if ($userLikesComment) { echo "userLiked"; } ?>" href="#"
-					  data-thread="<?php echo $this->thread->get('id'); ?>"
-					  data-post="<?php echo $this->comment->get('id'); ?>"
-					  data-user="<?php echo User::get('id'); ?>"
-					  data-user-name="<?php echo User::get('name'); ?>"
-					  data-likes-list="<?php echo $userNameLikesArray; ?>"
-					  data-count="<?php echo $countLike; ?>"
-					></a>
-					<span class="likesStat <?php if ($countLike==0) { echo "noLikes"; } ?>">
-						<?php echo ($countLike>0) ? "View Likes (" . $countLike . ")" : "No Likes"; ?>
-					</span>
-				</div>
-
-				<div class="clear"></div>
-
-				<div class="whoLikedPost">
-					<?php if (strlen($userNameLikesArray) > 0) { ?>
-					<div class="names">
-					<?php
-						$nameArray = preg_split("#/#", $userNameLikesArray);
-						$links = array();
-
-						foreach ($nameArray as $nameString) 
-						{
-							$nameArray = explode("#", $nameString);
-							$userName = $nameArray[0];
-							$userId =  isset($nameArray[1]) ? $nameArray[1] : '0';
-							$userProfileUrl = "/members/$userId/profile";
-
-							$links[] = "<a href=$userProfileUrl target='_blank'>$userName</a>";
-						}
-						echo join(", ", $links) . " liked this";
-					?>
+				<!-- Only show if people is logged in -->
+				<?php if (!User::isGuest()) { ?>
+					<div class="elementInline likeContainer">
+						<a class="icon-heart like <?php if ($userLikesComment) { echo "userLiked"; } ?>" href="#"
+						data-thread="<?php echo $this->thread->get('id'); ?>"
+						data-post="<?php echo $this->comment->get('id'); ?>"
+						data-user="<?php echo User::get('id'); ?>"
+						data-user-name="<?php echo User::get('name'); ?>"
+						data-likes-list="<?php echo $userNameLikesArray; ?>"
+						data-count="<?php echo $countLike; ?>"
+						></a>
+						<span class="likesStat <?php if ($countLike==0) { echo "noLikes"; } ?>">
+							<?php echo ($countLike>0) ? "View Likes (" . $countLike . ")" : "No Likes"; ?>
+						</span>
 					</div>
-					<?php } ?>
-				</div>
+
+					<div class="clear"></div>
+
+					<div class="whoLikedPost">
+						<?php if (strlen($userNameLikesArray) > 0) { ?>
+						<div class="names">
+						<?php
+							$nameArray = preg_split("#/#", $userNameLikesArray);
+							$links = array();
+
+							foreach ($nameArray as $nameString) 
+							{
+								$nameArray = explode("#", $nameString);
+								$userName = $nameArray[0];
+								$userId =  isset($nameArray[1]) ? $nameArray[1] : '0';
+								$userProfileUrl = "/members/$userId/profile";
+
+								$links[] = "<a href=$userProfileUrl target='_blank'>$userName</a>";
+							}
+							echo join(", ", $links) . " liked this";
+						?>
+						</div>
+						<?php } ?>
+					</div>
+				<?php } ?>
+
+
 			</div>
 
 			<div class="comment-attachments">

--- a/core/plugins/groups/forum/views/threads/tmpl/display.php
+++ b/core/plugins/groups/forum/views/threads/tmpl/display.php
@@ -226,7 +226,10 @@ $this->css()
 				</p>
 
 				<label for="field_comment" id="addNewPostAreaGroup">
-					<?php echo Lang::txt('PLG_GROUPS_FORUM_FIELD_COMMENTS'); ?> <span class="required"><?php echo Lang::txt('PLG_GROUPS_FORUM_REQUIRED'); ?></span>
+					<div>
+						<?php echo Lang::txt('PLG_GROUPS_FORUM_FIELD_COMMENTS'); ?> <span class="required"><?php echo Lang::txt('PLG_GROUPS_FORUM_REQUIRED'); ?></span>
+						<span class="note" style='float:right'>Use an @ sign to mention group users on the post</span>
+					</div>
 					<?php
 						$gid = $this->group->get('gidNumber');
 						$feedUrl = '/api/members/mentions/group?gid=' . $gid . '&search={encodedQuery}';

--- a/core/plugins/groups/forum/views/threads/tmpl/display.php
+++ b/core/plugins/groups/forum/views/threads/tmpl/display.php
@@ -238,7 +238,7 @@ $this->css()
 										'minChars' => 0,
 										'feed' =>  $feedUrl,
 										'itemTemplate' => '<li data-id="{id}"><img class="photo" src="{picture}" /><strong class="username">{username}</strong><span class="fullname">{name}</span></li>',
-										'outputTemplate' => '<a href="mailto:{email}">@{username}</a><span>&nbsp;</span>',
+										'outputTemplate' => '<a href="/members/{id}" data-user-id="{id}" target="_blank">@{username}</a>&nbsp;&nbsp;',
 									)
 								)
 							)); ?>


### PR DESCRIPTION
Fixes 1st issue: When user is not logged in, public page. When you go to forum post, click on like "heart" icon, the page will register a like but if you refresh the page, the post has 0 likes. The post API call should throw back an error message when user is null or 0. 

Fixes 2nd issue: when user clicks on a mentions in the forum post, it should redirect them to the profile page. 