### PR TITLE
Update supergroup GitLab to new standards

### DIFF
--- a/core/components/com_groups/admin/controllers/manage.php
+++ b/core/components/com_groups/admin/controllers/manage.php
@@ -628,22 +628,8 @@ class Manage extends AdminController
 	 */
 	private function _handSuperGroupGitlab($group)
 	{
-		// get needed config vars
-		$gitlabManagement = $this->config->get('super_gitlab', 0);
-		$gitlabUrl        = $this->config->get('super_gitlab_url', '');
-		$gitlabKey        = $this->config->get('super_gitlab_key', '');
-
-		// do we have repo management on
-		// dont output message
-		if (!$gitlabManagement)
-		{
-			return;
-		}
-
-		// make sure we have a url and key if repot management is on
-		if ($gitlabManagement && ($gitlabUrl == '' || $gitlabKey == ''))
-		{
-			Notify::warning(Lang::txt('COM_GROUPS_GITLAB_NOT_SETUP'));
+		$client = new Gitlab();
+		if (!$client->validate()) {
 			return;
 		}
 
@@ -656,22 +642,24 @@ class Manage extends AdminController
 
 		// build group & project names
 		$host        = explode('.', $_SERVER['HTTP_HOST']);
-		$groupName   = strtolower($host[0]);
-		$projectName = $group->get('cn');
-
-		// instantiate new gitlab client
-		$client = new Gitlab($gitlabUrl, $gitlabKey);
+		$groupName   = 'hub-' . strtolower($host[0]);
+		$projectName = 'sg_' . $group->get('cn');
 
 		// Search for group in Gitlab
 		$gitLabGroup = $client->groups($groupName);
 
 		// create group if doesnt exist
-		if ($gitLabGroup == null)
+		if (array_key_exists('message', $gitLabGroup)) {
+			Notify::error("Error requesting groups: " . $gitLabGroup['message']);
+			return;
+		}
+		elseif (empty($gitLabGroup))
 		{
 			$gitLabGroup = $client->createGroup(array(
 				'name' => $groupName,
-				'path' => strtolower($groupName)
+				'path' => $groupName
 			));
+			// Possible error check here
 		}
 		elseif (count($gitLabGroup) > 1)
 		{  // If search returns more than one match, return with error.
@@ -693,7 +681,12 @@ class Manage extends AdminController
 		$gitLabProject = $client->projects($projectName);
 
 		// create project if doesnt exist
-		if ($gitLabProject == null)
+		if (array_key_exists('message', $gitLabProject))
+		{
+			Notify::error("Error requesting projects: " . $gitLabProject['message']);
+			return;
+		}
+		elseif (empty($gitLabProject))
 		{
 			$gitLabProject = $client->createProject(array(
 				'namespace_id'           => $gitLabGroup['id'],
@@ -704,6 +697,7 @@ class Manage extends AdminController
 				'wiki_enabled'           => true,
 				'snippets_enabled'       => true,
 			));
+			// Possible error check here
 		}
 		elseif ($gitLabProject)
 		{  // search result must match hub group name to gitlab project name exactly or create new gitlab project
@@ -720,7 +714,7 @@ class Manage extends AdminController
 				}
 			}
 			// create project if doesnt exist
-			if ($gitLabProject == null)
+			if (empty($gitLabProject))
 			{
 				$gitLabProject = $client->createProject(array(
 					'namespace_id'           => $gitLabGroup['id'],
@@ -731,6 +725,7 @@ class Manage extends AdminController
 					'wiki_enabled'           => true,
 					'snippets_enabled'       => true,
 				));
+				// Possible error checking here
 			}
 		}
 		else
@@ -752,20 +747,18 @@ class Manage extends AdminController
 			return;
 		}
 
+		// url
+		$url_bits = parse_url($gitLabProject['http_url_to_repo']);
+		$gitLabUrl = $url_bits["scheme"] . '://oauth2:' . $client->get('token') . '@' . $url_bits["host"] . $url_bits["path"];
+
 		// build command to run via shell
 		// this will init the git repo, make the initial commit and push to the repo management machine
 		$cmd  = 'sh ' . dirname(dirname(__DIR__)) . DS . 'admin' . DS . 'assets' . DS . 'scripts' . DS . 'gitlab_setup.sh ';
-		$cmd .= $uploadPath  . ' ' . $authorInfo . ' ' . $gitLabProject['ssh_url_to_repo'] . ' 2>&1';
+		$cmd .= $uploadPath  . ' ' . $authorInfo . ' ' . $gitLabUrl . ' 2>&1';
 
 		// execute command
 		$output = shell_exec($cmd);
-
-		// make sure everything went well
-		if (preg_match("/Host key verification failed/uis", $output))
-		{
-			Notify::warning(Lang::txt('COM_GROUPS_GITLAB_NOT_SETUP_SSH'));
-			return;
-		}
+		// Possible error checking here if git push fails (likely will have failed before this)
 
 		// protect master branch
 		// allows only admins to accept Merge Requests
@@ -773,6 +766,11 @@ class Manage extends AdminController
 			'id'     => $gitLabProject['id'],
 			'branch' => 'master'
 		));
