### PR TITLE
new plugin to add users to a location_us group if they login from a US IP address

### DIFF
--- a/core/plugins/user/us/language/en-GB/en-GB.plg_user_us.sys.ini
+++ b/core/plugins/user/us/language/en-GB/en-GB.plg_user_us.sys.ini
@@ -1,0 +1,2 @@
+PLG_USER_US="User - US"
+PLG_USER_US_XML_DESCRIPTION="Adds users to the location_us group on login when their IP resolves to a US address via the ipcountry table."

--- a/core/plugins/user/us/migrations/Migration20260421000001PlgUserUs.php
+++ b/core/plugins/user/us/migrations/Migration20260421000001PlgUserUs.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding User - US plugin
+ **/
+class Migration20260421000001PlgUserUs extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$this->addPluginEntry('user', 'us');
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$this->deletePluginEntry('user', 'us');
+	}
+}

--- a/core/plugins/user/us/migrations/Migration20260421000001PlgUserUs.php
+++ b/core/plugins/user/us/migrations/Migration20260421000001PlgUserUs.php
@@ -21,6 +21,15 @@ class Migration20260421000001PlgUserUs extends Base
 	public function up()
 	{
 		$this->addPluginEntry('user', 'us');
+
+		if ($this->db->tableExists('#__xgroups'))
+		{
+			$this->db->setQuery(
+				"INSERT IGNORE INTO `#__xgroups` (`cn`, `published`, `approved`, `type`, `join_policy`, `discoverability`)
+				 VALUES ('location_us', 1, 1, 1, 3, 1)"
+			);
+			$this->db->query();
+		}
 	}
 
 	/**
@@ -28,6 +37,12 @@ class Migration20260421000001PlgUserUs extends Base
 	 **/
 	public function down()
 	{
+		if ($this->db->tableExists('#__xgroups'))
+		{
+			$this->db->setQuery("DELETE FROM `#__xgroups` WHERE `cn` = 'location_us'");
+			$this->db->query();
+		}
+
 		$this->deletePluginEntry('user', 'us');
 	}
 }

--- a/core/plugins/user/us/us.php
+++ b/core/plugins/user/us/us.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Plugin for automatically adding users to the location_us group based on IP country lookup
+ */
+class plgUserUs extends \Hubzero\Plugin\Plugin
+{
+	public function onLoginUser($user, $options = array())
+	{
+		return $this->onUserLogin($user, $options);
+	}
+
+	/**
+	 * This method should handle any login logic and report back to the subject
+	 *
+	 * @param   array  $user     holds the user data
+	 * @param   array  $options  holding options (remember, autoregister, group)
+	 * @return  bool
+	 */
+	public function onUserLogin($user, $options = array())
+	{
+		$ip = $_SERVER['REMOTE_ADDR'];
+
+		$gdb = \Hubzero\Geocode\Geocode::getGeoDBO();
+
+		if (!$gdb)
+		{
+			Log::debug('plgUserUs: geo database unavailable, skipping group update for [' . User::get('username') . '].');
+			return;
+		}
+
+		$gdb->setQuery(
+			"SELECT countrySHORT FROM ipcountry" .
+			" WHERE ipfrom <= INET_ATON(" . $gdb->quote($ip) . ")" .
+			" AND ipto >= INET_ATON(" . $gdb->quote($ip) . ")"
+		);
+		$country = $gdb->loadResult();
+
+		if ($country == 'US')
+		{
+			Log::debug($ip . ' is a US address, adding [' . User::get('username') . '] to group [location_us].');
+
+			$group = \Hubzero\User\Group::getInstance('location_us');
+
+			if (is_object($group))
+			{
+				$group->add('members', array(User::get('id')));
+				$group->update();
+			}
+			else
+			{
+				Log::debug('group [location_us] does not exist, member addition failed.');
+			}
+		}
+		else
+		{
+			Log::debug($ip . ' is not a US address, leaving [' . User::get('username') . '] membership to group [location_us] unchanged.');
+		}
+	}
+
+	public function onAfterDeleteUser($user, $success, $msg)
+	{
+		return $this->onUserAfterDelete($user, $success, $msg);
+	}
+
+	/**
+	 * Method is called after user data is deleted from the database
+	 *
+	 * @param   array   $user     holds the user data
+	 * @param   bool    $success  true if user was successfully stored in the database
+	 * @param   string  $msg      message
+	 */
+	public function onUserAfterDelete($user, $success, $msg)
+	{
+		$group = \Hubzero\User\Group::getInstance('location_us');
+
+		if (is_object($group))
+		{
+			$group->remove('members', array($user['id']));
+			$group->update();
+		}
+	}
+}

--- a/core/plugins/user/us/us.php
+++ b/core/plugins/user/us/us.php
@@ -29,6 +29,23 @@ class plgUserUs extends \Hubzero\Plugin\Plugin
 	{
 		$ip = $_SERVER['REMOTE_ADDR'];
 
+		$d1 = \Hubzero\User\Group::getInstance('d1_nation');
+
+		if (is_object($d1) && in_array(User::get('id'), $d1->get('members')))
+		{
+			Log::debug('[' . User::get('username') . '] is a member of [d1_nation], removing from group [location_us].');
+
+			$group = \Hubzero\User\Group::getInstance('location_us');
+
+			if (is_object($group))
+			{
+				$group->remove('members', array(User::get('id')));
+				$group->update();
+			}
+
+			return;
+		}
+
 		$gdb = \Hubzero\Geocode\Geocode::getGeoDBO();
 
 		if (!$gdb)
@@ -62,7 +79,15 @@ class plgUserUs extends \Hubzero\Plugin\Plugin
 		}
 		else
 		{
-			Log::debug($ip . ' is not a US address, leaving [' . User::get('username') . '] membership to group [location_us] unchanged.');
+			Log::debug($ip . ' is not a US address, removing [' . User::get('username') . '] from group [location_us].');
+
+			$group = \Hubzero\User\Group::getInstance('location_us');
+
+			if (is_object($group))
+			{
+				$group->remove('members', array(User::get('id')));
+				$group->update();
+			}
 		}
 	}
 

--- a/core/plugins/user/us/us.xml
+++ b/core/plugins/user/us/us.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="2.5" type="plugin" group="user">
+	<name>plg_user_us</name>
+	<author>HUBzero</author>
+	<authorUrl>hubzero.org</authorUrl>
+	<authorEmail>support@hubzero.org</authorEmail>
+	<copyright>Copyright (c) 2005-2020 The Regents of the University of California.</copyright>
+	<license>http://opensource.org/licenses/MIT MIT</license>
+	<description>PLG_USER_US_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="us">us.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_user_us.sys.ini</language>
+	</languages>
+</extension>


### PR DESCRIPTION
Motivation: file permissions require a group for people in the US. Filling the iplocation table of the network database with a copy of the ip ranges applicable to the us is silly because that's a lot of rows to copy and it creates a management problem to keep the copy up to date. Instead, this plugin uses an SQL query with a join operation.

Three files created under core/plugins/user/us/:
  - us.php — on login, queries the ipcountry table in the geo database using INET_ATON(). If countrySHORT == 'US', adds the user to location_us. Logs both the
  match and non-match cases. On account deletion, removes the user from location_us (with is_object() guard).
  - us.xml — extension manifest
  - language/en-GB/en-GB.plg_user_us.sys.ini — admin UI label
  
  