### PR TITLE
[PURR][#2780]Made a few updates to the image description

### DIFF
--- a/core/components/com_publications/admin/views/items/tmpl/editcontent.php
+++ b/core/components/com_publications/admin/views/items/tmpl/editcontent.php
@@ -95,7 +95,7 @@ if ($tmpl != 'component')
 								<input type="text" name="attachments[<?php echo $attach->id; ?>][title]" maxlength="250" value="<?php echo $attach->title; ?>" />
 								<?php if ($attach->role == 3) { ?>
 									<label><?php echo Lang::txt('COM_PUBLICATIONS_FIELD_ATTACHMENT_GALLERY_DESCRIPTION'); ?>:</label>
-									<input type="text" name="attachments[<?php echo $attach->id; ?>][attribs]" maxlength="250" value="<?php echo $attach->attribs; ?>" />
+									<textarea name="attachments[<?php echo $attach->id; ?>][attribs]" rows="10" cols="60" maxlength="5000" value="<?php echo $attach->attribs; ?>" placeholder="Enter up to 5000 characters..."><?php echo $attach->attribs;; ?></textarea>
 								<?php } ?>
 							</div>
 						<?php } ?>

--- a/core/components/com_publications/models/attachments/file.php
+++ b/core/components/com_publications/models/attachments/file.php
@@ -243,6 +243,11 @@ class File extends Base
 				if ($zip->addFile($filePath, $where))
 				{
 					$readme .= '>>> ' . str_replace($bundleDir . DS, '', $where) . "\n";
+					
+					if (!empty($attach->attribs))
+					{
+						$readme .= '>>> ' . $attach->attribs . "\n";
+					}
 				}
 			}
 		}
@@ -1818,6 +1823,7 @@ class File extends Base
 		$data->set('pubPath', $configs->pubPath);
 		$data->set('props', $view->master->block . '-' . $view->master->blockId . '-' . $view->elementId);
 		$data->set('downloadUrl', Route::url($view->pub->link('serve') . '&el=' . $view->elementId . '&a=' . $att->id . '&download=1'));
+		$data->set('attribs', $att->attribs);
 
 		// Is attachment (image) also publication thumbnail
 		$params = new \Hubzero\Config\Registry($att->params);

--- a/core/plugins/projects/publications/views/attachments/tmpl/image.php
+++ b/core/plugins/projects/publications/views/attachments/tmpl/image.php
@@ -18,6 +18,11 @@ if ($data->get('viewer') != 'freeze')
 	$details.= !$data->exists() ? ' | ' . Lang::txt('PLG_PROJECTS_PUBLICATIONS_MISSING_FILE') : '';
 }
 
+if (!empty($data->get('attribs')))
+{
+	$details.= ' | ' . $data->get('attribs');
+}
+
 // Get settings
 $suffix = isset($this->config->params->thumbSuffix) && $this->config->params->thumbSuffix
 		? $this->config->params->thumbSuffix : '-tn';

--- a/core/plugins/projects/publications/views/edititem/tmpl/attachment.php
+++ b/core/plugins/projects/publications/views/edititem/tmpl/attachment.php
@@ -84,7 +84,7 @@ $placeholder = $this->row->title && $this->row->title != $defaultTitle ? $this->
 						</p>
 						<p class="c-wrapper">
 							<span class="leftshift faded"><?php echo ucfirst(Lang::txt('PLG_PROJECTS_PUBLICATIONS_FILE_DESCRIPTION')); ?>:</span>
-							<input type="text" name="description" maxlength="250" class="long" value="<?php echo $this->row && $this->row->attribs ? $this->row->attribs : ""; ?>" placeholder="<?php echo $this->row->attribs; ?>" />
+							<textarea name="description" class="long" rows="10" cols="60" maxlength="5000" value="<?php echo $this->row->attribs; ?>" placeholder="Enter up to 5000 characters..."><?php echo $this->row->attribs;; ?></textarea>
 						</p>
 					<?php } else { ?>
 						<p class="c-wrapper">


### PR DESCRIPTION
PURR Ticket: https://purr.purdue.edu/support/ticket/2780

1. The input text field length for image description is set to 250 characters now, however, user might enter a longer description than what the input text field currently can accommodate.
2. We want the image description to be included in the download bundle. 
3. Display the image description in the gallery section in publication submission workflow and on dataset review page.

Code changes:
1. Switch the input text field for image description to textarea element, and the length is going to be set to 5000 to accommodate a long text.
2. Add the image description after the image file name in the hubREADME.txt that is part of the dataset bundle.
3. Add the attribs property value to the attachment model so that it can be used to display in the gallery section.

Test steps:
1. Create a publication and add image to the gallery section. Edit the image to enter a long text such as 2000 characters in the textarea field as image description, then save it which should be successful.
2. Submit the dataset. On the dataset review page, you should see the image description for the file in the gallery image section.
3. Approve the publication, download the dataset from the publication and check whether the 2000-character image description exists in the hubREADME.txt in the dataset bundle.

I tested changes on dev PURR and they work as expected.

Jerry