+		if (array_key_exists('message', $protected))
+		{
+			Notify::error("Error on branch protection: " . $protected['message']);
+			return;
+		}
 	}
 
 	/**
@@ -798,6 +796,12 @@ class Manage extends AdminController
 		if (empty($ids))
 		{
 			return $this->cancelTask();
+		}
+
+		// Get GitLab client
+		$client = new Gitlab();
+		if (!$client->validate()) {
+			return;
 		}
 
 		// vars to hold results of pull
@@ -850,15 +854,14 @@ class Manage extends AdminController
 				// build group & project names
 				$host        = explode('.', $_SERVER['HTTP_HOST']);
 				$tld         = array_pop($host);
-				$groupName   = strtolower(end($host));
-				$projectName = $group->get('cn');
+				$groupName   = 'hub-' . strtolower(end($host));
+				$projectName = 'sg_' . $group->get('cn');
 
 				// get gitlab config
 				$gitlabUrl = $this->config->get('super_gitlab_url', '');
 				$gitlabKey = $this->config->get('super_gitlab_key', '');
 
 				// instantiate new gitlab client
-				$client        = new Gitlab($gitlabUrl, $gitlabKey);
 				$gitlabGroup   = $client->group($groupName);
 				$gitlabProject = $client->project($projectName);
 
@@ -869,9 +872,13 @@ class Manage extends AdminController
 					continue;
 				}
 
+				// url
+				$url_bits = parse_url($gitLabProject['http_url_to_repo']);
+				$gitLabUrl = $url_bits["scheme"] . '://oauth2:' . $gitlabKey . '@' . $url_bits["host"] . $url_bits["path"];
+
 				// setup stage environment
 				$cmd  = 'sh ' . dirname(dirname(__DIR__)). DS . 'admin' . DS . 'assets' . DS . 'scripts' . DS . 'gitlab_setup_stage.sh ';
-				$cmd .= str_replace('/' . $group->get('gidNumber'), '', $uploadPath) . ' ' . $group->get('gidNumber') . ' ' . $group->get('cn') . ' ' . $gitlabProject['ssh_url_to_repo'] . ' 2>&1';
+				$cmd .= str_replace('/' . $group->get('gidNumber'), '', $uploadPath) . ' ' . $group->get('gidNumber') . ' ' . $group->get('cn') . ' ' . $gitLabUrl . ' 2>&1';
 
 				// execute command
 				$output = shell_exec($cmd);
@@ -885,7 +892,18 @@ class Manage extends AdminController
 				$user = Component::params('com_update')->get('system_user', 'hubadmin');
 			}
 
-			// The tasks and command to be perofmred
+			// Check to make sure using correct token
+			$output = shell_exec($cmd . "git remote -v");
+			$url_bits = parse_url(explode("\t", explode(" ", $output)[1])[1]);
+			$gitLabKey = $client->get('token');
+			if ($url_bits["pass"] !== $gitLabKey) {
+				$gitLabUrl = $url_bits["scheme"] . '://' . $url_bits["user"] . ':' . $gitLabKey . '@' . $url_bits["host"] . $url_bits["path"];
+				$rcmd  = 'sh ' . dirname(dirname(__DIR__)) . DS . 'admin' . DS . 'assets' . DS . 'scripts' . DS . 'gitlab_reset_remote.sh ';
+				$rcmd .= $uploadPath  . ' ' . $gitLabUrl . ' 2>&1';
+				$output = shell_exec($rcmd);
+			}
+
+			// The tasks and command to be performed
 			$task = 'group';
 			$museCmd = 'update';
 


### PR DESCRIPTION
This PR is needed to update Gitlab supergroup code to new standards implemented post-PHP update. It includes additional refactoring to clean code up a bit, as well as some code to report on Gitlab API errors. Summaries of code changes by file are listed below:

`core/components/com_groups/helpers/gitlab.php`

1. Constructor pulls GitLab config, rather than passing in config parameters
2. Moved free-floating code in manage.php into a validate method to check token
3. Created a general request method to handle general error messages, in particular expired or nonexistent token
4. `_getRequest` method uses `min_access_level=40` instead of `owned=true`. Token must have Maintainer or Owner access role for this to work. Previously, `owned=true` worked as API call was using a GitLab user that owned repositories (for QUBES, user was `qubeshub`). We are now using `oauth2`, however, with token bots that do not own the repositories.

`core/components/com_groups/admin/controllers/manage.php`

1. Use new Gitlab class constructor
2. Use new Gitlab class validate method
3. Add "hub-" prefix to Gitlab Group names
4. Add "sg_" prefix to Gitlab Project names
5. Include more Gitlab API error checking
6. Change remote url to use "oauth2" user
7. Added error check for failed branch protection. Note: The token must have full API access for branch protection to work
8. Added code to update remote url token if remote url token does not match existing token. This is important to avoid having to manually update the remote url when a token expires or changes.

NOTE: For the code changes to work, the Gitlab token needs to have scope "api" and role "Maintainer" or "Owner".