### PR TITLE
com_resources: play legacy video attachments instead of downloading them

### DIFF
--- a/core/components/com_resources/helpers/html.php
+++ b/core/components/com_resources/helpers/html.php
@@ -631,6 +631,38 @@ class Html
 	}
 
 	/**
+	 * Determine if a legacy media type is actually holding a playable video file
+	 *
+	 * Video attachments predating the 'video' resource type are typed
+	 * 'quicktime' or 'player'. The router knows neither, so they fall through
+	 * to a download link even though they are plain video files. Route those to
+	 * the HTML5 player instead - but only where the player can handle them: the
+	 * file has to be one of the formats the manifest builder collects, and it
+	 * has to live in the resource's own filespace.
+	 *
+	 * @param   object   $item  Child resource
+	 * @return  boolean
+	 */
+	public static function isLegacyPlayableVideo($item)
+	{
+		if (!in_array($item->type->alias, array('quicktime', 'player')))
+		{
+			return false;
+		}
+
+		// Externally hosted or absolute paths have no filespace to build a manifest from
+		if (strstr($item->path, 'http')
+		 || substr($item->path, 0, 3) == 'mms'
+		 || substr($item->path, 0, 1) == '/')
+		{
+			return false;
+		}
+
+		// Keep in sync with the extensions buildVideoManifestForResource() globs for
+		return (bool) preg_match('/\.(mp4|ogv|webm)$/i', $item->path);
+	}
+
+	/**
 	 * Determine the final URL for the primary resource child
 	 *
 	 * @param   string   $option  Component name
@@ -648,6 +680,14 @@ class Html
 		else
 		{
 			$type = $item->type->alias;
+
+			// Legacy media types still carry plain video files. Send those to the
+			// player too, unless the caller explicitly asked for the file itself
+			// ($action 3 - the OAI-PMH miner harvests direct file URLs).
+			if ($action != 3 && self::isLegacyPlayableVideo($item))
+			{
+				return Route::url('index.php?option=' . $option . '&id=' . $pid . '&resid=' . $item->id . '&task=video');
+			}
 
 			switch ($type)
 			{
@@ -1034,6 +1074,16 @@ class Html
 					$childParams = $firstChild->params;
 					$linkAction = intval($childParams->get('link_action', $linkAction));
 
+					$isVideo = ($firstChild->type->alias == 'video' || self::isLegacyPlayableVideo($firstChild));
+
+					// A playable video always goes to the player. The generic linkAction
+					// hint the type carries - legacy logical types such as
+					// 'Podcast (video)' are commonly set to 'download' - must not win.
+					if ($isVideo)
+					{
+						$linkAction = 0;
+					}
+
 					$url = self::processPath($option, $firstChild, $resource->id, $linkAction);
 
 					switch ($linkAction)
@@ -1077,6 +1127,13 @@ class Html
 					//$rt = new \Components\Resources\Tables\Type($database);
 					//$rt->load($firstChild->type);
 
+					// resources.js keys the inline embed off this class
+					if ($isVideo)
+					{
+						$class = 'video';
+						$mesg  = Lang::txt('COM_RESOURCES_VIEW_PRESENTATION');
+					}
+
 					//if we are a hubpresenter resource type, do not show file type in button
 					if ($firstChild->type->alias == 'hubpresenter')
 					{
@@ -1087,11 +1144,6 @@ class Html
 					else
 					{
 						$mesg .= ' ' . self::getFileAttribs($firstChild->path);
-					}
-
-					if ($firstChild->type->alias == 'video')
-					{
-						$class = 'video';
 					}
 
 					if ($resource->type->alias == 'databases')

--- a/core/components/com_resources/site/controllers/resources.php
+++ b/core/components/com_resources/site/controllers/resources.php
@@ -1083,21 +1083,32 @@ class Resources extends SiteController
 			App::abort(403, Lang::txt('COM_CONTRIBUTE_NOT_AUTH'));
 		}
 
-		// Check to see if we have a manifest
-		if (!$this->videoManifestExistsForResource($activechild))
+		// Load the manifest, rebuilding it from the filespace when it is missing or unusable
+		$manifest     = null;
+		$manifestPath = PATH_APP . $this->getVideoManifestForResource($activechild);
+
+		if (is_file($manifestPath))
 		{
-			$this->createVideoManifestForResource($activechild);
+			$manifest = json_decode(file_get_contents($manifestPath));
 		}
 
-		// Get manifest
-		$manifest = $this->getVideoManifestForResource($activechild);
+		if (!isset($manifest->presentation))
+		{
+			$manifest = $this->buildVideoManifestForResource($activechild);
 
-		if (!file_exists(PATH_APP . $manifest))
+			// Cache it for next time, but do not require the write to succeed - an
+			// unwritable filespace should not cost the user the player. An empty
+			// manifest is never cached, or it would mask files landing later.
+			if (count($manifest->presentation->media) > 0)
+			{
+				\Filesystem::write($manifestPath, json_encode($manifest, JSON_PRETTY_PRINT));
+			}
+		}
+
+		if (empty($manifest->presentation->media))
 		{
 			App::abort(404, Lang::txt('COM_RESOURCES_RESOURCE_NOT_FOUND'));
 		}
-
-		$manifest = json_decode(file_get_contents(PATH_APP . $manifest));
 
 		// Media tracking object
 		require_once dirname(dirname(__DIR__)) . DS . 'models' . DS . 'mediatracking.php';
@@ -1168,12 +1179,17 @@ class Resources extends SiteController
 	}
 
 	/**
-	 * Get Video Manifest for resource
+	 * Get the filespace holding a resource's video, relative to PATH_APP
 	 *
-	 * @param   object   $resource  HUB Resource
-	 * @return  boolean
+	 * Both the reader and the writer go through here. filespace() is not
+	 * interchangeable with it: that derives the directory from the created date
+	 * and a zero-padded id, which does not always agree with the path actually
+	 * stored on the attachment.
+	 *
+	 * @param   object  $resource  HUB Resource
+	 * @return  string
 	 */
