### PR TITLE
com_resources: restrict /api/resources/list to the caller's access level

### DIFF
--- a/core/components/com_resources/api/controllers/entriesv1_0.php
+++ b/core/components/com_resources/api/controllers/entriesv1_0.php
@@ -11,6 +11,7 @@ use Components\Resources\Models\Entry;
 use Components\Resources\Models\Type;
 use Hubzero\Component\ApiController;
 use Component;
+use User;
 use Exception;
 use stdClass;
 use Request;
@@ -100,9 +101,20 @@ class Entriesv1_0 extends ApiController
 					->resetDepth();
 		}
 
-		if ($filters['type'])
+		if ($filters['type'] !== '')
 		{
-			$query->whereEquals($r . '.type', $filters['type']);
+			// `type` is documented as a type name, but was compared straight
+			// against the numeric column, so only ids ever matched. Resolve an
+			// alias to its id, and let an unknown one match nothing rather
+			// than falling through and matching everything.
+			if (!is_numeric($filters['type']))
+			{
+				$type = Type::oneByAlias($filters['type']);
+
+				$filters['type'] = ($type && $type->get('id')) ? (int) $type->get('id') : -1;
+			}
+
+			$query->whereEquals($r . '.type', (int) $filters['type']);
 		}
 
 		$query->whereEquals($r . '.publish_up', '0000-00-00 00:00:00', 1)
@@ -116,6 +128,26 @@ class Entriesv1_0 extends ApiController
 			->resetDepth();
 
 		$query->whereEquals($r . '.published', Entry::STATE_PUBLISHED);
+
+		// Restrict to what the caller may actually see. Without this the
+		// endpoint returned registered-, protected- and private-level entries
+		// to anonymous callers: `standalone`, `published` and the publish
+		// window were the only filters applied.
+		//
+		// Same rule the site views use: public for everyone, plus
+		// registered-level once authenticated. Component administrators keep
+		// the unrestricted view they had.
+		if (!User::authorise('core.admin', 'com_resources'))
+		{
+			$access = array(0);   // public
+
+			if (!User::isGuest())
+			{
+				$access[] = 1;    // registered
+			}
+
+			$query->whereIn($r . '.access', $access);
+		}
 
 		switch ($filters['sortby'])
 		{

--- a/core/components/com_resources/api/controllers/entriesv1_1.php
+++ b/core/components/com_resources/api/controllers/entriesv1_1.php
@@ -12,6 +12,8 @@ use Components\Resources\Models\Type;
 use Components\Tags\Models\Cloud;
 use Hubzero\Component\ApiController;
 use Component;
+use Config;
+use User;
 use Exception;
 use stdClass;
 use Request;
@@ -111,9 +113,20 @@ class Entriesv1_1 extends ApiController
 					->resetDepth();
 		}
 
-		if ($filters['type'])
+		if ($filters['type'] !== '')
 		{
-			$query->whereEquals($r . '.type', $filters['type']);
+			// `type` is documented as a type name, but was compared straight
+			// against the numeric column, so only ids ever matched. Resolve an
+			// alias to its id, and let an unknown one match nothing rather
+			// than falling through and matching everything.
+			if (!is_numeric($filters['type']))
+			{
+				$type = Type::oneByAlias($filters['type']);
+
+				$filters['type'] = ($type && $type->get('id')) ? (int) $type->get('id') : -1;
+			}
+
+			$query->whereEquals($r . '.type', (int) $filters['type']);
 		}
 
 		$query->whereEquals($r . '.publish_up', '0000-00-00 00:00:00', 1)
@@ -127,6 +140,26 @@ class Entriesv1_1 extends ApiController
 			->resetDepth();
 
 		$query->whereEquals($r . '.published', Entry::STATE_PUBLISHED);
+
+		// Restrict to what the caller may actually see. Without this the
+		// endpoint returned registered-, protected- and private-level entries
+		// to anonymous callers: `standalone`, `published` and the publish
+		// window were the only filters applied.
+		//
+		// Same rule the site views use: public for everyone, plus
+		// registered-level once authenticated. Component administrators keep
+		// the unrestricted view they had.
+		if (!User::authorise('core.admin', 'com_resources'))
+		{
+			$access = array(0);   // public
+
+			if (!User::isGuest())
+			{
+				$access[] = 1;    // registered
+			}
+
+			$query->whereIn($r . '.access', $access);
+		}
 
 		switch ($filters['sortby'])
 		{


### PR DESCRIPTION
listTask filtered on standalone, published and the publish window only, so GET /api/resources/list returned registered-, protected- and private-level entries to anonymous callers, including their titles, introtext and fulltxt.

Apply the same rule the site views use: public for everyone, plus registered-level once authenticated. Component administrators keep the unrestricted view, so the admin `searchable` path in v1.1 is unaffected.

Two related fixes in the same task:

- `type` is documented as a type name but was compared straight against the numeric column, so only ids ever matched and an alias silently returned everything. Resolve an alias to its id, and let an unknown alias match nothing.

- v1.1 referenced Config:: and User:: without importing them. Inside `namespace Components\Resources\Api\Controllers` those resolve to classes in that namespace, so the first call would throw "class not found". v1.0 already used a leading backslash for Config.

# Before you submit this pull request, please make sure:

- [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [] Include a brief summary of the issue **in your own words**
- [] Include a brief summary of the fix/changed code
- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [] Double check someone is assigned to review the ticket

**Thanks!**
