### PR TITLE
Fix tool alias validation

### DIFF
--- a/core/components/com_tools/models/tool.php
+++ b/core/components/com_tools/models/tool.php
@@ -1460,7 +1460,7 @@ class Tool
 		{
 			$err['toolname'] = Lang::txt('COM_TOOLS_ERR_TOOLNAME_EXISTS');
 		}
-		else if ((preg_match('#^[a-zA-Z0-9]{3,15}$#', $tool['toolname']) === 0 || is_numeric($tool['toolname'])) && !$id)
+		else if ((!preg_match('#^[a-zA-Z0-9]{3,15}$#', $tool['toolname']) || is_numeric($tool['toolname'])) && !$id)
 		{
 			$err['toolname'] = Lang::txt('COM_TOOLS_ERR_TOOLNAME');
 		}

--- a/core/components/com_tools/models/tool.php
+++ b/core/components/com_tools/models/tool.php
@@ -1460,7 +1460,7 @@ class Tool
 		{
 			$err['toolname'] = Lang::txt('COM_TOOLS_ERR_TOOLNAME_EXISTS');
 		}
-		else if ((preg_match('#^[a-zA-Z0-9]{3,15}$#', $tool['toolname']) == '' || is_numeric($tool['toolname'])) && !$id)
+		else if ((preg_match('#^[a-zA-Z0-9]{3,15}$#', $tool['toolname']) === 0 || is_numeric($tool['toolname'])) && !$id)
 		{
 			$err['toolname'] = Lang::txt('COM_TOOLS_ERR_TOOLNAME');
 		}


### PR DESCRIPTION
PHP8 makes comparison stricter, preg_match returns 0 instead of an empty string.
