### PR TITLE
Include ReturnUrl helper in registration controller

### DIFF
--- a/core/components/com_members/site/controllers/register.php
+++ b/core/components/com_members/site/controllers/register.php
@@ -26,6 +26,7 @@ use Components\Members\Helpers\ReturnUrl;
 
 include_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'registration.php';
 include_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'member.php';
+include_once dirname(dirname(__DIR__)) . DS . 'helpers' . DS . 'returnurl.php';
 
 /**
  * Controller class for member registration


### PR DESCRIPTION
Include ReturnUrl helper in registration controller

Getting error "class not found" when registering new user on a new hub
