### PR TITLE
Qubes forum mail fixes

### DIFF
--- a/core/libraries/Hubzero/Mail/Message.php
+++ b/core/libraries/Hubzero/Mail/Message.php
@@ -528,23 +528,25 @@ class Message extends \Symfony\Component\Mime\Email
 
 		foreach($addresses as $key => $value)
 		{
-			if (is_numeric($key))
-			{
-				$address = new \Symfony\Component\Mime\Address($value);
-			}
-			else
-			{
-				$address = new \Symfony\Component\Mime\Address($key, $value);
-			}
+			if ($value) {
+				if (is_numeric($key))
+				{
+					$address = new \Symfony\Component\Mime\Address($value);
+				}
+				else
+				{
+					$address = new \Symfony\Component\Mime\Address($key, $value);
+				}
 
-			if (isset($first_set))
-			{
-				parent::bcc($address);
-				$first_set = true;
-			}
-			else
-			{
-				parent::addBcc($address);
+				if (isset($first_set))
+				{
+					parent::bcc($address);
+					$first_set = true;
+				}
+				else
+				{
+					parent::addBcc($address);
+				}
 			}
 		}
 

--- a/core/plugins/groups/forum/views/email/tmpl/comment_plain.php
+++ b/core/plugins/groups/forum/views/email/tmpl/comment_plain.php
@@ -28,7 +28,7 @@ if ($this->delimiter)
 $message .= ($this->post->get('anonymous')) ? Lang::txt('JANONYMOUS') : $this->post->creator->get('name') . ' (' . $this->post->creator->get('username') . ')';
 $message .= ' wrote (in ' . $this->group->get('description') . ': ' . $this->section->get('title') . ' - ' . $this->category->get('title') . ' - ' . $this->thread->get('title') . '):';
 
-$output = html_entity_decode(strip_tags($this->post->content), ENT_COMPAT, 'UTF-8');
+$output = html_entity_decode(strip_tags($this->post->content ?: ''), ENT_COMPAT, 'UTF-8');
 $output = preg_replace_callback(
 	"/(&#[0-9]+;)/",
 	function($m)


### PR DESCRIPTION
This pull request fixes two bugs.

- ab4570b8a53caf0958a30a0f18bf8aab9bb86e24: Standard null to '' fix
- 5895d1644e9b31edb29dfdef772c6ab51f906941: $value in the setBcc function was somehow null, so set a condition to avoid 

The errors are thrown when attempting to commit a forum post. I _think_ one of the errors (the setBcc one) happens when a hyperlink is included in the post.