### PR TITLE
Update to local parameters for new Solarium version

### DIFF
--- a/core/libraries/Hubzero/Search/Adapters/SolrQueryAdapter.php
+++ b/core/libraries/Hubzero/Search/Adapters/SolrQueryAdapter.php
@@ -329,7 +329,7 @@ class SolrQueryAdapter implements QueryInterface
 		$filterParams['query'] = $string;
 		if ($tag)
 		{
-			$filterParams['tag'] = $tag;
+			$filterParams['local_tag'] = $tag;
 		}
 
 		$this->query->createFilterQuery($filterParams);


### PR DESCRIPTION
See https://solarium.readthedocs.io/en/stable/getting-started/#local-parameter-names

Fixes: https://qubeshub.org/support/ticket/5088

Example of portion of uri without fix:
```
&fq=hubtype:publication&fq=access_level:public&fq=publish_up:[*+TO+NOW]&fq=tags:("qfa4978.qfa4985")
```

Example of portion of uri with fix:
```
&fq={!tag=root_type}hubtype:publication&fq={!tag=root_type}access_level:public&fq={!tag=root_type}publish_up:[*+TO+NOW]&fq={!tag=qfa4978}tags:("qfa4978.qfa4985")
```