### PR TITLE
[PURR][#2766]Update the name on publication page when user has updated it in user profile

### DIFF
--- a/core/components/com_publications/models/publication.php
+++ b/core/components/com_publications/models/publication.php
@@ -886,7 +886,7 @@ class Publication extends Obj
 				}
 				if ($contributor->lastName || $contributor->firstName)
 				{
-					$name  = stripslashes($contributor->lastName);
+					$name  = (!empty($contributor->surname)) ? stripslashes($contributor->surname) : stripslashes($contributor->lastName);
 					if (strstr($contributor->firstName, ' '))
 					{
 						$parts = explode(' ', $contributor->firstName);

--- a/core/components/com_publications/site/views/view/tmpl/_contributors.php
+++ b/core/components/com_publications/site/views/view/tmpl/_contributors.php
@@ -29,13 +29,13 @@ if ($this->contributors)
 		}
 
 		// Build the user's name and link to their profile
-		if ($contributor->name)
+		if ($contributor->p_name)
 		{
-			$name = $this->escape(stripslashes($contributor->name));
+			$name = $this->escape(stripslashes($contributor->p_name));
 		}
 		else
 		{
-			$name = $this->escape(stripslashes($contributor->p_name));
+			$name = $this->escape(stripslashes($contributor->name));
 		}
 		if ($this->format)
 		{


### PR DESCRIPTION
PURR Ticket: 
https://purr.purdue.edu/support/ticket/2766

Issue:
We found that a PURR user changed her last name at some time and the new name shows up properly on DataCite, but the new name doesn't show up on the PURR publication page. We want the name to be automatically updated on publication page if a publication author, as well as a PURR user, changed the name in the user profile. The new name shows in the dataset's record on DataCite because the author changed name some time before her last visit to PURR in 2024 and I have been updated the dataset record on DataCite in December 2025, where the update process takes the author's name from PURR user profile.

Code changes:
Make changes to the function getUnlinkedContributors() to use the surname that comes from the PURR user profile when an author is also a PURR user, so that the citation in "Cite this work" section will be constructed using the latest names from the author, as well as PURR user, if such user has changed the last name in the PURR user profile. Also make changes to the name setting in contributors view of publication component, so that it always display the author's name from user profile rather than that is provided by the submitter in the author section on publication page.

Testing steps:
1. Prepare a publication, set you as the author, then submit and approve it. Check the names in authors section and in the "Cite this work" section on publication page that your current last name displays over there.
2. Change your last name in your user profile to a new one and save the changes. Go back to the publication page and check whether the last name in the authors section and in the "Cite this work" display the new last name that you just set.

I tested it on dev PURR and it works as expected.

Jerry
