### PR TITLE
Init macro args to empty string to avoid null

### DIFF
--- a/core/plugins/content/formathtml/parser.php
+++ b/core/plugins/content/formathtml/parser.php
@@ -486,7 +486,7 @@ class Parser
 				return '';
 			}
 
-			$macro->args = null;
+			$macro->args = '';
 			if (isset($matches[3]) && $matches[3])
 			{
 				$macro->args = $matches[3];


### PR DESCRIPTION
I think this should fix the macros getArgs/explode issues once and for all