### PR TITLE
[PURR][2789]Solve special characters issue with publication description grant title and grant agency

### DIFF
--- a/core/components/com_publications/models/doi.php
+++ b/core/components/com_publications/models/doi.php
@@ -247,7 +247,7 @@ class Doi extends Obj
 		$this->set('doi', $pub->version->doi);
 		$this->set('title', htmlspecialchars($pub->version->title));
 		$this->set('version', htmlspecialchars($pub->version->version_label));
-		$this->set('abstract', htmlspecialchars($pub->version->description));
+		$this->set('abstract', html_entity_decode(strip_tags($pub->version->description), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
 		$this->set('synopsis', htmlspecialchars($pub->version->abstract));
 		
 		$this->set('url', $this->_configs->livesite . DS . 'publications'. DS . $pub->id . DS . $pub->version->version_number);
@@ -394,7 +394,7 @@ class Doi extends Obj
 		$grantInfo = [];
 		if ($project->params->get('grant_title'))
 		{
-			$grantInfo['grant_title'] = $project->params->get('grant_title');
+			$grantInfo['grant_title'] = html_entity_decode($project->params->get('grant_title'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
 		}
 		if ($project->params->get('award_number'))
 		{
@@ -402,7 +402,7 @@ class Doi extends Obj
 		}
 		if ($project->params->get('grant_agency'))
 		{
-			$grantInfo['grant_agency'] = $project->params->get('grant_agency');
+			$grantInfo['grant_agency'] = html_entity_decode($project->params->get('grant_agency'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
 		}
 		if ($project->params->get('grant_agency_id'))
 		{


### PR DESCRIPTION
PURR Ticket: https://purr.purdue.edu/support/ticket/2789

We recently dealt with an issue that the project (alias smtranscriptomic)'s grant agency and publication (pub id 5151, version 1) description in database include html entities such as "&rsquo;". They are not predefined and cause the xml validation error on DataCite. So, we need to decode the publication description, as well as grant title and grant agency, so that the text includes the Unicode characters only to be able to validated on DataCite.

The changes are to decode description in publication, grant title, grant agency in the project setting, when setting them in DOI metadata metadata xml that is sent to DataCite.

Test procedure:
1. Create a project, setting the funding title with the single quotation mark included, such as "Skeletal Muscle Dysfunction: A Missing Component in the Etiology's Dairy Cattle Ketosis", also includes it in the grant agency such as "U.S. Department of Agriculture’s National Institute of Food and Agriculture", then finish setting uo the project. Approve the funding info through the project review page.
2. Start a publication, include β, ≤, ≥ in the text that you fill out the description. Finish the rest of the steps and submit the publication.

The expected result is that the publication can be successfully submitted.

I test the changes on dev PURR and it works as expected.
