### PR TITLE
Validate that NULL is not passed

### DIFF
--- a/core/modules/mod_whatsnew/tmpl/default.php
+++ b/core/modules/mod_whatsnew/tmpl/default.php
@@ -70,7 +70,7 @@ else
 	}
 	$html .= "\t\t" . '<span class="q">' . Lang::txt('MOD_WHATSNEW_MY_INTERESTS') . ': ' . $this->formatTags($this->tags) . '</span>' . "\n";
 	$html .= "\t" . '</p>' . "\n";
-	if (count($rows2) > 0)
+	if ($rows2 !== NULL && count($rows2) > 0)
 	{
 		$count = 0;
 


### PR DESCRIPTION
rows2 attribute can be defined as NULL and can be passed to the template if there are no objects
