### PR TITLE
[fix] Missing closing brace for class

### DIFF
--- a/core/components/com_redirect/migrations/Migration20250417000000Redirect.php
+++ b/core/components/com_redirect/migrations/Migration20250417000000Redirect.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @packagehubzero-cms
  * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
@@ -19,18 +18,19 @@ defined('_HZEXEC_') or die();
  **/
 class Migration20250417000000Redirect extends Base
 {
-/**
- * Up
- **/
-public function up()
-{
-	$this->addComponentEntry('redirect');
-}
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$this->addComponentEntry('redirect');
+	}
 
-/**
- * Down
- **/
-public function down()
-{
-	$this->deleteComponentEntry('redirect');
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$this->deleteComponentEntry('redirect');
+	}
 }


### PR DESCRIPTION
# Before you submit this pull request, please make sure:

- [x] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [x] Include a brief summary of the issue **in your own words**

A migration file was missing a closing brace for the class, causing migration updates to fail.

- [x] Include a brief summary of the fix/changed code

I just added the closing brace and styled some of the code to match standards.

- [x] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?

This fix was tested with a migration up and passed.

- [x] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout

Maybe? It's possible migration scripts failed on a recent code push.

- [x] Double check someone is assigned to review the ticket

**Thanks!**
