### PR TITLE
Sanitize caching to a tmp file

### DIFF
--- a/core/libraries/Hubzero/Utility/Sanitize.php
+++ b/core/libraries/Hubzero/Utility/Sanitize.php
@@ -298,6 +298,7 @@ class Sanitize
 		$config = \HTMLPurifier_Config::createDefault();
 		$root = str_replace(['http://', 'https://', '.'], ['', '', '\.'], \App::get('request')->root());
 		$defaultSettings = [
+			'Cache.SerializerPath' => sys_get_temp_dir(),
 			'AutoFormat.Linkify' => false,
 			'AutoFormat.RemoveEmpty' => true,
 			'AutoFormat.RemoveEmpty.RemoveNbsp' => false,


### PR DESCRIPTION
By default, it is trying to save temp files on the libraries installation path. this PR forces the Sanitizer to use a temporal directory.
No sure if this is a new version issue or before that folder had apache access

```
[19-Aug-2025 17:32:53 UTC] cms.WARNING: Directory /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer not writable.  in /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer.php on lin
e 295
    [https://nanohub.org/groups/scale_international/modules/save]
    #0 [internal function]: Hubzero\Error\Handler->handleError(512, 'Directory /var/...', '/var/www/nanohu...', 295)
    #1 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer.php(295): trigger_error('Directory /var/...', 512)
    #2 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer.php(238): HTMLPurifier_DefinitionCache_Serializer->_testPermissions('/var/www/nanohu...', NULL)
    #3 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer.php(125): HTMLPurifier_DefinitionCache_Serializer->_prepareDir(Object(HTMLPurifier_Config))
    #4 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Decorator.php(108): HTMLPurifier_DefinitionCache_Serializer->cleanup(Object(HTMLPurifier_Config))
    #5 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Decorator/Cleanup.php(72): HTMLPurifier_DefinitionCache_Decorator->cleanup(Object(HTMLPurifier_Config))
    #6 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/Config.php(505): HTMLPurifier_DefinitionCache_Decorator_Cleanup->get(Object(HTMLPurifier_Config))
    #7 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/AttrDef/URI.php(72): HTMLPurifier_Config->getDefinition('URI')
    #8 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/AttrValidator.php(95): HTMLPurifier_AttrDef_URI->validate(Object(HTMLPurifier_URI), Object(HTMLPurifier_Config), Object(HTMLPurifier_Context))
    #9 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/Strategy/ValidateAttributes.php(38): HTMLPurifier_AttrValidator->validateToken(Object(HTMLPurifier_Token_Start), Object(HTMLPurifier_Config), Object(HTMLPurifier_Context))
    #10 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier/Strategy/Composite.php(24): HTMLPurifier_Strategy_ValidateAttributes->execute(Array, Object(HTMLPurifier_Config), Object(HTMLPurifier_Context))
    #11 /var/www/nanohub/core/vendor/ezyang/htmlpurifier/library/HTMLPurifier.php(209): HTMLPurifier_Strategy_Composite->execute(Array, Object(HTMLPurifier_Config), Object(HTMLPurifier_Context))
    #12 /var/www/nanohub/core/libraries/Hubzero/Utility/Sanitize.php(287): HTMLPurifier->purify('<!-- {FORMAT:HT...')```


