### PR TITLE
Allow template overloading for resources

### DIFF
--- a/core/components/com_resources/config/entry.xml
+++ b/core/components/com_resources/config/entry.xml
@@ -59,5 +59,6 @@
 			<option value="title">Title</option>
 			<option value="author">Author</option>
 		</param>
+		<param name="page_template" type="text" size="20" default="" label="Template" description="name of the overloading template" />
 	</params>
 </extension>

--- a/core/components/com_resources/site/controllers/resources.php
+++ b/core/components/com_resources/site/controllers/resources.php
@@ -1328,6 +1328,12 @@ class Resources extends SiteController
 			App::abort(404, Lang::txt('COM_RESOURCES_RESOURCE_NOT_FOUND'));
 		}
 
+		// Template overloading
+		$page_template = $this->model->params->get("page_template");
+		if ($page_template && $page_template != ""){
+				$app = App::getApplication()->template;
+				$app->template = $page_template;
+		}
 		// Make sure the resource is published and standalone
 		if (!$this->model->get('standalone')) // || !$this->model->isPublished())
 		{


### PR DESCRIPTION
# This change allow template overloading, resources can be assigned to be rendered on a different template defined on its params entry


