### PR TITLE
usage summary plugin is trying to add strings to values

### DIFF
--- a/core/plugins/members/usage/views/summary/tmpl/default.php
+++ b/core/plugins/members/usage/views/summary/tmpl/default.php
@@ -110,10 +110,10 @@ $this->css('usage', 'com_usage');
 				$sim_count_12  = plgMembersUsage::get_simcount($row->id, 12);
 				$sim_count_14  = plgMembersUsage::get_simcount($row->id, 14);
 
-				$sum_usercount_12 += $user_count_12;
-				$sum_usercount_14 += $user_count_14;
-				$sum_simcount_12  += $sim_count_12;
-				$sum_simcount_14  += $sim_count_14;
+                                $sum_usercount_12 += (is_numeric($user_count_12)?$user_count_12:0);
+                                $sum_usercount_14 += (is_numeric($user_count_14)?$user_count_14:0);
+                                $sum_simcount_12  += (is_numeric($sim_count_12)?$sim_count_12:0);
+                                $sum_simcount_14  += (is_numeric($sim_count_14)?$sim_count_14:0);
 				?>
 				<tr class="<?php
 					$cls = ($cls == 'even') ? 'odd' : 'even';


### PR DESCRIPTION
The method can return strings if there is no data, cumulative should not add those

# Before you submit this pull request, please make sure:

- [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [] Include a brief summary of the issue **in your own words**
- [] Include a brief summary of the fix/changed code
- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [] Double check someone is assigned to review the ticket

**Thanks!**
