### PR TITLE
Order by Title/Date is missing parent/sub-category

### DIFF
--- a/core/components/com_tags/site/views/tags/tmpl/view.php
+++ b/core/components/com_tags/site/views/tags/tmpl/view.php
@@ -151,12 +151,12 @@ foreach ($cats as $cat)
 				<nav class="entries-filters">
 					<ul class="entries-menu order-options">
 						<li>
-							<a<?php echo ($this->filters['sort'] == 'title') ? ' class="active"' : ''; ?> href="<?php echo Route::url('index.php?option=' . $this->option . '&tag=' . $this->tagstring . '&area=' . $this->active . '&sort=title&limit=' . $this->filters['limit'] . '&start=' . $this->filters['start']); ?>" title="<?php echo Lang::txt('COM_TAGS_OPT_SORT_BY_TITLE'); ?>">
+							<a<?php echo ($this->filters['sort'] == 'title') ? ' class="active"' : ''; ?> href="<?php echo Route::url('index.php?option=' . $this->option . '&tag=' . $this->tagstring . '&area=' . $this->active . '&parent=' . $this->parent . '&sort=title&limit=' . $this->filters['limit'] . '&start=' . $this->filters['start']); ?>" title="<?php echo Lang::txt('COM_TAGS_OPT_SORT_BY_TITLE'); ?>">
 								<?php echo Lang::txt('COM_TAGS_OPT_TITLE'); ?>
 							</a>
 						</li>
 						<li>
-							<a<?php echo ($this->filters['sort'] == 'date' || $this->filters['sort'] == '') ? ' class="active"' : ''; ?> href="<?php echo Route::url('index.php?option=' . $this->option . '&tag=' . $this->tagstring . '&area=' . $this->active . '&sort=date&limit=' . $this->filters['limit'] . '&start=' . $this->filters['start']); ?>" title="<?php echo Lang::txt('COM_TAGS_OPT_SORT_BY_DATE'); ?>">
+							<a<?php echo ($this->filters['sort'] == 'date' || $this->filters['sort'] == '') ? ' class="active"' : ''; ?> href="<?php echo Route::url('index.php?option=' . $this->option . '&tag=' . $this->tagstring . '&area=' . $this->active . '&parent=' . $this->parent . '&sort=date&limit=' . $this->filters['limit'] . '&start=' . $this->filters['start']); ?>" title="<?php echo Lang::txt('COM_TAGS_OPT_SORT_BY_DATE'); ?>">
 								<?php echo Lang::txt('COM_TAGS_OPT_DATE'); ?>
 							</a>
 						</li>


### PR DESCRIPTION
When sorting content by Title or Date (after subcategory is selected), the links aren’t including the correct parent/sub-category context, so no items are showing up.

https://nanohub.org/support/ticket/490024
