### PR TITLE
[NAIRR-50] Only single slashes in url for uncategorized Content items

### DIFF
--- a/core/components/com_content/models/article.php
+++ b/core/components/com_content/models/article.php
@@ -710,7 +710,7 @@ class Article extends Relational implements \Hubzero\Search\Searchable
 		}
 		else
 		{
-			$url = '/' . $this->alias;
+			$url = $this->alias;
 		}
 
 		if ($this->get('state') == 1 && $this->get('access') == 1)


### PR DESCRIPTION
This PR addresses Jira card [NAIRR-50](https://sdx-sdsc.atlassian.net/browse/NAIRR-50). 

The issue: Content items with no Category are indexed by Solr as having doubled slashes in their URLs. For example, we might see `https://stage.nairrpilot.org//path` instead of `https://stage.nairrpilot.org/path`. This does not affect the use of the links, so it is primarily a cosmetic problem.

In this PR, we remove a slash from the indexable path for Content items with no Category. This occurs in the model class for Content articles.

## Testing

This has been tested on an AWS instance and on NAIRR stage. 

## After merge

Note that all Content items should be reindexed after application of the PR. This will affect only their url appearance. Reindex them using the admin backend, by selecting Components:Search, then Searchable Components, then selecting Rebuild Index in the Content record. To speed reindexing, go to Components:Cron, select Solr Process Queue, and click the "Run" button in the toolbar.