### PR TITLE
[PURR][#2773]Fix issue that html tag is not stripped

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -832,7 +832,7 @@ class Doi extends Obj
 		{
 			foreach ($this->get('regTags') as $regTag)
 			{
-				if (!empty($regTag->description) && preg_match("/^lcsh::/i", trim($regTag->description)))
+				if (!empty($regTag->description) && preg_match("/^lcsh::/i", trim(strip_tags($regTag->description))))
 				{
 					$url = substr(trim(strip_tags($regTag->description)), 6);
 					$xmlfile .= '<subject subjectScheme="Library of Congress Subject Headings (LCSH)" schemeURI="https://id.loc.gov/authorities/" valueURI="' . $url . '">' . $regTag->raw_tag . '</subject>';


### PR DESCRIPTION
PURR Ticket: https://purr.purdue.edu/support/ticket/2773

The description field value of the library of Congress subject heading (LCSH) tags in tags component admin interface is saved with html tag <p> wrapped in database as attached screenshot shows. When feting and using the description value of the LCSH tag, we need strip the html tag p first, then apply the value in the process. The code change reflects such process.

Testing:
1. Assign a department tag such as Aeronautics and Astronautics (the description value is lcsh::https://lccn.loc.gov/sh95007821) to a dataset when submitting it.
2. After the dataset is published, check the dataset's DOI metadata record on DataCite to see if it includes the element below.
<subject subjectScheme="Library of Congress Subject Headings (LCSH)" schemeURI="https://id.loc.gov/authorities/" valueURI="https://lccn.loc.gov/sh95007821">'Aeronautics and Astronautics'</subject>

I test it on dev PURR and it works as expected.

Jerry
