### PR TITLE
Add a switch to control the display of search category

### DIFF
--- a/core/components/com_publications/admin/language/en-GB/en-GB.com_publications.ini
+++ b/core/components/com_publications/admin/language/en-GB/en-GB.com_publications.ini
@@ -661,6 +661,8 @@ COM_PUBLICATIONS_CONFIG_SFTP_TYPE_BLACKLIST="FTP File Type Blacklist"
 COM_PUBLICATIONS_CONFIG_SFTP_TYPE_BLACKLIST_DESC="Comma Separated List of Publication Types that shouldn't/ can't be downloaded via sFTP"
 COM_PUBLICATIONS_CONFIG_CONTACT_EMAIL_ADDRESS="Contact Email Address"
 COM_PUBLICATIONS_CONFIG_CONTACT_EMAIL_ADDRESS_DESC="The email address that user reaches out to for help"
+COM_PUBLICATIONS_CONFIG_SEARCH_CATEGORY="Search category"
+COM_PUBLICATIONS_CONFIG_SEARCH_CATEGORY_DESC="Search category in tag section of publication submission"
 
 ; Types
 COM_PUBLICATIONS_TYPES="Types"

--- a/core/components/com_publications/config/config.xml
+++ b/core/components/com_publications/config/config.xml
@@ -42,6 +42,10 @@
 			<option value="1">JYES</option>
 		</field>
 		<field name="contact_email" type="text" menu="hide" default="" label="COM_PUBLICATIONS_CONFIG_CONTACT_EMAIL_ADDRESS" description="COM_PUBLICATIONS_CONFIG_CONTACT_EMAIL_ADDRESS_DESC" />
+		<field name="search_category" type="list" default="1" label="COM_PUBLICATIONS_CONFIG_SEARCH_CATEGORY" description="COM_PUBLICATIONS_CONFIG_SEARCH_CATEGORY_DESC">
+			<option value="0">JOFF</option>
+			<option value="1">JON</option>
+		</field>
 	</fieldset>
 	<fieldset name="CURATION">
 		<field name="curatorreplyto" type="text" menu="hide" default="" label="COM_PUBLICATIONS_CONFIG_CURATOR_REPLYTO" description="COM_PUBLICATIONS_CONFIG_CURATOR_REPLYTO_DESC" />

--- a/core/plugins/projects/publications/views/draft/tmpl/tags.php
+++ b/core/plugins/projects/publications/views/draft/tmpl/tags.php
@@ -18,6 +18,8 @@ $elName = "tagsPick";
 // Get curator status
 $curatorStatus = $this->pub->_curationModel->getCurationStatus($this->pub, $this->step, 0, 'author');
 
+$searchCategory = $this->pub->config('search_category');
+
 ?>
 
 <!-- Load content selection browser //-->
@@ -50,7 +52,7 @@ $curatorStatus = $this->pub->_curationModel->getCurationStatus($this->pub, $this
 		</div>
 	</div>
 </div>
-<?php if ($this->categories && count($this->categories) > 1) { ?>
+<?php if ($searchCategory != 0 && $this->categories && count($this->categories) > 1) { ?>
 	<div class="blockelement el-optional el-complete">
 		<div class="element_editing">
 			<div class="pane-wrapper">

--- a/core/plugins/projects/publications/views/draft/tmpl/tags.php
+++ b/core/plugins/projects/publications/views/draft/tmpl/tags.php
@@ -18,7 +18,7 @@ $elName = "tagsPick";
 // Get curator status
 $curatorStatus = $this->pub->_curationModel->getCurationStatus($this->pub, $this->step, 0, 'author');
 
-$searchCategory = $this->pub->config('search_category');
+$searchCategory = $this->pub->config('search_category', 1);
 
 ?>
 


### PR DESCRIPTION
PURR Ticket #2305

User initiated a file publication. When user chooses the "Series/Dataset" in the search category UI in tag section of publication submission process, the publication's type is going to be set to a series publication. 

The change is to add a switch to control the displaying of the search category user interface. By default the switch is set to on. On PURR, we are going to turn it off so the file publication won't be set to a series type since there will be not a radio button for user to choose.

Test procedure:
1. Create a file publication. Navigate to the tag section and you should see the search category user interface that allows you to choose Datasets or Series/Dataset.
2. Login on admin interface and access the configuration of publication component. Set the Search category to off and save the changes.
3. Create a new file publication and navigate to the tag section. You won't see the search category user interface anymore.

