### PR TITLE
incorrect use of "setter"

### DIFF
--- a/core/plugins/user/middleware/middleware.php
+++ b/core/plugins/user/middleware/middleware.php
@@ -57,10 +57,10 @@ class plgUserMiddleware extends \Hubzero\Plugin\Plugin
 				if (!$row->get('id') || ($row->get('id') && $row->get('class_id')))
 				{
 					$val = array(
-						'hard_files'  => $row->set('hard_files', 0),
-						'soft_files'  => $row->set('soft_files', 0),
-						'hard_blocks' => $row->set('hard_blocks', 0),
-						'soft_blocks' => $row->set('soft_blocks', 0)
+						'hard_files'  => $row->get('hard_files', 0),
+						'soft_files'  => $row->get('soft_files', 0),
+						'hard_blocks' => $row->get('hard_blocks', 0),
+						'soft_blocks' => $row->get('soft_blocks', 0)
 					);
 
 					$db->setQuery("SELECT c.* FROM `#__users_quotas_classes` AS c LEFT JOIN `#__users_quotas_classes_groups` AS g ON g.`class_id`=c.`id` WHERE g.`group_id` IN (" . implode(',', $gids) . ")");


### PR DESCRIPTION
default values should be set by using "getters" functions not "setters" before PHP8, it was casting and object as integers and worked, but will crash on any PHP8

