### PR TITLE
Cast session to string in SafePath directory call

### DIFF
--- a/core/components/com_tools/api/controllers/sessionsv1_0.php
+++ b/core/components/com_tools/api/controllers/sessionsv1_0.php
@@ -1068,7 +1068,7 @@ class Sessionsv1_0 extends ApiController
 			$profile->get('username') . DS . 'data' . DS . 'sessions'
 		);
 
-		$dir = $sessions ? \Hubzero\Filesystem\SafePath::directory($sessions, $session) : false;
+		$dir = $sessions ? \Hubzero\Filesystem\SafePath::directory($sessions, (string) $session) : false;
 
 		// If the active session dir doesn't exist, look for an expired one
 		if (!$dir)


### PR DESCRIPTION
Cast session to string in SafePath directory call

SafePath expects a string not and integer