-	private function getVideoManifestForResource($resource)
+	private function getVideoPathForResource($resource)
 	{
 		// Base url for the resource
 		$base = DS . trim($this->config->get('uploadpath'), DS);
@@ -1188,41 +1204,32 @@ class Resources extends SiteController
 		// Build the rest of the resource path and combine with base
 		$path = $path ? $path : $resource->relativepath();
 
-		// Get manifests
-		$manifests = \Filesystem::files(PATH_APP . DS . $base . $path, '.json');
-
-		// Return path to manifest if we have one
-		return (count($manifests) > 0) ? $base . $path . DS . $manifests[0] : array();
+		return $base . $path;
 	}
 
 	/**
-	 * Check for Video manifest file
+	 * Get the path to a resource's video manifest, relative to PATH_APP
 	 *
-	 * @param   object   $resource  HUB Resource
-	 * @return  boolean
-	 */
-	private function videoManifestExistsForResource($resource)
-	{
-		// Get video manifest
-		$manifest = $this->getVideoManifestForResource($resource);
-
-		// Do we have a manifest already?
-		return (!is_array($manifest) || count($manifest) < 1) ? false : true;
-	}
-
-	/**
-	 * Create manifest file for video
+	 * Named explicitly rather than taken as "the first .json in the directory" -
+	 * an unrelated sidecar would otherwise be loaded as the manifest.
 	 *
 	 * @param   object  $resource  HUB Resource
-	 * @return  boolean
+	 * @return  string
 	 */
-	private function createVideoManifestForResource($resource)
+	private function getVideoManifestForResource($resource)
 	{
-		//base url for the resource
-		//$base = DS . trim($this->config->get('uploadpath'), DS);
+		return $this->getVideoPathForResource($resource) . DS . 'presentation.json';
+	}
 
-		//build the rest of the resource path and combine with base
-		$path = $resource->filespace();
+	/**
+	 * Build a video manifest for a resource from the files in its filespace
+	 *
+	 * @param   object  $resource  HUB Resource
+	 * @return  object
+	 */
+	private function buildVideoManifestForResource($resource)
+	{
+		$path = PATH_APP . $this->getVideoPathForResource($resource);
 
 		//instantiate params object then parse resource attributes
 		$attributes = $resource->attribs;
@@ -1302,16 +1309,7 @@ class Resources extends SiteController
 		$manifest->presentation->media     = array_values($manifest->presentation->media);
 		$manifest->presentation->subtitles = array_values($manifest->presentation->subtitles);
 
-		// json encode manifest
-		$manifest = json_encode($manifest, JSON_PRETTY_PRINT);
-
-		// attempt to create manifest file
-		if (!\Filesystem::write($path . DS . 'presentation.json', $manifest))
-		{
-			return false;
-		}
-
-		return true;
+		return $manifest;
 	}
 
 	/**


### PR DESCRIPTION
The HTML5 player is only reachable when a child attachment's type alias is literally 'video'. Hubs that predate that type store plain video files under 'quicktime' or 'player', neither of which processPath() knows about, so they fall through to the download branch. On nanoHUB no 'video' type exists in the child-type category at all, which makes task=video unreachable: every mp4 gets a download link, even though both aliases sit in the $mediatypes list that labels them "View Presentation".

Route those two aliases to the player when the attachment is something the player can actually handle - one of the formats the manifest builder collects, living in the resource's own filespace. Externally hosted and absolute paths keep their existing behaviour, as does a caller explicitly asking for the file itself ($action 3), so the OAI-PMH miner still harvests direct file URLs.

primary_child() forces linkAction to 0 for a playable video: legacy logical types such as 'Podcast (video)' commonly carry a 'download' hint that would otherwise both relabel the button and beat the routing. The 'video' CSS class is what resources.js keys the inline embed off.

Also harden videoTask now that far more resources reach it:

- read and write the manifest through one path helper. The writer used filespace(), which derives the directory from the created date and a padded id; where that disagreed with the attachment's stored path the manifest was written somewhere the reader never looked, giving a permanent 404.
- name presentation.json explicitly instead of taking the first .json in the directory, so an unrelated sidecar cannot be loaded as the manifest and fatal the view.
- fall back to an in-memory manifest when the filespace is unwritable, rather than 404ing, and never cache an empty one.

