### PR TITLE
created plugin to add users to a D1 nations group if they login from an IP address from one of those nations

### DIFF
--- a/core/plugins/user/d1/d1.php
+++ b/core/plugins/user/d1/d1.php
@@ -27,11 +27,11 @@ class plgUserD1 extends \Hubzero\Plugin\Plugin
 	 */
 	public function onUserLogin($user, $options = array())
 	{
-		$approved = \Hubzero\User\Group::getInstance('d1_approved');
+		$approved = \Hubzero\User\Group::getInstance('d1_override');
 
 		if (is_object($approved) && $approved->isMember(User::get('id')))
 		{
-			Log::debug('plgUserD1: [' . User::get('username') . '] is in d1_approved, removing from d1_nation and skipping geo check.');
+			Log::debug('plgUserD1: [' . User::get('username') . '] is in d1_override, removing from d1_nation and skipping geo check.');
 
 			$nation = \Hubzero\User\Group::getInstance('d1_nation');
 

--- a/core/plugins/user/d1/d1.php
+++ b/core/plugins/user/d1/d1.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Plugin for automatically adding users to the d1_nation group based on IP country group lookup
+ */
+class plgUserD1 extends \Hubzero\Plugin\Plugin
+{
+	public function onLoginUser($user, $options = array())
+	{
+		return $this->onUserLogin($user, $options);
+	}
+
+	/**
+	 * This method should handle any login logic and report back to the subject
+	 *
+	 * @param   array  $user     holds the user data
+	 * @param   array  $options  holding options (remember, autoregister, group)
+	 * @return  bool
+	 */
+	public function onUserLogin($user, $options = array())
+	{
+		$ip = $_SERVER['REMOTE_ADDR'];
+
+		$gdb = \Hubzero\Geocode\Geocode::getGeoDBO();
+
+		if (!$gdb)
+		{
+			Log::debug('plgUserD1: geo database unavailable, skipping group update for [' . User::get('username') . '].');
+			return;
+		}
+
+		$gdb->setQuery(
+			"SELECT cg.countrygroup FROM ipcountry ic" .
+			" JOIN countrygroup cg ON ic.countrySHORT = cg.countrycode" .
+			" WHERE ic.ipfrom <= INET_ATON(" . $gdb->quote($ip) . ")" .
+			" AND ic.ipto >= INET_ATON(" . $gdb->quote($ip) . ")"
+		);
+		$countrygroup = $gdb->loadResult();
+
+		if (!$countrygroup)
+		{
+			return;
+		}
+
+		if ($countrygroup == 'D1')
+		{
+			Log::debug($ip . ' is in a D1 nation, adding [' . User::get('username') . '] to group [d1_nation].');
+
+			$group = \Hubzero\User\Group::getInstance('d1_nation');
+
+			if (is_object($group))
+			{
+				$group->add('members', array(User::get('id')));
+				$group->update();
+			}
+			else
+			{
+				Log::debug('group [d1_nation] does not exist, member addition failed.');
+			}
+		}
+		else
+		{
+			Log::debug($ip . ' has countrygroup [' . $countrygroup . '], leaving [' . User::get('username') . '] membership to group [d1_nation] unchanged.');
+		}
+	}
+
+	public function onAfterDeleteUser($user, $success, $msg)
+	{
+		return $this->onUserAfterDelete($user, $success, $msg);
+	}
+
+	/**
+	 * Method is called after user data is deleted from the database
+	 *
+	 * @param   array   $user     holds the user data
+	 * @param   bool    $success  true if user was successfully stored in the database
+	 * @param   string  $msg      message
+	 */
+	public function onUserAfterDelete($user, $success, $msg)
+	{
+		$group = \Hubzero\User\Group::getInstance('d1_nation');
+
+		if (is_object($group))
+		{
+			$group->remove('members', array($user['id']));
+			$group->update();
+		}
+	}
+}

--- a/core/plugins/user/d1/d1.php
+++ b/core/plugins/user/d1/d1.php
@@ -27,6 +27,23 @@ class plgUserD1 extends \Hubzero\Plugin\Plugin
 	 */
 	public function onUserLogin($user, $options = array())
 	{
+		$approved = \Hubzero\User\Group::getInstance('d1_approved');
+
+		if (is_object($approved) && $approved->isMember(User::get('id')))
+		{
+			Log::debug('plgUserD1: [' . User::get('username') . '] is in d1_approved, removing from d1_nation and skipping geo check.');
+
+			$nation = \Hubzero\User\Group::getInstance('d1_nation');
+
+			if (is_object($nation))
+			{
+				$nation->remove('members', array(User::get('id')));
+				$nation->update();
+			}
+
+			return;
+		}
+
 		$ip = $_SERVER['REMOTE_ADDR'];
 
 		$gdb = \Hubzero\Geocode\Geocode::getGeoDBO();

--- a/core/plugins/user/d1/d1.xml
+++ b/core/plugins/user/d1/d1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="2.5" type="plugin" group="user">
+	<name>plg_user_d1</name>
+	<author>HUBzero</author>
+	<authorUrl>hubzero.org</authorUrl>
+	<authorEmail>support@hubzero.org</authorEmail>
+	<copyright>Copyright (c) 2005-2020 The Regents of the University of California.</copyright>
+	<license>http://opensource.org/licenses/MIT MIT</license>
+	<description>PLG_USER_D1_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="d1">d1.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_user_d1.sys.ini</language>
+	</languages>
+</extension>

--- a/core/plugins/user/d1/language/en-GB/en-GB.plg_user_d1.sys.ini
+++ b/core/plugins/user/d1/language/en-GB/en-GB.plg_user_d1.sys.ini
@@ -1,0 +1,2 @@
+PLG_USER_D1="User - D1"
+PLG_USER_D1_XML_DESCRIPTION="Adds users to the d1_nation group on login when their IP resolves to a D1 country group via the ipcountry and countrygroup tables."

--- a/core/plugins/user/d1/migrations/Migration20260421000000PlgUserD1.php
+++ b/core/plugins/user/d1/migrations/Migration20260421000000PlgUserD1.php
@@ -21,6 +21,18 @@ class Migration20260421000000PlgUserD1 extends Base
 	public function up()
 	{
 		$this->addPluginEntry('user', 'd1');
+
+		if ($this->db->tableExists('#__xgroups'))
+		{
+			foreach (array('d1_nation', 'd1_override') as $cn)
+			{
+				$this->db->setQuery(
+					"INSERT IGNORE INTO `#__xgroups` (cn, description, published, approved, type, join_policy, discoverability, created)" .
+					" VALUES (" . $this->db->quote($cn) . ", " . $this->db->quote($cn) . ", 1, 1, 1, 3, 1, NOW())"
+				);
+				$this->db->query();
+			}
+		}
 	}
 
 	/**
@@ -29,5 +41,13 @@ class Migration20260421000000PlgUserD1 extends Base
 	public function down()
 	{
 		$this->deletePluginEntry('user', 'd1');
+
+		if ($this->db->tableExists('#__xgroups'))
+		{
+			$this->db->setQuery(
+				"DELETE FROM `#__xgroups` WHERE cn IN ('d1_nation', 'd1_override')"
+			);
+			$this->db->query();
+		}
 	}
 }

--- a/core/plugins/user/d1/migrations/Migration20260421000000PlgUserD1.php
+++ b/core/plugins/user/d1/migrations/Migration20260421000000PlgUserD1.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package    hubzero-cms
+ * @copyright  Copyright (c) 2005-2020 The Regents of the University of California.
+ * @license    http://opensource.org/licenses/MIT MIT
+ */
+
+use Hubzero\Content\Migration\Base;
+
+// No direct access
+defined('_HZEXEC_') or die();
+
+/**
+ * Migration script for adding User - D1 plugin
+ **/
+class Migration20260421000000PlgUserD1 extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+		$this->addPluginEntry('user', 'd1');
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+		$this->deletePluginEntry('user', 'd1');
+	}
+}


### PR DESCRIPTION
Motivation: file permissions require a group for people from D1 nations. Filling the iplocation table of the network database with a copy of the ip ranges applicable to the D1 nations group is silly because that's a lot of rows to copy and it creates a management problem to keep the copy up to date. Instead, this plugin uses an SQL query with a join operation.

Does plg_user_purdue duplicate what plg_user_geo could do if it was configured to use the purdue group and the "pu" location? From what I can see both use custom locations in the iplocation table of the network database, in this case it would be the "pu" location
[7:09 PM]There's a need to put users from D1 nations into a group at login, so that the tool access limitation done in PHP can be mirrored in the filesystem permissions for /apps by setting UNIX acls using that group

Three files created under core/plugins/user/d1/:
  - d1.php — on login, runs the JOIN query against the geo database. If no row is returned (IP not in any country group), returns immediately without touching group membership. If
  countrygroup == 'D1', adds the user to d1_nation. Any other countrygroup is logged but ignored. On account deletion, removes the user from d1_nation.
  - d1.xml — extension manifest
  - language/en-GB/en-GB.plg_user_d1.sys.ini — admin UI label (edited)   