### PR TITLE
interests variable can be a string instead of array

### DIFF
--- a/core/modules/mod_myquestions/helper.php
+++ b/core/modules/mod_myquestions/helper.php
@@ -101,7 +101,14 @@ class Helper extends Module
 
 		$limit = intval($this->params->get('limit', 10));
 		$tags  = null;
-
+                if (is_string($interests))
+                {
+                        $interests = explode(',', $interests);
+                }
+                if (!is_array($interests))
+                {
+                        $interests = array();
+                }
 		$records = \Components\Answers\Models\Question::all()
 			->including(['responses', function ($response){
 				$response


### PR DESCRIPTION
interests variable can be a string not array

# Before you submit this pull request, please make sure:

- [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [] Include a brief summary of the issue **in your own words**
- [] Include a brief summary of the fix/changed code
- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [] Double check someone is assigned to review the ticket

**Thanks!**
