### PR TITLE
all existing members beyond the first treated as new enrollments 

### DIFF
--- a/core/libraries/Hubzero/User/Group.php
+++ b/core/libraries/Hubzero/User/Group.php
@@ -557,15 +557,7 @@ class Group extends Obj
 				$db->setQuery($query);
 
 				// compile current list of members in this group
-				$aExistingUserMembership = array();
-
-				if (($results = $db->loadAssoc()))
-				{
-					foreach ($results as $uid)
-					{
-						$aExistingUserMembership[] = $uid;
-					}
-				}
+				$aExistingUserMembership = $db->loadColumn() ?: array();
 
 				// see who is new, merge with previous additions so we have a complete list after we are done
 				$aNewUserGroupEnrollments = array_merge($aNewUserGroupEnrollments, array_diff($list, $aExistingUserMembership));


### PR DESCRIPTION
Group::update() must detect which UIDs are newly added to a group so it can fire groups.onGroupUserEnrollment only for real new enrollments. Because the method rewrites the entire membership list on every save (noted in the two @FIXME comments at lines 544–552), it snapshots the current DB members before the write and diffs against them.

The snapshot at line 562 uses loadAssoc(), which returns one row as a flat associative array — ['uidNumber' => '123']. The foreach over that result iterates key/value pairs, so $aExistingUserMembership ends up as ['uidNumber', '123'] regardless of group size. array_diff($list, $aExistingUserMembership) then classifies every UID except the first as a new enrollment, causing the event to fire spuriously for all existing members whenever the group is saved.

 Fix

     File: core/libraries/Hubzero/User/Group.php
     Lines: 559–568 (inside update(), within the members/managers branch)

     Replace the buggy snapshot block with a single loadColumn() call — consistent with the identical pattern already used in _userids() at line 947.

     loadColumn() returns a flat array of every value in the first selected column — here all uidNumber values for the group — and returns null on an empty result set, so ?: array() provides the safe fallback.

     Everything else (the array_diff, array_merge, event firing loop at lines 570–619) is correct and unchanged.
     - The two @FIXME comments (lines 544–552) document known scale limitations and the reason for this workaround; they remain accurate and should be
     preserved.
     - The query itself (SELECT uidNumber FROM #__xgroups_members WHERE gidNumber=…) is correct.
     - The managers branch uses the same query and same snapshot, so the single-line fix covers both.

The fix replaces lines 559–568 with a single line:

  $aExistingUserMembership = $db->loadColumn() ?: array();

  Why this fixes it: loadAssoc() returns one row as ['uidNumber' => '123'], so the old foreach only ever added one UID (plus the string key 'uidNumber') to the
  array. loadColumn() returns a flat array of all values in the first column — every uidNumber in the group — which is what array_diff needs to correctly
  identify only truly new enrollments.

  The pattern is consistent with _userids() at line 947, the two @FIXME comments are preserved verbatim, and nothing else in the method changes.

