### PR TITLE
ORCID: Added a guard before rendering the OAuth buttons

### DIFF
--- a/core/components/com_members/config/config.xml
+++ b/core/components/com_members/config/config.xml
@@ -270,7 +270,7 @@
 		</field>
 		<field name="rorApiVersion" type="text" menu="hide" default="" label="Research Organization Registry API Version Number" description="The version number of Research Organization Registry API, such as 'v2'." />
 		<field name="@spacer" type="spacer" default="" label="" description="" />
-		<field name="orcid_service" type="list" default="public" label="ORCID Service" description="Select the service to use for ORCID. Sandbox is for testing and debugging purposes. The Public service only allows for searching records, new ID creation is not allowed.">
+		<field name="orcid_service" type="list" default="members" label="ORCID Service" description="Select the service to use for ORCID. Sandbox is for testing and debugging purposes. The Public service only allows for searching records, new ID creation is not allowed.">
 			<option value="public">Public (search only)</option>
 			<option value="members">Members</option>
 			<option value="sandbox">Sandbox</option>

--- a/core/components/com_members/models/fields/orcid.php
+++ b/core/components/com_members/models/fields/orcid.php
@@ -78,15 +78,18 @@ class Orcid extends Text
 			$profile = \Components\Members\Models\Member::oneOrFail($userID);
 		}
 
+		$oauthConfigured = ($srv !== 'public' && !empty($clientID) && !empty($redirectURI));
+		$isSandbox = ($srv === 'sandbox');
+
 		$html[] = '	<div class="orcid-actions">';
 		if ($userID != 0 && !empty($profile->get('orcid')))
 		{
 			$html[] = '<p>' . Lang::txt('COM_MEMBERS_PROFILE_ORCID_ID_AUTHORIZED') . '</p>';
 		}
-		else
+		elseif ($oauthConfigured)
 		{
 			$html[] = '     <a id="authorize-orcid" class="btn" href="https://';
-			if ($config->get('orcid_service', 'members') == 'sandbox')
+			if ($isSandbox)
 			{
 				$html[] = 'sandbox.';
 			}
@@ -97,14 +100,15 @@ class Orcid extends Text
 
 		// Grant permission to manage ORCID record
 		$permissionURI = $config->get('orcid_' . $srv . '_permission_uri', '');
+		$permissionConfigured = ($oauthConfigured && !empty($permissionURI));
 		if ($userID != 0 && !empty($profile->get('orcid')) && !empty($profile->get('access_token')))
 		{
 			$html[] = '<p>' . Lang::txt('COM_MEMBERS_PROFILE_ORCID_PERMISSION_AUTHORIZED') . '</p>';
 		}
-		else
+		elseif ($permissionConfigured)
 		{
 			$html[] = '     <a id="grant-orcid-management-permission" class="btn" href="https://';
-			if ($config->get('orcid_service', 'members') == 'sandbox')
+			if ($isSandbox)
 			{
 				$html[] = 'sandbox.';
 			}

--- a/core/components/com_members/models/fields/orcid.php
+++ b/core/components/com_members/models/fields/orcid.php
@@ -81,7 +81,6 @@ class Orcid extends Text
 		$oauthConfigured = ($srv !== 'public' && !empty($clientID) && !empty($redirectURI));
 		$isSandbox = ($srv === 'sandbox');
 
-
 		$html[] = '	<div class="orcid-actions">';
 		if ($userID != 0 && !empty($profile->get('orcid')))
 		{

--- a/core/components/com_members/models/fields/orcid.php
+++ b/core/components/com_members/models/fields/orcid.php
@@ -80,7 +80,8 @@ class Orcid extends Text
 
 		$oauthConfigured = ($srv !== 'public' && !empty($clientID) && !empty($redirectURI));
 		$isSandbox = ($srv === 'sandbox');
-		
+
+
 		$html[] = '	<div class="orcid-actions">';
 		if ($userID != 0 && !empty($profile->get('orcid')))
 		{


### PR DESCRIPTION
ticket https://nanohub.org/support/ticket/505173

Two changes made:                                                                                                                                             
                                                                                                                                                                
  config/config.xml — Changed orcid_service default from "public" to "members". The XML default was "public" but every PHP code path uses 'members' as its      
  fallback, so if an admin ever saved the config page without explicitly choosing a service it would store "public" — and there's no orcid_public_client_id     
  field, making $clientID permanently empty.                                                                                                                    
                                                                                                                                                                
  models/fields/orcid.php — Added an $oauthConfigured guard before rendering the OAuth buttons:                                                                 
  $oauthConfigured = ($srv !== 'public' && !empty($clientID) && !empty($redirectURI));                                                                          
  The "Create or Connect" and "Grant Permission" buttons now only appear when:                                                                                  
  - The service is not 'public' (which is documented as search-only)                                                                                            
  - orcid_members_client_id (or _sandbox_) is actually filled in                                                                                                
  - The redirect URI is configured                                                                                                                              
                                                                                                                                                                
  This prevents users from clicking a broken link that ORCID rejects. Until the admin configures orcid_members_client_id and orcid_members_redirect_uri in      
  Administrator → Components → Members → Options, the buttons will simply not appear.                                                                           
