### PR TITLE
[NAIRR-164] Use correct Solarium object in method signature

### DIFF
--- a/core/components/com_search/models/solr/filters/listfilter.php
+++ b/core/components/com_search/models/solr/filters/listfilter.php
@@ -56,10 +56,10 @@ class Listfilter extends Filter
 	/**
 	 * Add filter options to solr count query
 	 *
-	 * @param   object   $multifacet  Solarium object that permits getting invidual counts
+	 * @param   object   $multifacet  Solarium object that permits getting individual facet counts
 	 * @return  string
 	 */
-	public function addCounts(\Solarium\QueryType\Select\Query\Component\Facet\MultiQuery $multifacet)
+	public function addCounts(\Solarium\Component\Facet\MultiQuery $multifacet)
 	{
 		$filterField = $this->get('field');
 		foreach ($this->options as $option)


### PR DESCRIPTION
This PR corrects the Solarium object type used in a signature. The relevant method determines the counts of item "facets" in a result set. This error is reported in Jira [NAIRR-164](https://sdx-sdsc.atlassian.net/browse/NAIRR-164) and was introduced during PHP8 worrk.

## Summary 

If a user uses Solr search on a component type such as Resources, which has facets (subtypes), the result set display is designed to show the counts of each facets in the result set, in addition to the total. The wrong object was specified in the signature of the function that computes these facet counts, resulting in this error being thrown:

```Components\Search\Models\Solr\Filters\Listfilter::addCounts(): Argument #1 ($multifacet) must be of type Solarium\QueryType\Select\Query\Component\Facet\MultiQuery, Solarium\Component\Facet\MultiQuery given, called in /var/www/jsperhac/core/components/com_search/site/controllers/solr.php on line 136 in /var/www/jsperhac/core/components/com_search/models/solr/filters/listfilter.php:63```

## Template caveat

This is a simple fix requiring only an object type change, and was tested on an AWS instance. Note that the template used may require an adjustment so that the facet counts are visible.

In this case, the counts are not evident on the web page:

![image](https://github.com/user-attachments/assets/5ac24575-eac9-4c55-8c0e-b3dcf097b860)

Here is the output of 'inspect', which shows that the counts are being generated (see 'item-count'):

![image](https://github.com/user-attachments/assets/c1532873-e6a1-44c0-98ed-5a3c728cfcef)