### PR TITLE
[PURR][2689]Adding datasize column to publication version table

### DIFF
--- a/core/components/com_publications/site/controllers/curation.php
+++ b/core/components/com_publications/site/controllers/curation.php
@@ -544,6 +544,14 @@ class Curation extends SiteController
 		// Store curation manifest
 		$this->_pub->version->set('curation', $curation);
 		$this->_pub->version->set('curation_version_id', $versionNumber);
+		
+		// Save dataset bundle size
+		$zipPath = PATH_APP . DS . trim($this->config->get('webpath'), DS) . DS . \Hubzero\Utility\Str::pad($pid) . DS . \Hubzero\Utility\Str::pad($vid) . DS . str_replace(['.', '/'], '_', $this->_pub->version->doi) . ".zip";
+		
+		if (file_exists($zipPath))
+		{
+			$this->_pub->version->set('datasize', filesize($zipPath));
+		}
 
 		if (!$this->_pub->version->store())
 		{

--- a/core/migrations/Migration20251120161115PlgProjectsPublications.php
+++ b/core/migrations/Migration20251120161115PlgProjectsPublications.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2025 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+/**
+ * Migration script for column size in publication version table
+ **/
+class Migration20251120161115PlgProjectsPublications extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		if ($this->db->tableExists('#__publication_versions') && !$this->db->tableHasField('#__publication_versions', 'datasize'))
+		{
+			$query = "ALTER TABLE `#__publication_versions` ADD COLUMN `datasize` BIGINT UNSIGNED";
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		if ($this->db->tableExists('#__publication_versions') && $this->db->tableHasField('#__publication_versions', 'datasize'))
+		{
+			$query = "ALTER TABLE `#__publication_versions` DROP COLUMN `datasize`";
+			$this->db->setQuery($query);
+			$this->db->query();
+		}
+	}
+}


### PR DESCRIPTION
We want to have the dataset's size saved in the "publication_version" table so that we can get the data size along with other publication information together for further process. 

The changes include adding "datasize" column to the "publication_version" table and the column will be updated when a dataset is approved. For the datasets' size of existing datasets, please run the mysql statement in attached. I got the datasets' size (dataset bundle in publication directory) on the PURR server.
[MySQL_update_datasize_for_existing_publications_11212025.txt](https://github.com/user-attachments/files/23681075/MySQL_update_datasize_for_existing_publications_11212025.txt)

Test procedure:
1. Submit and approve a file publication.
2. Check the publication table datasize column to see whether there is a value in the datasize column for the dataset that you just published.

Test has been done on dev PURR and it has the correct result.

