### PR TITLE
[NAIRR-162] Improve category display text for search results

### DIFF
--- a/core/components/com_search/models/solr/searchcomponent.php
+++ b/core/components/com_search/models/solr/searchcomponent.php
@@ -280,7 +280,7 @@ class SearchComponent extends Relational
 			$class = ($activeType == $this->id) ? 'class="active"' : '';
 			$link = Route::url('index.php?option=com_search&terms=' . $terms . '&type=' . $this->id . $childTerms);
 			$html .= '<li><a ' . $class . ' href="' . $link . '" data-type=' . $this->id . '>';
-			$html .= $this->name . '<span class="item-count">' . $count . '</span></a>';
+			$html .= $this->title . '<span class="item-count">' . $count . '</span></a>';
 
 			// Display filter controls, if the admin has configured a filter for this component:
 			if ($activeType && $this->filters->count() > 0)


### PR DESCRIPTION
Here we improve the way Solr search results are shown to the site user. When displaying the Category of solr search results, we show the customizable `title` column ("Content", "Kb", and "Events") as shown here:

![improve-display-text](https://github.com/user-attachments/assets/dcb81788-84df-4baf-abb7-5d401cbf76da)

This commit makes a small adjustment in `com_search/models/solr/searchcomponent.php` to display the `title` column from the jos_solr_search_searchcomponents table instead of the `name` column. This enables devs to customize the display name (`title`) for clarity. The `name` column is used in code as something of a unique identifier for the searchable components, so it cannot be changed, customized, or clarified.

For example: The search category for the custom component called “pilotevents” is now displayed as “Events”, as driven by the database record (id=12) shown below.

```
MariaDB [stage]> select * from jos_solr_search_searchcomponents where id>10;
+----+------------------+---------------------+---------+-------+-----------------+--------------+--------+
| id | name             | created             | indexed | state | indexed_records | title        | custom |
+----+------------------+---------------------+---------+-------+-----------------+--------------+--------+
| 11 | resources        | 2025-02-28 16:54:51 | NULL    | 1     |            1500 | Resources    | NULL   |
| 12 | pilotevents      | 2025-04-30 19:55:38 | NULL    | 1     |            1500 | Events       | NULL   |
| 13 | pilotallocations | 2025-05-07 20:24:58 | NULL    | 1     |            1500 | Allocations  | NULL   |
+----+------------------+---------------------+---------+-------+-----------------+--------------+--------+
```

The `title` column is populated automatically on record creation, as before. Devs wishing to customize it will update the `title` column directly in the database.

This was tested on NAIRR stage and on an AWS instance.

Associated Jira card is: `https://sdx-sdsc.atlassian.net/browse/NAIRR-162`
