### PR TITLE
[PURR][#2806]Update the author name ordering in OAIPMH

### DIFF
--- a/core/plugins/oaipmh/publications/data/miner.php
+++ b/core/plugins/oaipmh/publications/data/miner.php
@@ -387,7 +387,7 @@ class Miner extends Obj implements Provider
 			"SELECT pa.name, pa.user_id
 			FROM `#__publication_authors` AS pa
 			WHERE (pa.role IS NULL OR pa.role != 'submitter') AND pa.status=1 AND pa.publication_version_id=" . $this->database->quote($record->version_id) . "
-			ORDER BY pa.name"
+			ORDER BY pa.ordering"
 		);
 		$creators = $this->database->loadObjectList();
 		foreach ($creators as $creator)


### PR DESCRIPTION
Author order in OAIPMH harvest

The author's order in OAIPMH harvest result is sorted by the author name. However, we expect the order is sorted by the ordering when they are set in PURR publication.

The change is to set the author order by ordering in publication instead of by author name.

Test procedure:

Harvest any dataset and compare the result with the author order on publication page to see if it is the same or not.

Visit the URL: view-source:https://purr.purdue.edu/oaipmh?verb=GetRecord&identifier=10.4231/Y5P6-1V33&metadataPrefix=oai_dc in browser. Check whether the order of the author names in element <dc:creator> is the same as that on the publication page: https://purr.purdue.edu/publications/5151/1

Test is done on production and it works as expected.